### PR TITLE
feat: add OEM config

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import "./variables.css";
 
 import { clientPostgrest } from "./lib/api";
 import { useTranslation } from "./lib/i18n";
+import { Logo } from "@/components/business/Logo";
 import {
   Layers,
   Cpu,
@@ -38,6 +39,7 @@ import {
   Server,
   BookOpen,
   Calculator,
+  Settings,
 } from "lucide-react";
 
 import {
@@ -89,6 +91,7 @@ import { YamlImportButton } from "./components/business/YamlImportButton";
 import { YamlExportButton } from "./components/business/YamlExportButton";
 import Dashboard from "./pages/dashboard/Dashboard";
 import VRAMCalculator from "./pages/vram-calculator/VramCalculatorPage";
+import { OemConfigShow } from "./pages/oem-config";
 
 const resources: ResourceProps[] = [
   {
@@ -251,6 +254,15 @@ const resources: ResourceProps[] = [
       parent: "tools",
     },
   },
+  {
+    name: "oem_configs",
+    list: "/oem-configs",
+    meta: {
+      icon: <Settings />,
+      parent: "tools",
+      idColumnName: "metadata->name",
+    },
+  },
 ];
 
 function App({ i18nProvider }: { i18nProvider: I18nProvider }) {
@@ -303,23 +315,8 @@ function App({ i18nProvider }: { i18nProvider: I18nProvider }) {
                       defaultLayout={[]}
                       navCollapsedSize={4}
                       logo={{
-                        default: (
-                          <div className="flex justify-center items-center">
-                            <img
-                              alt="logo"
-                              src="/logo.png"
-                              className="w-8 h-8 block"
-                            />
-                            <div className="text-sm font-bold">Neutree</div>
-                          </div>
-                        ),
-                        collapsed: (
-                          <img
-                            alt="logo"
-                            src="/logo.png"
-                            className="w-8 h-8 block"
-                          />
-                        ),
+                        default: <Logo />,
+                        collapsed: <Logo collapsed />,
                       }}
                       navbar={{
                         leftSide: (
@@ -414,6 +411,9 @@ function App({ i18nProvider }: { i18nProvider: I18nProvider }) {
                 <Route path="/:workspace/api-keys">
                   <Route index element={<ApiKeysList />} />
                   <Route path="show/:id" element={<ApiKeysShow />} />
+                </Route>
+                <Route path="/oem-configs">
+                  <Route index element={<OemConfigShow />} />
                 </Route>
               </Route>
 

--- a/src/auth-provider/ThemedTitle.tsx
+++ b/src/auth-provider/ThemedTitle.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { useOemConfig } from "@/hooks/use-oem-config";
 
 type ThemedTitleProps = {
   collapsed: boolean;
@@ -8,13 +9,19 @@ type ThemedTitleProps = {
 
 export const ThemedTitle: React.FC<ThemedTitleProps> = ({
   collapsed,
-  text = "Neutree",
+  text,
   icon,
 }) => {
+  const { brandName, isLoading } = useOemConfig();
+  let displayText = text || brandName;
+  if (isLoading) {
+    displayText = "...";
+  }
+
   return (
     <div className="flex items-center gap-2">
       {icon && <div className="flex items-center justify-center">{icon}</div>}
-      {!collapsed && <div className="font-bold text-xl">{text}</div>}
+      {!collapsed && <div className="font-bold text-xl">{displayText}</div>}
     </div>
   );
 };

--- a/src/components/business/Logo.tsx
+++ b/src/components/business/Logo.tsx
@@ -1,0 +1,30 @@
+import { useOemConfig } from "@/hooks/use-oem-config";
+
+interface LogoProps {
+  collapsed?: boolean;
+}
+
+export const Logo: React.FC<LogoProps> = ({ collapsed = false }) => {
+  const { brandName, logoBase64, logoCollapsedBase64, isLoading } =
+    useOemConfig();
+
+  const logoSrc =
+    collapsed && logoCollapsedBase64
+      ? logoCollapsedBase64
+      : logoBase64 || "/logo.png"; // fallback to default logo
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (collapsed) {
+    return <img alt="logo" src={logoSrc} className="w-8 h-8 block" />;
+  }
+
+  return (
+    <div className="flex justify-center items-center">
+      <img alt="logo" src={logoSrc} className="w-8 h-8 block" />
+      <div className="text-sm font-bold">{brandName}</div>
+    </div>
+  );
+};

--- a/src/components/business/PermissionsTree.tsx
+++ b/src/components/business/PermissionsTree.tsx
@@ -152,7 +152,7 @@ const ActionNode = ({
   const fullPermission = `${resource}:${action}`;
 
   return (
-    <div className="flex items-center p-2 rounded bg-card border border-border hover:bg-accent text-card-foreground">
+    <div className="flex items-center p-2 rounded bg-card border border-border text-card-foreground">
       <div className="mr-2">{actionIcon}</div>
 
       <div className="text-xs ml-1 text-muted-foreground font-mono">

--- a/src/hooks/use-oem-config.ts
+++ b/src/hooks/use-oem-config.ts
@@ -1,0 +1,26 @@
+import { useList } from "@refinedev/core";
+
+export const useOemConfig = () => {
+  const { data, isLoading, error, refetch } = useList({
+    resource: "oem_configs",
+    filters: [
+      {
+        field: "metadata->>name",
+        operator: "eq",
+        value: "default",
+      },
+    ],
+  });
+
+  const oemConfig = data?.data?.[0];
+
+  return {
+    oemConfig,
+    isLoading,
+    error,
+    refetch,
+    brandName: oemConfig?.spec?.brand_name || "Neutree",
+    logoBase64: oemConfig?.spec?.logo_base64,
+    logoCollapsedBase64: oemConfig?.spec?.logo_collapsed_base64,
+  };
+};

--- a/src/hooks/use-yaml-import.ts
+++ b/src/hooks/use-yaml-import.ts
@@ -96,7 +96,6 @@ export const useYamlImport = () => {
           labels: resource.metadata.labels || {},
         },
         spec: resource.spec,
-        status: null,
       };
 
       return baseResource;

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -859,5 +859,32 @@
 	},
 	"vram_calculator": {
 		"title": "VRAM Calculator"
+	},
+	"oem_configs": {
+		"title": "Customize Appearance",
+		"description": "Customize your application's appearance",
+		"fields": {
+			"brandName": "Brand Name",
+			"mainLogo": "Main Logo",
+			"collapsedLogo": "Collapsed Logo",
+			"brandSettings": "Brand Settings"
+		},
+		"placeholders": {
+			"brandName": "Enter brand name"
+		},
+		"descriptions": {
+			"brandName": "This will be displayed in the navigation and login pages",
+			"mainLogo": "Recommended size: 64x64px. Supports PNG, JPG, SVG formats.",
+			"collapsedLogo": "Used when the sidebar is collapsed. If not provided, the main logo will be used."
+		},
+		"buttons": {
+			"uploadLogo": "Upload Logo",
+			"uploadCollapsedLogo": "Upload Collapsed Logo",
+			"resetToDefault": "Reset to Default",
+			"saveConfiguration": "Save Configuration"
+		},
+		"labels": {
+			"optional": "(Optional)"
+		}
 	}
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -859,5 +859,32 @@
 	},
 	"vram_calculator": {
 		"title": "显存计算器"
+	},
+	"oem_configs": {
+		"title": "自定义外观",
+		"description": "自定义应用程序的外观",
+		"fields": {
+			"brandName": "品牌名称",
+			"mainLogo": "主要 Logo",
+			"collapsedLogo": "折叠 Logo",
+			"brandSettings": "品牌设置"
+		},
+		"placeholders": {
+			"brandName": "输入品牌名称"
+		},
+		"descriptions": {
+			"brandName": "这将显示在导航栏和登录页面中",
+			"mainLogo": "推荐尺寸：64x64px。支持 PNG、JPG、SVG 格式。",
+			"collapsedLogo": "在侧边栏折叠时使用。如果未提供，将使用主要 Logo。"
+		},
+		"buttons": {
+			"uploadLogo": "上传 Logo",
+			"uploadCollapsedLogo": "上传折叠 Logo",
+			"resetToDefault": "重置为默认",
+			"saveConfiguration": "保存配置"
+		},
+		"labels": {
+			"optional": "（可选）"
+		}
 	}
 }

--- a/src/pages/oem-config/index.ts
+++ b/src/pages/oem-config/index.ts
@@ -1,0 +1,1 @@
+export * from "./show";

--- a/src/pages/oem-config/show.tsx
+++ b/src/pages/oem-config/show.tsx
@@ -1,0 +1,36 @@
+import { useOemConfigForm } from "@/pages/oem-config/use-oem-config-form";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Form } from "@/components/theme";
+import { useTranslation } from "@/lib/i18n";
+import { useOemConfig } from "@/hooks/use-oem-config";
+import { Loader2 } from "lucide-react";
+
+export function OemConfigShow() {
+  const { oemConfig, isLoading } = useOemConfig();
+
+  const { form, formFields } = useOemConfigForm({
+    action: oemConfig ? "edit" : "create",
+  });
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return <Loader2 className="h-4 w-4 animate-spin" />;
+  }
+
+  return (
+    <div className="p-2 mx-auto space-y-2">
+      <div>
+        <p className="text-muted-foreground">{t("oem_configs.description")}</p>
+      </div>
+
+      <Form {...form} hideCancel>
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("oem_configs.fields.brandSettings")}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">{formFields}</CardContent>
+        </Card>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/oem-config/use-oem-config-form.tsx
+++ b/src/pages/oem-config/use-oem-config-form.tsx
@@ -1,0 +1,190 @@
+import { useForm } from "@refinedev/react-hook-form";
+import { useTranslation } from "@/lib/i18n";
+import { Field } from "@/components/theme";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Upload, X } from "lucide-react";
+import { useRef } from "react";
+
+export interface OemConfigFormData {
+  api_version: string;
+  kind: string;
+  metadata: {
+    name: string;
+  };
+  spec: {
+    brand_name: string;
+    logo_base64: string;
+    logo_collapsed_base64: string;
+  };
+}
+
+export const useOemConfigForm = ({ action }: { action: "create" | "edit" }) => {
+  const { t } = useTranslation();
+  const logoInputRef = useRef<HTMLInputElement>(null);
+  const logoCollapsedInputRef = useRef<HTMLInputElement>(null);
+
+  const form = useForm<OemConfigFormData>({
+    mode: "all",
+    defaultValues: {
+      api_version: "v1",
+      kind: "OemConfig",
+      metadata: {
+        name: "default",
+      },
+      spec: {
+        brand_name: "",
+        logo_base64: "",
+        logo_collapsed_base64: "",
+      },
+    },
+    refineCoreProps: {
+      action,
+      id: action === "edit" ? "default" : undefined,
+      autoSave: {
+        enabled: true,
+      },
+    },
+    warnWhenUnsavedChanges: true,
+  });
+
+  const { setValue, watch } = form;
+  const formValues = watch();
+
+  // File upload handler
+  const handleFileUpload = (
+    file: File,
+    fieldName: "spec.logo_base64" | "spec.logo_collapsed_base64",
+  ) => {
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        setValue(fieldName, result, { shouldDirty: true });
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  // File clear handler
+  const handleFileClear = (
+    fieldName: "spec.logo_base64" | "spec.logo_collapsed_base64",
+  ) => {
+    setValue(fieldName, "", { shouldDirty: true });
+  };
+
+  return {
+    form,
+    handleFileUpload,
+    handleFileClear,
+    formFields: (
+      <>
+        <Field
+          {...form}
+          name="spec.brand_name"
+          label={t("oem_configs.fields.brandName")}
+        >
+          <Input placeholder={t("oem_configs.placeholders.brandName")} />
+        </Field>
+
+        {/* Main Logo */}
+        <div className="space-y-2">
+          <Label>{t("oem_configs.fields.mainLogo")}</Label>
+          <div className="space-y-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => logoInputRef.current?.click()}
+              className="w-full"
+            >
+              <Upload className="w-4 h-4 mr-2" />
+              {t("oem_configs.buttons.uploadLogo")}
+            </Button>
+            <input
+              ref={logoInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) handleFileUpload(file, "spec.logo_base64");
+              }}
+            />
+            {formValues.spec?.logo_base64 && (
+              <div className="relative p-4 border rounded-lg bg-muted/50">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleFileClear("spec.logo_base64")}
+                  className="absolute top-2 right-2 h-6 w-6 p-0"
+                >
+                  <X className="w-4 h-4" />
+                </Button>
+                <img
+                  src={formValues.spec.logo_base64}
+                  alt="Main logo preview"
+                  className="w-16 h-16 object-contain"
+                />
+              </div>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {t("oem_configs.descriptions.mainLogo")}
+          </p>
+        </div>
+
+        {/* Collapsed Logo */}
+        <div className="space-y-2">
+          <Label>
+            {t("oem_configs.fields.collapsedLogo")}{" "}
+            {t("oem_configs.labels.optional")}
+          </Label>
+          <div className="space-y-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => logoCollapsedInputRef.current?.click()}
+              className="w-full"
+            >
+              <Upload className="w-4 h-4 mr-2" />
+              {t("oem_configs.buttons.uploadCollapsedLogo")}
+            </Button>
+            <input
+              ref={logoCollapsedInputRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) handleFileUpload(file, "spec.logo_collapsed_base64");
+              }}
+            />
+            {formValues.spec?.logo_collapsed_base64 && (
+              <div className="relative p-4 border rounded-lg bg-muted/50">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleFileClear("spec.logo_collapsed_base64")}
+                  className="absolute top-2 right-2 h-6 w-6 p-0"
+                >
+                  <X className="w-4 h-4" />
+                </Button>
+                <img
+                  src={formValues.spec.logo_collapsed_base64}
+                  alt="Collapsed logo preview"
+                  className="w-16 h-16 object-contain"
+                />
+              </div>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {t("oem_configs.descriptions.collapsedLogo")}
+          </p>
+        </div>
+      </>
+    ),
+  };
+};

--- a/src/types/api-gen.ts
+++ b/src/types/api-gen.ts
@@ -316,6 +316,57 @@ export type Database = {
         };
         Relationships: [];
       };
+      oem_config: {
+        Row: {
+          brand_name: string | null;
+          created_at: string | null;
+          id: number;
+          logo_base64: string | null;
+          logo_collapsed_base64: string | null;
+          updated_at: string | null;
+        };
+        Insert: {
+          brand_name?: string | null;
+          created_at?: string | null;
+          id?: number;
+          logo_base64?: string | null;
+          logo_collapsed_base64?: string | null;
+          updated_at?: string | null;
+        };
+        Update: {
+          brand_name?: string | null;
+          created_at?: string | null;
+          id?: number;
+          logo_base64?: string | null;
+          logo_collapsed_base64?: string | null;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
+      oem_configs: {
+        Row: {
+          api_version: string;
+          id: number;
+          kind: string;
+          metadata: Database["api"]["CompositeTypes"]["metadata"] | null;
+          spec: Database["api"]["CompositeTypes"]["oem_config_spec"] | null;
+        };
+        Insert: {
+          api_version: string;
+          id?: number;
+          kind: string;
+          metadata?: Database["api"]["CompositeTypes"]["metadata"] | null;
+          spec?: Database["api"]["CompositeTypes"]["oem_config_spec"] | null;
+        };
+        Update: {
+          api_version?: string;
+          id?: number;
+          kind?: string;
+          metadata?: Database["api"]["CompositeTypes"]["metadata"] | null;
+          spec?: Database["api"]["CompositeTypes"]["oem_config_spec"] | null;
+        };
+        Relationships: [];
+      };
       role_assignments: {
         Row: {
           api_version: string;
@@ -564,8 +615,9 @@ export type Database = {
         | "model_catalog:read"
         | "model_catalog:create"
         | "model_catalog:update"
-        | "model_catalog:delete";
-      role_preset: "admin" | "workspace_user";
+        | "model_catalog:delete"
+        | "system:admin";
+      role_preset: "admin" | "workspace-user";
     };
     CompositeTypes: {
       api_daily_usage_spec: {
@@ -694,6 +746,11 @@ export type Database = {
         version: string | null;
         task: string | null;
       };
+      oem_config_spec: {
+        brand_name: string | null;
+        logo_base64: string | null;
+        logo_collapsed_base64: string | null;
+      };
       replica_spec: {
         num: number | null;
       };
@@ -736,769 +793,6 @@ export type Database = {
         service_url: string | null;
         error_message: string | null;
       };
-    };
-  };
-  auth: {
-    Tables: {
-      audit_log_entries: {
-        Row: {
-          created_at: string | null;
-          id: string;
-          instance_id: string | null;
-          ip_address: string;
-          payload: Json | null;
-        };
-        Insert: {
-          created_at?: string | null;
-          id: string;
-          instance_id?: string | null;
-          ip_address?: string;
-          payload?: Json | null;
-        };
-        Update: {
-          created_at?: string | null;
-          id?: string;
-          instance_id?: string | null;
-          ip_address?: string;
-          payload?: Json | null;
-        };
-        Relationships: [];
-      };
-      flow_state: {
-        Row: {
-          auth_code: string;
-          auth_code_issued_at: string | null;
-          authentication_method: string;
-          code_challenge: string;
-          code_challenge_method: Database["auth"]["Enums"]["code_challenge_method"];
-          created_at: string | null;
-          id: string;
-          provider_access_token: string | null;
-          provider_refresh_token: string | null;
-          provider_type: string;
-          updated_at: string | null;
-          user_id: string | null;
-        };
-        Insert: {
-          auth_code: string;
-          auth_code_issued_at?: string | null;
-          authentication_method: string;
-          code_challenge: string;
-          code_challenge_method: Database["auth"]["Enums"]["code_challenge_method"];
-          created_at?: string | null;
-          id: string;
-          provider_access_token?: string | null;
-          provider_refresh_token?: string | null;
-          provider_type: string;
-          updated_at?: string | null;
-          user_id?: string | null;
-        };
-        Update: {
-          auth_code?: string;
-          auth_code_issued_at?: string | null;
-          authentication_method?: string;
-          code_challenge?: string;
-          code_challenge_method?: Database["auth"]["Enums"]["code_challenge_method"];
-          created_at?: string | null;
-          id?: string;
-          provider_access_token?: string | null;
-          provider_refresh_token?: string | null;
-          provider_type?: string;
-          updated_at?: string | null;
-          user_id?: string | null;
-        };
-        Relationships: [];
-      };
-      identities: {
-        Row: {
-          created_at: string | null;
-          email: string | null;
-          id: string;
-          identity_data: Json;
-          last_sign_in_at: string | null;
-          provider: string;
-          provider_id: string;
-          updated_at: string | null;
-          user_id: string;
-        };
-        Insert: {
-          created_at?: string | null;
-          email?: string | null;
-          id?: string;
-          identity_data: Json;
-          last_sign_in_at?: string | null;
-          provider: string;
-          provider_id: string;
-          updated_at?: string | null;
-          user_id: string;
-        };
-        Update: {
-          created_at?: string | null;
-          email?: string | null;
-          id?: string;
-          identity_data?: Json;
-          last_sign_in_at?: string | null;
-          provider?: string;
-          provider_id?: string;
-          updated_at?: string | null;
-          user_id?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "identities_user_id_fkey";
-            columns: ["user_id"];
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      instances: {
-        Row: {
-          created_at: string | null;
-          id: string;
-          raw_base_config: string | null;
-          updated_at: string | null;
-          uuid: string | null;
-        };
-        Insert: {
-          created_at?: string | null;
-          id: string;
-          raw_base_config?: string | null;
-          updated_at?: string | null;
-          uuid?: string | null;
-        };
-        Update: {
-          created_at?: string | null;
-          id?: string;
-          raw_base_config?: string | null;
-          updated_at?: string | null;
-          uuid?: string | null;
-        };
-        Relationships: [];
-      };
-      mfa_amr_claims: {
-        Row: {
-          authentication_method: string;
-          created_at: string;
-          id: string;
-          session_id: string;
-          updated_at: string;
-        };
-        Insert: {
-          authentication_method: string;
-          created_at: string;
-          id: string;
-          session_id: string;
-          updated_at: string;
-        };
-        Update: {
-          authentication_method?: string;
-          created_at?: string;
-          id?: string;
-          session_id?: string;
-          updated_at?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "mfa_amr_claims_session_id_fkey";
-            columns: ["session_id"];
-            referencedRelation: "sessions";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      mfa_challenges: {
-        Row: {
-          created_at: string;
-          factor_id: string;
-          id: string;
-          ip_address: unknown;
-          otp_code: string | null;
-          verified_at: string | null;
-          web_authn_session_data: Json | null;
-        };
-        Insert: {
-          created_at: string;
-          factor_id: string;
-          id: string;
-          ip_address: unknown;
-          otp_code?: string | null;
-          verified_at?: string | null;
-          web_authn_session_data?: Json | null;
-        };
-        Update: {
-          created_at?: string;
-          factor_id?: string;
-          id?: string;
-          ip_address?: unknown;
-          otp_code?: string | null;
-          verified_at?: string | null;
-          web_authn_session_data?: Json | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "mfa_challenges_auth_factor_id_fkey";
-            columns: ["factor_id"];
-            referencedRelation: "mfa_factors";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      mfa_factors: {
-        Row: {
-          created_at: string;
-          factor_type: Database["auth"]["Enums"]["factor_type"];
-          friendly_name: string | null;
-          id: string;
-          last_challenged_at: string | null;
-          phone: string | null;
-          secret: string | null;
-          status: Database["auth"]["Enums"]["factor_status"];
-          updated_at: string;
-          user_id: string;
-          web_authn_aaguid: string | null;
-          web_authn_credential: Json | null;
-        };
-        Insert: {
-          created_at: string;
-          factor_type: Database["auth"]["Enums"]["factor_type"];
-          friendly_name?: string | null;
-          id: string;
-          last_challenged_at?: string | null;
-          phone?: string | null;
-          secret?: string | null;
-          status: Database["auth"]["Enums"]["factor_status"];
-          updated_at: string;
-          user_id: string;
-          web_authn_aaguid?: string | null;
-          web_authn_credential?: Json | null;
-        };
-        Update: {
-          created_at?: string;
-          factor_type?: Database["auth"]["Enums"]["factor_type"];
-          friendly_name?: string | null;
-          id?: string;
-          last_challenged_at?: string | null;
-          phone?: string | null;
-          secret?: string | null;
-          status?: Database["auth"]["Enums"]["factor_status"];
-          updated_at?: string;
-          user_id?: string;
-          web_authn_aaguid?: string | null;
-          web_authn_credential?: Json | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "mfa_factors_user_id_fkey";
-            columns: ["user_id"];
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      one_time_tokens: {
-        Row: {
-          created_at: string;
-          id: string;
-          relates_to: string;
-          token_hash: string;
-          token_type: Database["auth"]["Enums"]["one_time_token_type"];
-          updated_at: string;
-          user_id: string;
-        };
-        Insert: {
-          created_at?: string;
-          id: string;
-          relates_to: string;
-          token_hash: string;
-          token_type: Database["auth"]["Enums"]["one_time_token_type"];
-          updated_at?: string;
-          user_id: string;
-        };
-        Update: {
-          created_at?: string;
-          id?: string;
-          relates_to?: string;
-          token_hash?: string;
-          token_type?: Database["auth"]["Enums"]["one_time_token_type"];
-          updated_at?: string;
-          user_id?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "one_time_tokens_user_id_fkey";
-            columns: ["user_id"];
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      refresh_tokens: {
-        Row: {
-          created_at: string | null;
-          id: number;
-          instance_id: string | null;
-          parent: string | null;
-          revoked: boolean | null;
-          session_id: string | null;
-          token: string | null;
-          updated_at: string | null;
-          user_id: string | null;
-        };
-        Insert: {
-          created_at?: string | null;
-          id?: number;
-          instance_id?: string | null;
-          parent?: string | null;
-          revoked?: boolean | null;
-          session_id?: string | null;
-          token?: string | null;
-          updated_at?: string | null;
-          user_id?: string | null;
-        };
-        Update: {
-          created_at?: string | null;
-          id?: number;
-          instance_id?: string | null;
-          parent?: string | null;
-          revoked?: boolean | null;
-          session_id?: string | null;
-          token?: string | null;
-          updated_at?: string | null;
-          user_id?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "refresh_tokens_session_id_fkey";
-            columns: ["session_id"];
-            referencedRelation: "sessions";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      saml_providers: {
-        Row: {
-          attribute_mapping: Json | null;
-          created_at: string | null;
-          entity_id: string;
-          id: string;
-          metadata_url: string | null;
-          metadata_xml: string;
-          name_id_format: string | null;
-          sso_provider_id: string;
-          updated_at: string | null;
-        };
-        Insert: {
-          attribute_mapping?: Json | null;
-          created_at?: string | null;
-          entity_id: string;
-          id: string;
-          metadata_url?: string | null;
-          metadata_xml: string;
-          name_id_format?: string | null;
-          sso_provider_id: string;
-          updated_at?: string | null;
-        };
-        Update: {
-          attribute_mapping?: Json | null;
-          created_at?: string | null;
-          entity_id?: string;
-          id?: string;
-          metadata_url?: string | null;
-          metadata_xml?: string;
-          name_id_format?: string | null;
-          sso_provider_id?: string;
-          updated_at?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "saml_providers_sso_provider_id_fkey";
-            columns: ["sso_provider_id"];
-            referencedRelation: "sso_providers";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      saml_relay_states: {
-        Row: {
-          created_at: string | null;
-          flow_state_id: string | null;
-          for_email: string | null;
-          id: string;
-          redirect_to: string | null;
-          request_id: string;
-          sso_provider_id: string;
-          updated_at: string | null;
-        };
-        Insert: {
-          created_at?: string | null;
-          flow_state_id?: string | null;
-          for_email?: string | null;
-          id: string;
-          redirect_to?: string | null;
-          request_id: string;
-          sso_provider_id: string;
-          updated_at?: string | null;
-        };
-        Update: {
-          created_at?: string | null;
-          flow_state_id?: string | null;
-          for_email?: string | null;
-          id?: string;
-          redirect_to?: string | null;
-          request_id?: string;
-          sso_provider_id?: string;
-          updated_at?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "saml_relay_states_flow_state_id_fkey";
-            columns: ["flow_state_id"];
-            referencedRelation: "flow_state";
-            referencedColumns: ["id"];
-          },
-          {
-            foreignKeyName: "saml_relay_states_sso_provider_id_fkey";
-            columns: ["sso_provider_id"];
-            referencedRelation: "sso_providers";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      schema_migrations: {
-        Row: {
-          version: string;
-        };
-        Insert: {
-          version: string;
-        };
-        Update: {
-          version?: string;
-        };
-        Relationships: [];
-      };
-      sessions: {
-        Row: {
-          aal: Database["auth"]["Enums"]["aal_level"] | null;
-          created_at: string | null;
-          factor_id: string | null;
-          id: string;
-          ip: unknown | null;
-          not_after: string | null;
-          refreshed_at: string | null;
-          tag: string | null;
-          updated_at: string | null;
-          user_agent: string | null;
-          user_id: string;
-        };
-        Insert: {
-          aal?: Database["auth"]["Enums"]["aal_level"] | null;
-          created_at?: string | null;
-          factor_id?: string | null;
-          id: string;
-          ip?: unknown | null;
-          not_after?: string | null;
-          refreshed_at?: string | null;
-          tag?: string | null;
-          updated_at?: string | null;
-          user_agent?: string | null;
-          user_id: string;
-        };
-        Update: {
-          aal?: Database["auth"]["Enums"]["aal_level"] | null;
-          created_at?: string | null;
-          factor_id?: string | null;
-          id?: string;
-          ip?: unknown | null;
-          not_after?: string | null;
-          refreshed_at?: string | null;
-          tag?: string | null;
-          updated_at?: string | null;
-          user_agent?: string | null;
-          user_id?: string;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "sessions_user_id_fkey";
-            columns: ["user_id"];
-            referencedRelation: "users";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      sso_domains: {
-        Row: {
-          created_at: string | null;
-          domain: string;
-          id: string;
-          sso_provider_id: string;
-          updated_at: string | null;
-        };
-        Insert: {
-          created_at?: string | null;
-          domain: string;
-          id: string;
-          sso_provider_id: string;
-          updated_at?: string | null;
-        };
-        Update: {
-          created_at?: string | null;
-          domain?: string;
-          id?: string;
-          sso_provider_id?: string;
-          updated_at?: string | null;
-        };
-        Relationships: [
-          {
-            foreignKeyName: "sso_domains_sso_provider_id_fkey";
-            columns: ["sso_provider_id"];
-            referencedRelation: "sso_providers";
-            referencedColumns: ["id"];
-          },
-        ];
-      };
-      sso_providers: {
-        Row: {
-          created_at: string | null;
-          id: string;
-          resource_id: string | null;
-          updated_at: string | null;
-        };
-        Insert: {
-          created_at?: string | null;
-          id: string;
-          resource_id?: string | null;
-          updated_at?: string | null;
-        };
-        Update: {
-          created_at?: string | null;
-          id?: string;
-          resource_id?: string | null;
-          updated_at?: string | null;
-        };
-        Relationships: [];
-      };
-      users: {
-        Row: {
-          aud: string | null;
-          banned_until: string | null;
-          confirmation_sent_at: string | null;
-          confirmation_token: string | null;
-          confirmed_at: string | null;
-          created_at: string | null;
-          deleted_at: string | null;
-          email: string | null;
-          email_change: string | null;
-          email_change_confirm_status: number | null;
-          email_change_sent_at: string | null;
-          email_change_token_current: string | null;
-          email_change_token_new: string | null;
-          email_confirmed_at: string | null;
-          encrypted_password: string | null;
-          id: string;
-          instance_id: string | null;
-          invited_at: string | null;
-          is_anonymous: boolean;
-          is_sso_user: boolean;
-          is_super_admin: boolean | null;
-          last_sign_in_at: string | null;
-          phone: string | null;
-          phone_change: string | null;
-          phone_change_sent_at: string | null;
-          phone_change_token: string | null;
-          phone_confirmed_at: string | null;
-          raw_app_meta_data: Json | null;
-          raw_user_meta_data: Json | null;
-          reauthentication_sent_at: string | null;
-          reauthentication_token: string | null;
-          recovery_sent_at: string | null;
-          recovery_token: string | null;
-          role: string | null;
-          updated_at: string | null;
-        };
-        Insert: {
-          aud?: string | null;
-          banned_until?: string | null;
-          confirmation_sent_at?: string | null;
-          confirmation_token?: string | null;
-          confirmed_at?: string | null;
-          created_at?: string | null;
-          deleted_at?: string | null;
-          email?: string | null;
-          email_change?: string | null;
-          email_change_confirm_status?: number | null;
-          email_change_sent_at?: string | null;
-          email_change_token_current?: string | null;
-          email_change_token_new?: string | null;
-          email_confirmed_at?: string | null;
-          encrypted_password?: string | null;
-          id: string;
-          instance_id?: string | null;
-          invited_at?: string | null;
-          is_anonymous?: boolean;
-          is_sso_user?: boolean;
-          is_super_admin?: boolean | null;
-          last_sign_in_at?: string | null;
-          phone?: string | null;
-          phone_change?: string | null;
-          phone_change_sent_at?: string | null;
-          phone_change_token?: string | null;
-          phone_confirmed_at?: string | null;
-          raw_app_meta_data?: Json | null;
-          raw_user_meta_data?: Json | null;
-          reauthentication_sent_at?: string | null;
-          reauthentication_token?: string | null;
-          recovery_sent_at?: string | null;
-          recovery_token?: string | null;
-          role?: string | null;
-          updated_at?: string | null;
-        };
-        Update: {
-          aud?: string | null;
-          banned_until?: string | null;
-          confirmation_sent_at?: string | null;
-          confirmation_token?: string | null;
-          confirmed_at?: string | null;
-          created_at?: string | null;
-          deleted_at?: string | null;
-          email?: string | null;
-          email_change?: string | null;
-          email_change_confirm_status?: number | null;
-          email_change_sent_at?: string | null;
-          email_change_token_current?: string | null;
-          email_change_token_new?: string | null;
-          email_confirmed_at?: string | null;
-          encrypted_password?: string | null;
-          id?: string;
-          instance_id?: string | null;
-          invited_at?: string | null;
-          is_anonymous?: boolean;
-          is_sso_user?: boolean;
-          is_super_admin?: boolean | null;
-          last_sign_in_at?: string | null;
-          phone?: string | null;
-          phone_change?: string | null;
-          phone_change_sent_at?: string | null;
-          phone_change_token?: string | null;
-          phone_confirmed_at?: string | null;
-          raw_app_meta_data?: Json | null;
-          raw_user_meta_data?: Json | null;
-          reauthentication_sent_at?: string | null;
-          reauthentication_token?: string | null;
-          recovery_sent_at?: string | null;
-          recovery_token?: string | null;
-          role?: string | null;
-          updated_at?: string | null;
-        };
-        Relationships: [];
-      };
-    };
-    Views: {
-      [_ in never]: never;
-    };
-    Functions: {
-      email: {
-        Args: Record<PropertyKey, never>;
-        Returns: string;
-      };
-      jwt: {
-        Args: Record<PropertyKey, never>;
-        Returns: Json;
-      };
-      role: {
-        Args: Record<PropertyKey, never>;
-        Returns: string;
-      };
-      uid: {
-        Args: Record<PropertyKey, never>;
-        Returns: string;
-      };
-    };
-    Enums: {
-      aal_level: "aal1" | "aal2" | "aal3";
-      code_challenge_method: "s256" | "plain";
-      factor_status: "unverified" | "verified";
-      factor_type: "totp" | "webauthn" | "phone";
-      one_time_token_type:
-        | "confirmation_token"
-        | "reauthentication_token"
-        | "recovery_token"
-        | "email_change_token_new"
-        | "email_change_token_current"
-        | "phone_change_token";
-    };
-    CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-  public: {
-    Tables: {
-      schema_migrations: {
-        Row: {
-          dirty: boolean;
-          version: number;
-        };
-        Insert: {
-          dirty: boolean;
-          version: number;
-        };
-        Update: {
-          dirty?: boolean;
-          version?: number;
-        };
-        Relationships: [];
-      };
-    };
-    Views: {
-      [_ in never]: never;
-    };
-    Functions: {
-      armor: {
-        Args: {
-          "": string;
-        };
-        Returns: string;
-      };
-      dearmor: {
-        Args: {
-          "": string;
-        };
-        Returns: string;
-      };
-      gen_random_bytes: {
-        Args: {
-          "": number;
-        };
-        Returns: string;
-      };
-      gen_random_uuid: {
-        Args: Record<PropertyKey, never>;
-        Returns: string;
-      };
-      gen_salt: {
-        Args: {
-          "": string;
-        };
-        Returns: string;
-      };
-      pgp_armor_headers: {
-        Args: {
-          "": string;
-        };
-        Returns: Record<string, unknown>[];
-      };
-      pgp_key_id: {
-        Args: {
-          "": string;
-        };
-        Returns: string;
-      };
-    };
-    Enums: {
-      [_ in never]: never;
-    };
-    CompositeTypes: {
-      [_ in never]: never;
     };
   };
 };


### PR DESCRIPTION
## Changes

1. Remove hard-coded `Neutree` from the codebase; the remaining one, `neutree-cluster` in the Grafana config, is not visible to end users, so we keep it.
2. Add a `use-oem-config` hook to fetch OEM config from the API. All the UIs that need the brand name or logo image should use the new hook to get data. And since the hook has a fallback logic in it, the UIs should handle loading state correctly to avoid the default brand name/logo being displayed.
3. Add the OEM config form UI, let the user customize the config end-to-end.

---

The changes to the `api-gen.ts` can be ignored, just a housekeeping.


## Test

Posted a test video in our internal channel.