### PR TITLE
fix: ssh cluster editing page IP validation

### DIFF
--- a/src/components/business/NodeIPsField.tsx
+++ b/src/components/business/NodeIPsField.tsx
@@ -50,6 +50,9 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
     const validateIp = (ip: string) => {
       if (!ip) return "IP address is required";
       if (!ipRegex.test(ip)) return "Invalid IP address format";
+      if (workerIps.includes(ip) || ip === headIp) {
+        return "This IP address is already in use";
+      }
       return "";
     };
 
@@ -85,15 +88,6 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
         setErrors({
           ...errors,
           newWorkerIp: error,
-        });
-        return;
-      }
-
-      // Check for duplicates
-      if (workerIps.includes(newWorkerIp) || newWorkerIp === headIp) {
-        setErrors({
-          ...errors,
-          newWorkerIp: "This IP address is already in use",
         });
         return;
       }

--- a/src/components/business/NodeIPsField.tsx
+++ b/src/components/business/NodeIPsField.tsx
@@ -46,11 +46,19 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
       }
     }, [headIp, workerIps, onChange]);
 
+    // Check for duplications
+    const ipIsDuplicated = (ip: string) => {
+      if (workerIps.includes(ip) || ip === headIp) {
+        return true;
+      }
+      return false;
+    };
+
     // Validate an IP address
     const validateIp = (ip: string) => {
       if (!ip) return "IP address is required";
       if (!ipRegex.test(ip)) return "Invalid IP address format";
-      if (workerIps.includes(ip) || ip === headIp) {
+      if (ipIsDuplicated(ip)) {
         return "This IP address is already in use";
       }
       return "";


### PR DESCRIPTION
Added duplicate checking in the validateIp function that prevents adding IPs that already exist in either the head node or worker nodes list.