### PR TITLE
feat: Add Model Cache Configuration Support to Cluster Creation UI

### DIFF
--- a/src/components/theme/components/field.tsx
+++ b/src/components/theme/components/field.tsx
@@ -7,7 +7,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { type ReactElement, cloneElement } from "react";
+import { type ReactElement, cloneElement, forwardRef } from "react";
 import type {
   ControllerRenderProps,
   FieldPath,
@@ -27,7 +27,7 @@ export type FieldProps<
     field: ControllerRenderProps<TFieldValues, TName>;
   }>;
 };
-export const Field = (props: FieldProps) => {
+export const Field = forwardRef<HTMLDivElement, FieldProps>((props: FieldProps, _) => {
   return (
     <FormField
       control={props.control}
@@ -63,4 +63,4 @@ export const Field = (props: FieldProps) => {
       }}
     />
   );
-};
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export const isValidIPAddress = (ip: string): boolean => {
+  const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+  return ipRegex.test(ip);
+};
+
+export const isValidPath = (path: string): boolean => {
+  // Check if it's a valid Unix/Linux path
+  const pathRegex = /^\/[a-zA-Z0-9._/-]*$/;
+  return pathRegex.test(path) && path.length > 0;
+};

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -299,15 +299,15 @@
 			"sshUser": "SSH User",
 			"sshPrivateKey": "SSH Private Key",
 			"modelCache": {
+				"title": "Model Cache",
 				"type": {
 					"host_path": "Local",
 					"nfs": "NFS"
 				},
 				"cacheType": "Cache Type",
 				"modelRegistry": "Model Registry",
-				"hostPath": "Host Path",
-				"nfsServer": "NFS Server",
-				"nfsPath": "NFS Path"
+				"cachePath": "Cache Path",
+				"nfsServer": "NFS Server"
 			}
 		},
 		"sections": {
@@ -341,6 +341,12 @@
 		},
 		"actions": {
 			"addModelCache": "Add Model Cache"
+		},
+		"validation": {
+			"nfsServerRequired": "Server address is required",
+			"invalidIPAddress": "Invalid IP address",
+			"cachePathRequired": "Cache path is required",
+			"invalidPath": "Invalid path (Must start with /)"
 		}
 	},
 	"model_registries": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -297,7 +297,18 @@
 			"memory": "Memory",
 			"replicas": "Replicas",
 			"sshUser": "SSH User",
-			"sshPrivateKey": "SSH Private Key"
+			"sshPrivateKey": "SSH Private Key",
+			"modelCache": {
+				"type": {
+					"host_path": "Local",
+					"nfs": "NFS"
+				},
+				"cacheType": "Cache Type",
+				"modelRegistry": "Model Registry",
+				"hostPath": "Host Path",
+				"nfsServer": "NFS Server",
+				"nfsPath": "NFS Path"
+			}
 		},
 		"sections": {
 			"basicInformation": "Basic Information",
@@ -305,23 +316,31 @@
 			"provider": "Provider",
 			"headNode": "Head Node",
 			"workerNode": "Worker Node",
+			"modelCaches": "Model Caches",
 			"nodeAuthentication": "Node Authentication"
 		},
 		"placeholders": {
 			"clusterName": "Cluster Name",
 			"selectImageRegistry": "Select A Image Registry",
-			"sshUserExample": "e.g root"
+			"sshUserExample": "e.g root",
+			"nfsServerExample": "192.168.1.1"
 		},
 		"options": {
 			"multipleStaticNodes": "Multiple Static Nodes",
 			"kubernetes": "Kubernetes",
 			"loadBalancer": "LoadBalancer",
 			"ingress": "Ingress",
-			"none": "None"
+			"none": "None",
+			"hostPath": "Host Path",
+			"nfs": "NFS"
 		},
 		"messages": {
 			"notFound": "404 not found",
-			"rayDashboardTitle": "Ray Dashboard"
+			"rayDashboardTitle": "Ray Dashboard",
+			"noModelCaches": "No model caches"
+		},
+		"actions": {
+			"addModelCache": "Add Model Cache"
 		}
 	},
 	"model_registries": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -297,7 +297,18 @@
 			"memory": "内存",
 			"replicas": "副本数",
 			"sshUser": "SSH 用户",
-			"sshPrivateKey": "SSH 私钥"
+			"sshPrivateKey": "SSH 私钥",
+			"modelCache": {
+				"type": {
+					"host_path": "主机缓存",
+					"nfs": "文件服务器缓存"
+				},
+				"cacheType": "缓存类型",
+				"modelRegistry": "模型仓库",
+				"hostPath": "主机路径",
+				"nfsServer": "文件服务器地址",
+				"nfsPath": "文件路径"
+			}
 		},
 		"sections": {
 			"basicInformation": "基础信息",
@@ -305,23 +316,31 @@
 			"provider": "提供商",
 			"headNode": "主节点",
 			"workerNode": "工作节点",
+			"modelCaches": "模型缓存",
 			"nodeAuthentication": "节点认证"
 		},
 		"placeholders": {
 			"clusterName": "集群名称",
 			"selectImageRegistry": "选择镜像仓库",
-			"sshUserExample": "例如 root"
+			"sshUserExample": "例如 root",
+			"nfsServerExample": "192.168.1.1"
 		},
 		"options": {
 			"multipleStaticNodes": "静态节点",
 			"kubernetes": "Kubernetes",
 			"loadBalancer": "负载均衡器",
 			"ingress": "入口",
-			"none": "不使用"
+			"none": "不使用",
+			"hostPath": "主机缓存",
+			"nfs": "文件服务器缓存"
 		},
 		"messages": {
 			"notFound": "404 未找到",
-			"rayDashboardTitle": "Ray 仪表板"
+			"rayDashboardTitle": "Ray 仪表板",
+			"noModelCaches": "没有模型缓存"
+		},
+		"actions": {
+			"addModelCache": "添加模型缓存"
 		}
 	},
 	"model_registries": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -299,15 +299,15 @@
 			"sshUser": "SSH 用户",
 			"sshPrivateKey": "SSH 私钥",
 			"modelCache": {
+				"title": "模型缓存",
 				"type": {
 					"host_path": "主机缓存",
 					"nfs": "文件服务器缓存"
 				},
 				"cacheType": "缓存类型",
 				"modelRegistry": "模型仓库",
-				"hostPath": "主机路径",
-				"nfsServer": "文件服务器地址",
-				"nfsPath": "文件路径"
+				"cachePath": "缓存路径",
+				"nfsServer": "文件服务器地址"
 			}
 		},
 		"sections": {
@@ -341,6 +341,12 @@
 		},
 		"actions": {
 			"addModelCache": "添加模型缓存"
+		},
+		"validation": {
+			"nfsServerRequired": "服务器地址是必填项",
+			"invalidIPAddress": "无效的 IP 地址",
+			"cachePathRequired": "缓存路径是必填项",
+			"invalidPath": "无效的路径(需以 / 开头)"
 		}
 	},
 	"model_registries": {

--- a/src/pages/clusters/create.tsx
+++ b/src/pages/clusters/create.tsx
@@ -23,8 +23,8 @@ export const ClustersCreate = () => {
       {providerFields}
       {headNodeFields}
       {workerNodeFields}
-      {modelCacheFields}
       {authFields}
+      {modelCacheFields}
     </Form>
   );
 };

--- a/src/pages/clusters/create.tsx
+++ b/src/pages/clusters/create.tsx
@@ -12,6 +12,7 @@ export const ClustersCreate = () => {
     providerFields,
     headNodeFields,
     workerNodeFields,
+    modelCacheFields,
     authFields,
   } = useClusterForm({ action: "create" });
   return (
@@ -22,6 +23,7 @@ export const ClustersCreate = () => {
       {providerFields}
       {headNodeFields}
       {workerNodeFields}
+      {modelCacheFields}
       {authFields}
     </Form>
   );

--- a/src/pages/clusters/edit.tsx
+++ b/src/pages/clusters/edit.tsx
@@ -12,6 +12,7 @@ export const ClustersEdit = () => {
     providerFields,
     headNodeFields,
     workerNodeFields,
+    modelCacheFields,
     authFields,
   } = useClusterForm({ action: "edit" });
   return (
@@ -22,6 +23,7 @@ export const ClustersEdit = () => {
       {providerFields}
       {headNodeFields}
       {workerNodeFields}
+      {modelCacheFields}
       {authFields}
     </Form>
   );

--- a/src/pages/clusters/use-cluster-form.tsx
+++ b/src/pages/clusters/use-cluster-form.tsx
@@ -18,6 +18,7 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
     { label: t("clusters.options.none"), value:NO_ACCELERATOR},
     { label: "NVIDIA GPU", value: "nvidia.com/gpu" },
     { label: "Ascend310P", value: "huawei.com/Ascend310P" },
+    { label: "AMD GPU", value: "amd.com/gpu" },
   ];
 
 

--- a/src/pages/clusters/use-cluster-form.tsx
+++ b/src/pages/clusters/use-cluster-form.tsx
@@ -8,7 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { isValidIPAddress, isValidPath } from "@/lib/utils";
-import type { Cluster, ImageRegistry } from "@/types";
+import type { Cluster, HostPathCache, ImageRegistry, ModelCache } from "@/types";
 import { useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import { Plus, Trash2 } from "lucide-react";
@@ -120,13 +120,7 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
   const isEdit = action === "edit";
 
   const addModelCache = () => {
-      append({
-        nfs: {
-          server: '',
-          path: '',
-        },
-        model_registry_type: ''
-      });
+      append({ host_path: {path: '' }, model_registry_type: '' } as HostPathCache); // Default to host_path with empty path
   };
 
   const getCacheType = (index: number): 'nfs' | 'host_path' => {
@@ -455,7 +449,7 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
         <div />
       </FormCardGrid>
     ) : null,
-    modelCacheFields: isKubernetes ? (<div>
+    modelCacheFields: (<div>
       <FormCardGrid title={t("clusters.sections.modelCaches")}>
       <div className="col-span-full space-y-4">
 
@@ -490,10 +484,10 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
                       {t("clusters.fields.modelCache.cacheType")}
                     </Label>
                     <Select
-                      options={[
+                      options={isKubernetes ? [
+                        { label: t("clusters.options.hostPath"), value: "host_path" },
                         { label: t("clusters.options.nfs"), value: "nfs" },
-                        { label: t("clusters.options.hostPath"), value: "host_path" }
-                      ]}
+                      ] : [{ label: t("clusters.options.hostPath"), value: "host_path" }]}
                       value={cacheType}
                       onChange={(value) => {
                         switchCacheType(index, value as 'nfs' | 'host_path');
@@ -521,6 +515,7 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
                   {cacheType === 'nfs' && (
                     <>
                       <Field
+                        {...form}
                         label={t("clusters.fields.modelCache.nfsServer")}
                         {...form.register(`spec.config.model_caches.${index}.nfs.server`,
                         {
@@ -572,21 +567,20 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
                     <>
                     <Field
                       {...form}
-                      name={`spec.config.model_caches.${index}.host_path.path`}
                       label={t("clusters.fields.modelCache.cachePath")}
-                      rules={{
+                      {...form.register(`spec.config.model_caches.${index}.host_path.path`, {
                         required: {
                           value: true,
                           message: t("clusters.validation.cachePathRequired") || "Cache path is required"
                         },
                         validate: (value: string) => {
                           if (!value) return true;
-                          return isValidPath(value) || t("clusters.validation.invalidPath") || "Please enter a valid path (e.g., /home/bentoml)";
+                          return isValidPath(value) || t("clusters.validation.invalidPath") || "Please enter a valid path (e.g., /dir/cache)";
                         }
-                      }}
+                      })}
                     >
                       <Input
-                        placeholder="/home/bentoml"
+                        placeholder="/path/to/cache"
                         disabled={isEdit}
                         className={`col-span-2 ${form.formState.errors[`spec.config.model_caches.${index}.host_path.path`] ? "border-red-500 focus:border-red-500" : ""}`}
                       />
@@ -620,7 +614,7 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
       </div>
       </div>
     </FormCardGrid>
-    </div>) : null,
+    </div>),
     authFields: isKubernetes ? null : (
       <FormCardGrid title={t("clusters.sections.nodeAuthentication")}>
         <Field

--- a/src/pages/clusters/use-cluster-form.tsx
+++ b/src/pages/clusters/use-cluster-form.tsx
@@ -3,10 +3,14 @@ import NodeIPsField from "@/components/business/NodeIPsField";
 import WorkspaceField from "@/components/business/WorkspaceField";
 import { Combobox, Field, Select } from "@/components/theme";
 import { useWorkspace } from "@/components/theme/hooks";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import type { Cluster, ImageRegistry } from "@/types";
 import { useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
+import { Plus, Trash2 } from "lucide-react";
+import { useFieldArray } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
 export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
@@ -54,6 +58,11 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
   const workerResources = form.watch(
     "spec.config.worker_group_specs.0.resources",
   );
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "spec.config.model_caches"
+  });
 
   const getAcceleratorInfo = (
     resources: Record<string, string | number> | undefined,
@@ -107,6 +116,42 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
   });
 
   const isEdit = action === "edit";
+
+  const addModelCache = () => {
+      append({
+        nfs: {
+          server: '',
+          path: '',
+        },
+        model_registry_type: ''
+      });
+  };
+
+  const getCacheType = (index: number): 'nfs' | 'host_path' => {
+    const cache = form.watch(`spec.config.model_caches.${index}`);
+    return cache?.nfs ? 'nfs' : 'host_path';
+  };
+
+  const switchCacheType = (index: number, newType: 'nfs' | 'host_path') => {
+    const currentCache = form.getValues(`spec.config.model_caches.${index}`);
+    
+    if (newType === 'nfs') {
+      form.setValue(`spec.config.model_caches.${index}`, {
+        nfs: {
+          server: '',
+          path: '',
+        },
+        model_registry_type: currentCache.model_registry_type || 'hugging-face'
+      });
+    } else {
+      form.setValue(`spec.config.model_caches.${index}`, {
+        host_path: {
+          path: '',
+        },
+        model_registry_type: currentCache.model_registry_type || 'bentoml'
+      });
+    }
+  };
 
   return {
     form,
@@ -199,6 +244,9 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
                         "nvidia.com/gpu": "0",
                       },
                     },
+                  ],
+                  model_caches: [
+                    
                   ],
                 });
               }
@@ -395,6 +443,136 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
         <div />
       </FormCardGrid>
     ) : null,
+    modelCacheFields: isKubernetes ? (<div>
+      <FormCardGrid title={t("clusters.sections.modelCaches")}>
+      <div className="col-span-full space-y-4">
+
+
+      {fields.map((field, index) => {
+          const cacheType = getCacheType(index);
+          
+          return (
+            <Card key={field.id} className="relative">
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-sm font-medium">
+                  #{index + 1} -  {t(`clusters.fields.modelCache.type.${cacheType}`)}
+                  </CardTitle>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => remove(index)}
+                    disabled={isEdit}
+                    className="text-red-500 hover:text-red-700"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </CardHeader>
+              
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <Field
+                    {...form}
+                    name={`spec.config.model_caches.${index}.cache_type_selector`}
+                    label={t("clusters.fields.modelCache.cacheType")}
+                  >
+                    <Select
+                      options={[
+                        { label: t("clusters.options.nfs"), value: "nfs" },
+                        { label: t("clusters.options.hostPath"), value: "host_path" }
+                      ]}
+                      value={cacheType}
+                      onChange={(value) => {
+                        switchCacheType(index, value as 'nfs' | 'host_path');
+                      }}
+                      disabled={isEdit}
+                    />
+                  </Field>
+
+                  <Field
+                    {...form}
+                    name={`spec.config.model_caches.${index}.model_registry_type`}
+                    label={t("clusters.fields.modelCache.modelRegistry")}
+                  >
+                    <Select
+                      options={[
+                        { label: "Hugging Face", value: "hugging-face" },
+                        { label: "BentoML", value: "bentoml" }
+                      ]}
+                      disabled={isEdit}
+                    />
+                  </Field>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  {cacheType === 'nfs' && (
+                    <>
+                      <Field
+                        {...form}
+                        name={`spec.config.model_caches.${index}.nfs.server`}
+                        label={t("clusters.fields.modelCache.nfsServer")}
+                      >
+                        <Input
+                          placeholder="10.255.1.54"
+                          disabled={isEdit}
+                        />
+                      </Field>
+
+                      <Field
+                        {...form}
+                        name={`spec.config.model_caches.${index}.nfs.path`}
+                        label={t("clusters.fields.modelCache.nfsPath")}
+                      >
+                        <Input
+                          placeholder="/path/to/cache"
+                          disabled={isEdit}
+                        />
+                      </Field>
+                    </>
+                  )}
+
+                  {cacheType === 'host_path' && (
+                    <Field
+                      {...form}
+                      name={`spec.config.model_caches.${index}.host_path.path`}
+                      label={t("clusters.fields.modelCache.hostPath")}
+                    >
+                      <Input
+                        placeholder="/home/bentoml"
+                        disabled={isEdit}
+                        className="col-span-2"
+                      />
+                    </Field>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}        
+
+      {fields.length === 0 && (
+        <div className="text-center py-8 text-gray-500">
+          {t("clusters.messages.noModelCaches")}
+        </div>
+      )}
+      <div className="flex gap-2 pt-2">          
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={addModelCache}
+          disabled={isEdit}
+          className="flex ml-auto gap-2"
+        >
+          <Plus className="h-4 w-4" />
+          {t("clusters.actions.addModelCache")}
+        </Button>
+      </div>
+      </div>
+    </FormCardGrid>
+    </div>) : null,
     authFields: isKubernetes ? null : (
       <FormCardGrid title={t("clusters.sections.nodeAuthentication")}>
         <Field

--- a/src/pages/clusters/use-cluster-form.tsx
+++ b/src/pages/clusters/use-cluster-form.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { isValidIPAddress, isValidPath } from "@/lib/utils";
 import type { Cluster, ImageRegistry } from "@/types";
 import { useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
@@ -152,6 +153,16 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
         model_registry_type: currentCache.model_registry_type || 'bentoml'
       });
     }
+  };
+
+  const FieldError = ({ error }: { error?: { message?: string } }) => {
+    if (!error?.message) return null;
+    
+    return (
+      <p className="text-sm text-red-500 mt-1">
+        {error.message}
+      </p>
+    );
   };
 
   return {
@@ -510,41 +521,78 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
                   {cacheType === 'nfs' && (
                     <>
                       <Field
-                        {...form}
-                        name={`spec.config.model_caches.${index}.nfs.server`}
                         label={t("clusters.fields.modelCache.nfsServer")}
+                        {...form.register(`spec.config.model_caches.${index}.nfs.server`,
+                        {
+                          required: {
+                            value: true,
+                            message: t("clusters.validation.nfsServerRequired") || "NFS server is required"
+                          },
+                          validate: (value: string) => {
+                            if (!value) return true; // Let required rule handle empty values
+                            return isValidIPAddress(value) || t("clusters.validation.invalidIPAddress") || "Please enter a valid IP address";
+                          }
+                        }
+                        )}
                       >
                         <Input
                           placeholder="10.255.1.54"
                           disabled={isEdit}
+                          className={form.formState.errors[`spec.config.model_caches.${index}.nfs.server`] ? "border-red-500 focus:border-red-500" : ""}
                         />
                       </Field>
+                      <FieldError error={form.formState.errors[`spec.config.model_caches.${index}.nfs.server`]}/>
 
                       <Field
                         {...form}
-                        name={`spec.config.model_caches.${index}.nfs.path`}
-                        label={t("clusters.fields.modelCache.nfsPath")}
-                      >
+                        label={t("clusters.fields.modelCache.cachePath")}
+                        {...form.register(`spec.config.model_caches.${index}.nfs.path`, 
+                          {
+                            required: {
+                              value: true,
+                              message: t("clusters.validation.cachePathRequired") || "Cache path is required"
+                            },
+                            validate: (value: string) => {
+                              if (!value) return true; // Let required rule handle empty values
+                              return isValidPath(value) || t("clusters.validation.invalidPath") || "Please enter a valid path (e.g., /path/to/cache)";
+                            }
+                          }
+                        )}>
                         <Input
                           placeholder="/path/to/cache"
                           disabled={isEdit}
+                          className={form.formState.errors[`spec.config.model_caches.${index}.nfs.path`] ? "border-red-500 focus:border-red-500" : ""}
                         />
                       </Field>
+                      <FieldError error={form.formState.errors[`spec.config.model_caches.${index}.nfs.path`]}/>
                     </>
                   )}
 
                   {cacheType === 'host_path' && (
+                    <>
                     <Field
                       {...form}
                       name={`spec.config.model_caches.${index}.host_path.path`}
-                      label={t("clusters.fields.modelCache.hostPath")}
+                      label={t("clusters.fields.modelCache.cachePath")}
+                      rules={{
+                        required: {
+                          value: true,
+                          message: t("clusters.validation.cachePathRequired") || "Cache path is required"
+                        },
+                        validate: (value: string) => {
+                          if (!value) return true;
+                          return isValidPath(value) || t("clusters.validation.invalidPath") || "Please enter a valid path (e.g., /home/bentoml)";
+                        }
+                      }}
                     >
                       <Input
                         placeholder="/home/bentoml"
                         disabled={isEdit}
-                        className="col-span-2"
+                        className={`col-span-2 ${form.formState.errors[`spec.config.model_caches.${index}.host_path.path`] ? "border-red-500 focus:border-red-500" : ""}`}
                       />
                     </Field>
+                    <FieldError error={form.formState.errors[`spec.config.model_caches.${index}.host_path.path`]} />
+                    </>
                   )}
                 </div>
               </CardContent>

--- a/src/pages/clusters/use-cluster-form.tsx
+++ b/src/pages/clusters/use-cluster-form.tsx
@@ -6,6 +6,7 @@ import { useWorkspace } from "@/components/theme/hooks";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import type { Cluster, ImageRegistry } from "@/types";
 import { useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
@@ -473,11 +474,10 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
               
               <CardContent className="space-y-4">
                 <div className="grid grid-cols-2 gap-4">
-                  <Field
-                    {...form}
-                    name={`spec.config.model_caches.${index}.cache_type_selector`}
-                    label={t("clusters.fields.modelCache.cacheType")}
-                  >
+                <div className="space-y-2">
+                    <Label className="text-sm font-medium">
+                      {t("clusters.fields.modelCache.cacheType")}
+                    </Label>
                     <Select
                       options={[
                         { label: t("clusters.options.nfs"), value: "nfs" },
@@ -489,7 +489,7 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
                       }}
                       disabled={isEdit}
                     />
-                  </Field>
+                  </div>
 
                   <Field
                     {...form}

--- a/src/pages/endpoints/use-endpoint-form.tsx
+++ b/src/pages/endpoints/use-endpoint-form.tsx
@@ -145,6 +145,11 @@ const resourceMapping: Record<
     apiValue: "NVIDIA_TESLA_A10G",
     type: "gpu",
   },
+  AMDInstinctMI300XVF: {
+    label: "AMD Instinct MI300X VF",
+    apiValue: "AMD_Instinct_MI300X_VF",
+    type: "gpu",
+  },
   NVIDIAL40S: { label: "NVIDIA L40S", apiValue: "NVIDIA_L40S", type: "gpu" },
   NVIDIAL4: { label: "NVIDIA L4", apiValue: "NVIDIA_L4", type: "gpu" },
   NVIDIAL20: { label: "NVIDIA L20", apiValue: "NVIDIA_L20", type: "gpu" },
@@ -215,14 +220,14 @@ const parseClusterResources = (
   }
 
   // Add generic options
-  acceleratorTypes.unshift({
+  gpu.total && acceleratorTypes.unshift({
     label: "Generic",
     value: "-",
     available: gpu.available,
     total: gpu.total,
     type: "gpu",
   });
-  acceleratorTypes.unshift({
+  npu.total && acceleratorTypes.unshift({
     label: "Generic",
     value: "-",
     available: npu.available,

--- a/src/types/cluster-types.ts
+++ b/src/types/cluster-types.ts
@@ -55,6 +55,7 @@ export type Auth = {
 export type RaySSHProvisionClusterConfig = {
   provider: Provider;
   auth: Auth;
+  model_caches?: HostPathCache[];
 };
 
 export enum KubernetesAccessMode {
@@ -81,12 +82,18 @@ export type RayKubernetesProvisionClusterConfig = {
   model_caches?: ModelCache[];
 };
 
-export type ModelCache = {
+export type ModelCache = NFSCache | HostPathCache;
+
+export type NFSCache = {
   nfs?: {
     server: string;
     path: string;
   };
-  host_path?: {
+  model_registry_type: string;
+};
+
+export type HostPathCache = {
+  host_path: {
     path: string;
   };
   model_registry_type: string;

--- a/src/types/cluster-types.ts
+++ b/src/types/cluster-types.ts
@@ -1,3 +1,4 @@
+import { Mode } from "fs";
 import type { Metadata } from "./basic-types";
 
 export type RayClusterConfig = {
@@ -78,6 +79,18 @@ export type RayKubernetesProvisionClusterConfig = {
   kubeconfig?: string;
   head_node_spec?: HeadNodeSpec;
   worker_group_specs?: WorkerGroupSpec[];
+  model_caches?: ModelCache[];
+};
+
+export type ModelCache = {
+  nfs?: {
+    server: string;
+    path: string;
+  };
+  host_path?: {
+    path: string;
+  };
+  model_registry_type: string;
 };
 
 export type Cluster = {

--- a/src/types/cluster-types.ts
+++ b/src/types/cluster-types.ts
@@ -1,4 +1,3 @@
-import { Mode } from "fs";
 import type { Metadata } from "./basic-types";
 
 export type RayClusterConfig = {


### PR DESCRIPTION
Implements UI support for configuring model caches when creating Kubernetes clusters, allowing users to add multiple cache configurations with different storage types.

Added type-specific form fields that adapt based on selected cache type:
- NFS Cache: Server IP, path, and model registry type configuration
- Host Path Cache: Local path and model registry type configuration

The implementation supports the YAML structure from the requirements:
```yaml
model_caches:
  - nfs:
      server: 10.255.1.54
      path: /bentoml/hf
    model_registry_type: hugging-face
  - host_path:
      path: /home/bentoml
    model_registry_type: bentoml
```