### PR TITLE
Fix workspace switching race condition on page reload

### DIFF
--- a/src/components/theme/hooks/useWorkspace.ts
+++ b/src/components/theme/hooks/useWorkspace.ts
@@ -8,8 +8,9 @@ export const ALL_WORKSPACES = "_all_";
 export const useWorkspace = () => {
   const { params } = useParsed();
   const [value, setValue] = useLocalStorage<string>(WORKSPACE_STORAGE_KEY);
+  
   useEffect(() => {
-    if (params?.workspace !== value) {
+    if (params?.workspace && params?.workspace !== value) {
       setValue(params?.workspace);
     }
   }, [params?.workspace, setValue, value]);
@@ -21,12 +22,12 @@ export const useWorkspace = () => {
   const preferred =
     data?.data?.find((workspace) => workspace.metadata.name === value)?.metadata
       .name || ALL_WORKSPACES;
-  const current =
-    data?.data?.find(
-      (workspace) => workspace.metadata.name === params?.workspace,
-    )?.metadata.name ||
-    preferred ||
-    ALL_WORKSPACES;
+
+  const current = params?.workspace 
+    ? (data?.data?.find(
+        (workspace) => workspace.metadata.name === params?.workspace,
+      )?.metadata.name || params?.workspace)
+    : preferred;
 
   return {
     current,


### PR DESCRIPTION
## Problem
When reloading pages with workspace parameters (e.g., `/default/endpoints/create`), the `useWorkspace` hook briefly returned `_all_` before switching to the correct workspace (`default`), causing stale state displaying on the UI.

## Root Cause
Race condition between URL parsing and localStorage fallback:
1. Initial render: `params?.workspace` is `undefined` while router parses
2. Hook falls back to localStorage value or `_all_`
3. Next render: `params?.workspace` becomes available and switches

## Solution
- Only update localStorage when `params?.workspace` is truthy
- Prioritize URL parameters over localStorage fallback
- Maintain workspace validation while preserving URL parameter value

## Changes
- Modified `useEffect` to trigger only when `params?.workspace` has value
- Restructured `current` calculation to respect URL parameters first
- Return URL workspace immediately to prevent flicker

## Result
Consistent behavior between navigation and direct URL access.