### PR TITLE
fix: use the uuid package for better compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"sonner": "^2.0.2",
 		"tailwind-merge": "^3.0.1",
 		"tailwindcss-animate": "^1.0.7",
+		"uuid": "^11.1.0",
 		"zod": "^3.24.2"
 	},
 	"devDependencies": {

--- a/src/components/business/FunctionsManager.tsx
+++ b/src/components/business/FunctionsManager.tsx
@@ -8,6 +8,7 @@ import { Trash2, Edit, Plus } from "lucide-react";
 import { FunctionDialog } from "./FunctionDialog";
 import type { ChatFunction } from "@/types/chat-types";
 import { cn } from "@/lib/utils";
+import { v4 } from "uuid";
 
 interface FunctionsManagerProps {
   functions: ChatFunction[];
@@ -47,7 +48,7 @@ export function FunctionsManager({
       // Create new function
       const newFunction: ChatFunction = {
         ...functionData,
-        id: crypto.randomUUID(),
+        id: v4(),
         enabled: true,
       };
       onFunctionsChange([...functions, newFunction]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3748,6 +3748,11 @@ util-deprecate@^1.0.2:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
+
 vfile-message@^4.0.0:
   version "4.0.2"
   resolved "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz"


### PR DESCRIPTION
randomUUID is available only in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS), in some or all [supporting browsers](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID#browser_compatibility).

MDN Link: https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID

 Use the UUID package instead.