### PR TITLE
fix: endpoint resource slider miscalculation issue

### DIFF
--- a/src/hooks/use-endpoint-resources.ts
+++ b/src/hooks/use-endpoint-resources.ts
@@ -59,8 +59,7 @@ const useEndpointResources = (
     action, 
     metadata?.name,
     resources,
-    isInitialized,
-    currentUsage
+    isInitialized
   ]);
 
   return currentUsage || {

--- a/src/hooks/use-endpoint-resources.ts
+++ b/src/hooks/use-endpoint-resources.ts
@@ -1,74 +1,39 @@
-import { useEffect, useState } from "react";
+import { useMemo } from "react";
 
 const useEndpointResources = (
-  resources: {
+  resources?: {
     cpu?: number;
     memory?: number;
     gpu?: number;
     npu?: number;
     accelerator?: Record<string, number>;
-  } | null,
-  metadata: {
-    name?: string;
-  } | null,
-  action: "create" | "edit"
+  },
+  metadata?: Record<string, any>
 ) => {
-  const [currentUsage, setCurrentUsage] = useState<{
-    cpu: number;
-    memory: number;
-    gpu: number;
-    npu: number;
-    accelerator: Record<string, number>;
-  } | null>(null);
-
-  const [isInitialized, setIsInitialized] = useState(false);
-
-  useEffect(() => {
-    if (isInitialized) return;
-
-    if (action === "create") {
-      const usage = {
-        cpu: resources?.cpu || 0,
-        memory: resources?.memory || 0,
-        gpu: resources?.gpu || 0,
-        npu: resources?.accelerator?.NPU || 0,
-        accelerator: resources?.accelerator || { "-": 0 }
-      };
-      setCurrentUsage(usage);
-      setIsInitialized(true);
-      return;
-    }
-    
-    // For edit mode, check if we have real data
-    const hasRealData = metadata?.name && 
-                       metadata.name !== "" &&
-                       resources;
+  return useMemo(() => {
+    const hasRealData = metadata?.name && metadata.name !== "" && resources;
 
     if (hasRealData) {
-      const usage = {
+      return {
         cpu: resources?.cpu || 0,
         memory: resources?.memory || 0,
         gpu: resources?.gpu || 0,
         npu: resources?.accelerator?.NPU || 0,
         accelerator: resources?.accelerator || { "-": 0 }
       };
-      setCurrentUsage(usage);
-      setIsInitialized(true);
     }
+    
+    return {
+      cpu: 0,
+      memory: 0,
+      gpu: 0,
+      npu: 0,
+      accelerator: {}
+    };
   }, [
-    action, 
     metadata?.name,
-    resources,
-    isInitialized
+    resources
   ]);
-
-  return currentUsage || {
-    cpu: 0,
-    memory: 0,
-    gpu: 0,
-    npu: 0,
-    accelerator: {}
-  };
 };
 
 export default useEndpointResources;

--- a/src/hooks/use-endpoint-resources.ts
+++ b/src/hooks/use-endpoint-resources.ts
@@ -24,7 +24,7 @@ const useEndpointResources = (
   const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
-    if (isInitialized || currentUsage) return;
+    if (isInitialized) return;
 
     if (action === "create") {
       const usage = {
@@ -68,7 +68,7 @@ const useEndpointResources = (
     memory: 0,
     gpu: 0,
     npu: 0,
-    accelerator: { "-": 0, NPU: 0 }
+    accelerator: {}
   };
 };
 

--- a/src/hooks/use-endpoint-resources.ts
+++ b/src/hooks/use-endpoint-resources.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+
+const useEndpointResources = (
+  resources: {
+    cpu?: number;
+    memory?: number;
+    gpu?: number;
+    npu?: number;
+    accelerator?: Record<string, number>;
+  } | null,
+  metadata: {
+    name?: string;
+  } | null,
+  action: "create" | "edit"
+) => {
+  const [currentUsage, setCurrentUsage] = useState<{
+    cpu: number;
+    memory: number;
+    gpu: number;
+    npu: number;
+    accelerator: Record<string, number>;
+  } | null>(null);
+
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  useEffect(() => {
+    if (isInitialized || currentUsage) return;
+
+    if (action === "create") {
+      const usage = {
+        cpu: resources?.cpu || 0,
+        memory: resources?.memory || 0,
+        gpu: resources?.gpu || 0,
+        npu: resources?.accelerator?.NPU || 0,
+        accelerator: resources?.accelerator || { "-": 0 }
+      };
+      setCurrentUsage(usage);
+      setIsInitialized(true);
+      return;
+    }
+    
+    // For edit mode, check if we have real data
+    const hasRealData = metadata?.name && 
+                       metadata.name !== "" &&
+                       resources;
+
+    if (hasRealData) {
+      const usage = {
+        cpu: resources?.cpu || 0,
+        memory: resources?.memory || 0,
+        gpu: resources?.gpu || 0,
+        npu: resources?.accelerator?.NPU || 0,
+        accelerator: resources?.accelerator || { "-": 0 }
+      };
+      setCurrentUsage(usage);
+      setIsInitialized(true);
+    }
+  }, [
+    action, 
+    metadata?.name,
+    resources,
+    isInitialized,
+    currentUsage
+  ]);
+
+  return currentUsage || {
+    cpu: 0,
+    memory: 0,
+    gpu: 0,
+    npu: 0,
+    accelerator: { "-": 0, NPU: 0 }
+  };
+};
+
+export default useEndpointResources;

--- a/src/pages/endpoints/use-endpoint-form.tsx
+++ b/src/pages/endpoints/use-endpoint-form.tsx
@@ -768,7 +768,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
               <span>{formatToDecimal(form.watch("spec.resources.memory"))} GiB</span>
               {clusterResources && (
                 <span>
-                  Remaining: {formatToDecimal(clusterResources.memory.available)} /{" "}
+                  Remaining: {formatToDecimal(dynamicAvailability.memory)} /{" "}
                   {formatToDecimal(clusterResources.memory.total)} GiB
                 </span>
               )}

--- a/src/pages/endpoints/use-endpoint-form.tsx
+++ b/src/pages/endpoints/use-endpoint-form.tsx
@@ -14,7 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Combobox as AsyncCombobox } from "@/components/ui/combobox";
 import { useWorkspace } from "@/components/theme/hooks";
 import { useCustom, useSelect } from "@refinedev/core";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import WorkspaceField from "@/components/business/WorkspaceField";
 import { CommandLoading } from "@/components/ui/command";
 import { Slider } from "@/components/ui/slider";
@@ -251,6 +251,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   const [selectedModelCatalog, setSelectedModelCatalog] = useState<string>("");
   const [isCustomizeOpen, setIsCustomizeOpen] = useState(false);
   const [modelSearch, setModelSearch] = useState("");
+  
 
   const form = useForm<Endpoint>({
     mode: "all",
@@ -275,8 +276,8 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
           version: "",
         },
         resources: {
-          cpu: 1,
-          memory: 1,
+          cpu: 0,
+          memory: 0,
           gpu: 0,
           accelerator: {
             "-": 0,
@@ -326,6 +327,18 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
     },
   });
 
+  const originalResources = useMemo(() => {
+    const formValues = form.getValues() || form.formState.defaultValues;
+    const resources = {
+      cpu: formValues?.spec?.resources?.cpu || 0,
+      memory: formValues?.spec?.resources?.memory || 0,
+      gpu: formValues?.spec?.resources?.gpu || 0,
+      npu: formValues?.spec?.resources?.accelerator?.NPU || 0,
+      accelerator: formValues?.spec?.resources?.accelerator || { "-": 0, NPU: 0 }
+    };
+    return resources;
+  }, [form.formState.defaultValues]); 
+
   const workspace = form.watch("metadata.workspace");
   const currentModelName = form.watch("spec.model.name");
   const currentRegistry = form.watch("spec.model.registry");
@@ -374,6 +387,39 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   const clusterResources = useMemo(() => {
     return parseClusterResources(clusterStatusQuery.data?.data);
   }, [clusterStatusQuery.data?.data]);
+
+  const maxAvailable = useMemo(() => {
+    if (!clusterResources || !originalResources) {
+      return { cpu: 0, memory: 0, gpu: 0, npu: 0, accelerator: {} };
+    }
+    return {
+      cpu: Number(clusterResources.cpu?.available || 0) + Number(originalResources.cpu || 0),
+      memory: Number(clusterResources.memory?.available || 0) + Number(originalResources.memory || 0),
+      gpu: Number(clusterResources.gpu?.available || 0) + Number(originalResources.gpu || 0),
+      npu: Number(clusterResources.npu?.available || 0) + Number(originalResources.npu || 0),
+      accelerator: Object.keys(originalResources.accelerator).reduce((acc, key) => {
+        const specificAccelerator = clusterResources.acceleratorTypes.find(
+          acc => acc.value === key
+        );
+        acc[key] = Number(specificAccelerator?.available || 0) + Number(originalResources.accelerator[key] || 0);
+        return acc;
+      }, {} as Record<string, number>)
+    };
+  }, [clusterResources, originalResources]);
+
+  const dynamicAvailability = useMemo(() => {
+    const currentCpu = form.watch("spec.resources.cpu") || 0;
+    const currentMemory = form.watch("spec.resources.memory") || 0;
+    const currentAcceleratorType = Object.keys(acceleratorValue)[0];
+    const currentAcceleratorValue = acceleratorValue[currentAcceleratorType] || 0;
+    return {
+      cpu: maxAvailable.cpu - currentCpu,
+      memory: maxAvailable.memory - currentMemory,
+      accelerator: {
+        [currentAcceleratorType]: (maxAvailable.accelerator[currentAcceleratorType] || 0) - currentAcceleratorValue
+      }
+    };
+  }, [maxAvailable, form.watch("spec.resources.cpu"), form.watch("spec.resources.memory"), acceleratorValue]);
 
   const isEdit = action === "edit";
 
@@ -498,17 +544,14 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
     );
 
     const currentAcceleratorType = Object.keys(acceleratorValue)[0];
-    const currentAccelerator = clusterResources?.acceleratorTypes.find(
-      (acc) => acc.value === currentAcceleratorType && acc.type === type,
-    );
 
     // Extract computed values
     const currentAcceleratorValue = acceleratorValue[currentAcceleratorType] || 0;
     const specificAccelerator = clusterResources?.acceleratorTypes.find(
       (acc) => acc.value === currentAcceleratorType && acc.type === type,
     );
-    const maxSliderValue = !clusterResources ? 2 : 
-      (specificAccelerator?.available ?? totalResources?.available ?? 0);
+    const maxSliderValue = !clusterResources ? 0 : (maxAvailable.accelerator[currentAcceleratorType] || 0);
+    const availableCount = dynamicAvailability.accelerator[currentAcceleratorType] || 0;
 
     const typeLabel = isGpu
       ? t("endpoints.fields.gpu")
@@ -560,9 +603,9 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
               </span>
               {clusterResources && (
                 <span>
-                  {currentAccelerator
-                    ? `Available: ${currentAccelerator.available} / ${currentAccelerator.total}`
-                    : `Available: ${totalResources?.available} / ${totalResources?.total}`}
+                  Remaining: {formatToDecimal(availableCount)} / {formatToDecimal(
+                    specificAccelerator?.total ?? totalResources?.total ?? 0
+                  )}
                 </span>
               )}
             </div>
@@ -698,19 +741,16 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
               <span>{formatToDecimal(form.watch("spec.resources.cpu"))} cores</span>
               {clusterResources && (
                 <span>
-                  Available: {formatToDecimal(clusterResources.cpu.available)} /{" "}
-                  {formatToDecimal(clusterResources.cpu.total)}
+                  Remaining: {formatToDecimal(dynamicAvailability.cpu)} / {formatToDecimal(clusterResources.cpu.total)}
                 </span>
               )}
             </div>
             <Slider
               min={0}
-              max={clusterResources?.cpu.available ?? 0}
+              max={maxAvailable.cpu}
               step={0.1}
               value={[form.watch("spec.resources.cpu")]}
-              onValueChange={(value) => {
-                form.setValue("spec.resources.cpu", value[0]);
-              }}
+              onValueChange={(value) => form.setValue("spec.resources.cpu", value[0])}
               disabled={clusterStatusQuery.isLoading || !currentCluster}
             />
           </div>
@@ -726,7 +766,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
               <span>{formatToDecimal(form.watch("spec.resources.memory"))} GiB</span>
               {clusterResources && (
                 <span>
-                  Available: {formatToDecimal(clusterResources.memory.available)} /{" "}
+                  Remaining: {formatToDecimal(clusterResources.memory.available)} /{" "}
                   {formatToDecimal(clusterResources.memory.total)} GiB
                 </span>
               )}

--- a/src/pages/endpoints/use-endpoint-form.tsx
+++ b/src/pages/endpoints/use-endpoint-form.tsx
@@ -14,7 +14,7 @@ import { Input } from "@/components/ui/input";
 import { Combobox as AsyncCombobox } from "@/components/ui/combobox";
 import { useWorkspace } from "@/components/theme/hooks";
 import { useCustom, useSelect } from "@refinedev/core";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import WorkspaceField from "@/components/business/WorkspaceField";
 import { CommandLoading } from "@/components/ui/command";
 import { Slider } from "@/components/ui/slider";
@@ -30,6 +30,7 @@ import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { formatToDecimal } from "@/lib/unit";
+import useEndpointResources from "@/hooks/use-endpoint-resources";
 
 // Types for Ray cluster status API response
 type RayClusterResourceUsage = {
@@ -327,17 +328,12 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
     },
   });
 
-  const originalResources = useMemo(() => {
-    const formValues = form.getValues() || form.formState.defaultValues;
-    const resources = {
-      cpu: formValues?.spec?.resources?.cpu || 0,
-      memory: formValues?.spec?.resources?.memory || 0,
-      gpu: formValues?.spec?.resources?.gpu || 0,
-      npu: formValues?.spec?.resources?.accelerator?.NPU || 0,
-      accelerator: formValues?.spec?.resources?.accelerator || { "-": 0, NPU: 0 }
-    };
-    return resources;
-  }, [form.formState.defaultValues]); 
+  const formValues = form.getValues();
+  const currentUsage = useEndpointResources(
+    formValues.spec?.resources,
+    formValues.metadata,
+    action
+  );
 
   const workspace = form.watch("metadata.workspace");
   const currentModelName = form.watch("spec.model.name");
@@ -389,23 +385,30 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   }, [clusterStatusQuery.data?.data]);
 
   const maxAvailable = useMemo(() => {
-    if (!clusterResources || !originalResources) {
-      return { cpu: 0, memory: 0, gpu: 0, npu: 0, accelerator: {} };
+    if (!clusterResources) {
+      return { cpu: 0, memory: 0, gpu: 0, npu: 0, accelerator: {"-": 0} };
     }
+
+    const remainingAvailable = clusterResources.acceleratorTypes?.reduce((acc, item) => {
+      acc[item.value] = Number(item.available || 0);
+      return acc;
+    }, {} as Record<string, number>);
+
+    const accelerator = Object.keys(remainingAvailable).reduce((acc, key) => {
+      const usage = Number(currentUsage.accelerator[key] || 0);
+      const available = remainingAvailable?.[key] || 0;
+      acc[key] = usage + available;
+      return acc;
+    }, {} as Record<string, number>);
+
     return {
-      cpu: Number(clusterResources.cpu?.available || 0) + Number(originalResources.cpu || 0),
-      memory: Number(clusterResources.memory?.available || 0) + Number(originalResources.memory || 0),
-      gpu: Number(clusterResources.gpu?.available || 0) + Number(originalResources.gpu || 0),
-      npu: Number(clusterResources.npu?.available || 0) + Number(originalResources.npu || 0),
-      accelerator: Object.keys(originalResources.accelerator).reduce((acc, key) => {
-        const specificAccelerator = clusterResources.acceleratorTypes.find(
-          acc => acc.value === key
-        );
-        acc[key] = Number(specificAccelerator?.available || 0) + Number(originalResources.accelerator[key] || 0);
-        return acc;
-      }, {} as Record<string, number>)
+      cpu: Number(clusterResources.cpu?.available || 0) + Number(currentUsage.cpu || 0),
+      memory: Number(clusterResources.memory?.available || 0) + Number(currentUsage.memory || 0),
+      gpu: Number(clusterResources.gpu?.available || 0) + Number(currentUsage.gpu || 0),
+      npu: Number(clusterResources.npu?.available || 0) + Number(currentUsage.npu || 0),
+      accelerator
     };
-  }, [clusterResources, originalResources]);
+  }, [clusterResources, currentUsage, action]);
 
   const dynamicAvailability = useMemo(() => {
     const currentCpu = form.watch("spec.resources.cpu") || 0;
@@ -423,7 +426,6 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
 
   const isEdit = action === "edit";
 
-  // Auto-initialize model search with current model name for better UX
   const effectiveModelSearch = modelSearch || currentModelName || "";
 
   const modelsData = useCustom({
@@ -575,7 +577,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
               const currentCount =
                 acceleratorValue[Object.keys(acceleratorValue)[0]];
               form.setValue("spec.resources.accelerator", {
-                [value as string]: currentCount,
+                [value as string]: Math.min(currentCount, maxAvailable.accelerator[value as string]),
               });
               
               // Update the corresponding accelerator field based on type
@@ -773,7 +775,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
             </div>
             <Slider
               min={0}
-              max={clusterResources?.memory.available ?? 0}
+              max={maxAvailable.memory}
               step={0.5}
               value={[form.watch("spec.resources.memory")]}
               onValueChange={(value) => {

--- a/src/pages/endpoints/use-endpoint-form.tsx
+++ b/src/pages/endpoints/use-endpoint-form.tsx
@@ -332,7 +332,6 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   const currentUsage = useEndpointResources(
     formValues.spec?.resources,
     formValues.metadata,
-    action
   );
 
   const workspace = form.watch("metadata.workspace");

--- a/src/pages/endpoints/use-endpoint-form.tsx
+++ b/src/pages/endpoints/use-endpoint-form.tsx
@@ -408,7 +408,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
       npu: Number(clusterResources.npu?.available || 0) + Number(currentUsage.npu || 0),
       accelerator
     };
-  }, [clusterResources, currentUsage, action]);
+  }, [clusterResources, currentUsage]);
 
   const dynamicAvailability = useMemo(() => {
     const currentCpu = form.watch("spec.resources.cpu") || 0;
@@ -577,7 +577,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
               const currentCount =
                 acceleratorValue[Object.keys(acceleratorValue)[0]];
               form.setValue("spec.resources.accelerator", {
-                [value as string]: Math.min(currentCount, maxAvailable.accelerator[value as string]),
+                [value as string]: Math.min(currentCount, maxAvailable.accelerator[value as string] || 0),
               });
               
               // Update the corresponding accelerator field based on type


### PR DESCRIPTION
This PR fixes the issue where the resource slider incorrectly included the instance’s current usage in the available resource pool. Now, the slider correctly excludes already-used resources and reflects the true remaining resource available, allowing users to utilize the full capacity as expected.