### PR TITLE
fix: UI behavior for user creation and cluster config updates

### DIFF
--- a/src/components/business/NodeIPsField.tsx
+++ b/src/components/business/NodeIPsField.tsx
@@ -29,12 +29,12 @@ type NodeIPsFieldProps = {
 
 const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
   (
-    { 
-      value = { head_ip: "", worker_ips: [] }, 
-      onChange, 
+    {
+      value = { head_ip: "", worker_ips: [] },
+      onChange,
       disabled = false,
       name,
-      ...props 
+      ...props
     },
     ref,
   ) => {
@@ -51,7 +51,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
       setHeadIp(value.head_ip || "");
     }, [value.head_ip]);
 
-    useEffect(() => { 
+    useEffect(() => {
       setworkerIps(value.worker_ips || []);
     }, [JSON.stringify(value.worker_ips)]);
 
@@ -69,20 +69,23 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
     );
 
     // Validate an IP address
-    const validateIp = useCallback((ip: string) => {
-      if (!ip) return "IP address is required";
-      if (!ipRegex.test(ip)) return "Invalid IP address format";
-      if (ipIsDuplicated(ip)) {
-        return "This IP address is already in use";
-      }
-      return "";
-    }, [ipIsDuplicated]);
+    const validateIp = useCallback(
+      (ip: string) => {
+        if (!ip) return "IP address is required";
+        if (!ipRegex.test(ip)) return "Invalid IP address format";
+        if (ipIsDuplicated(ip)) {
+          return "This IP address is already in use";
+        }
+        return "";
+      },
+      [ipIsDuplicated],
+    );
 
     // Update newWorkerIp validation when dependencies change
     useEffect(() => {
       if (newWorkerIp) {
         const newError = validateIp(newWorkerIp);
-        setErrors(prev => ({
+        setErrors((prev) => ({
           ...prev,
           newWorkerIp: newError,
         }));
@@ -93,7 +96,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
     const handleheadIpChange: ChangeEventHandler<HTMLInputElement> = (e) => {
       const ip = e.target.value;
       setHeadIp(ip);
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
         headIp: validateIp(ip),
       }));
@@ -105,7 +108,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
     ) => {
       const ip = e.target.value;
       setNewWorkerIp(ip);
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
         newWorkerIp: validateIp(ip),
       }));
@@ -113,15 +116,13 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
 
     // Add a new worker node IP
     const addWorkerNodeIp = () => {
-      // if (disabled) return;
-
       // Block adding if there are errors
       if (!newWorkerIp || errors.newWorkerIp) return;
 
       // Add the new IP and clear the input
       setworkerIps([...workerIps, newWorkerIp]);
       setNewWorkerIp("");
-      setErrors(prev => ({
+      setErrors((prev) => ({
         ...prev,
         newWorkerIp: "",
       }));
@@ -129,15 +130,15 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
 
     // Remove a worker node IP
     const removeWorkerNodeIp = (ipToRemove: string) => {
-      // if (disabled) return;
-
       setworkerIps(workerIps.filter((ip) => ip !== ipToRemove));
 
       // Clear any errors for this IP
-      setErrors(prev => {
+      setErrors((prev) => {
         const updatedErrors = { ...prev };
         if (ipToRemove in updatedErrors.workerIps) {
-          delete (updatedErrors.workerIps as Record<string, unknown>)[ipToRemove];
+          delete (updatedErrors.workerIps as Record<string, unknown>)[
+            ipToRemove
+          ];
         }
         if (ipToRemove === headIp) {
           // invariant: headIP === ipToRemove is valid as the ipToRemove has been validated upon adding
@@ -202,7 +203,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
                     <div className="flex items-center">
                       <span className="font-mono text-sm">{ip}</span>
                     </div>
-                    {(
+                    {
                       <Button
                         variant="ghost"
                         size="sm"
@@ -211,14 +212,14 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
                       >
                         <Trash className="h-4 w-4 text-destructive" />
                       </Button>
-                    )}
+                    }
                   </div>
                 ))
               )}
             </div>
 
             {/* Add new worker node IP */}
-            {(
+            {
               <div className="flex flex-col">
                 <div className="flex items-center">
                   <Input
@@ -251,7 +252,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
                   </div>
                 )}
               </div>
-            )}
+            }
           </CardContent>
         </Card>
       </div>

--- a/src/components/business/NodeIPsField.tsx
+++ b/src/components/business/NodeIPsField.tsx
@@ -113,7 +113,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
 
     // Add a new worker node IP
     const addWorkerNodeIp = () => {
-      if (disabled) return;
+      // if (disabled) return;
 
       // Block adding if there are errors
       if (!newWorkerIp || errors.newWorkerIp) return;
@@ -129,7 +129,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
 
     // Remove a worker node IP
     const removeWorkerNodeIp = (ipToRemove: string) => {
-      if (disabled) return;
+      // if (disabled) return;
 
       setworkerIps(workerIps.filter((ip) => ip !== ipToRemove));
 
@@ -202,7 +202,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
                     <div className="flex items-center">
                       <span className="font-mono text-sm">{ip}</span>
                     </div>
-                    {!disabled && (
+                    {(
                       <Button
                         variant="ghost"
                         size="sm"
@@ -218,7 +218,7 @@ const NodeIPsField = forwardRef<HTMLDivElement, NodeIPsFieldProps>(
             </div>
 
             {/* Add new worker node IP */}
-            {!disabled && (
+            {(
               <div className="flex flex-col">
                 <div className="flex items-center">
                   <Input

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -551,6 +551,10 @@
 		"sections": {
 			"globalRoles": "Global Roles",
 			"joinedWorkspaces": "Joined Workspaces"
+		},
+		"validation": {
+			"confirmPasswordRequired": "Confirm password is required",
+			"confirmPasswordNotMatch": "Passwords do not match"
 		}
 	},
 	"roles": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -551,6 +551,10 @@
 		"sections": {
 			"globalRoles": "全局角色",
 			"joinedWorkspaces": "已加入的工作空间"
+		},
+		"validation": {
+			"confirmPasswordRequired": "确认密码是必填项",
+			"confirmPasswordNotMatch": "密码不匹配"
 		}
 	},
 	"roles": {

--- a/src/pages/clusters/use-cluster-form.tsx
+++ b/src/pages/clusters/use-cluster-form.tsx
@@ -362,7 +362,6 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
         >
           <Input
             type="number"
-            disabled={isEdit}
             onChange={(evt) => {
               const value = Number(evt.target.value);
               form.setValue(
@@ -610,14 +609,14 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
           name="spec.config.auth.ssh_user"
           label={t("clusters.fields.sshUser")}
         >
-          <Input placeholder={t("clusters.placeholders.sshUserExample")} />
+          <Input placeholder={t("clusters.placeholders.sshUserExample")} disabled={isEdit}/>
         </Field>
         <Field
           {...form}
           name="spec.config.auth.ssh_private_key"
           label={t("clusters.fields.sshPrivateKey")}
         >
-          <Input type="password" />
+          <Input type="password" disabled={isEdit} />
         </Field>
       </FormCardGrid>
     ),

--- a/src/pages/clusters/use-cluster-form.tsx
+++ b/src/pages/clusters/use-cluster-form.tsx
@@ -256,7 +256,7 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
       <FormCardGrid title={t("clusters.sections.provider")}>
         {type === "ssh" && (
           <Field {...form} name="spec.config.provider" className="col-span-4">
-            <NodeIPsField />
+            <NodeIPsField disabled={isEdit} />
           </Field>
         )}
 

--- a/src/pages/users/use-user-form.tsx
+++ b/src/pages/users/use-user-form.tsx
@@ -65,24 +65,27 @@ export const useUserForm = ({ action }: { action: "create" | "edit" }) => {
           name="password"
           label={translate("user_profiles.fields.password")}
         >
-          <Input type="password" placeholder={"••••••••"} />
+          <Input type="password" />
         </Field>
         <Field
           {...form}
           label={translate("user_profiles.fields.confirmPassword")}
-          {...form.register("confirmPassword",
-            {
-              required: {
-                value: true,
-                message: (translate("user_profiles.validation.confirmPasswordRequired")),
-              },
-              validate: (value: string) => {
-                return value === form.getValues("password") || translate("user_profiles.validation.confirmPasswordNotMatch");
-              }
-            }
-          )}
+          {...form.register("confirmPassword", {
+            required: {
+              value: true,
+              message: translate(
+                "user_profiles.validation.confirmPasswordRequired",
+              ),
+            },
+            validate: (value: string) => {
+              return (
+                value === form.getValues("password") ||
+                translate("user_profiles.validation.confirmPasswordNotMatch")
+              );
+            },
+          })}
         >
-          <Input type="password" placeholder={"••••••••"} />
+          <Input type="password" />
         </Field>
       </FormCardGrid>
     ),

--- a/src/pages/users/use-user-form.tsx
+++ b/src/pages/users/use-user-form.tsx
@@ -65,14 +65,24 @@ export const useUserForm = ({ action }: { action: "create" | "edit" }) => {
           name="password"
           label={translate("user_profiles.fields.password")}
         >
-          <Input type="password" />
+          <Input type="password" placeholder={"••••••••"} />
         </Field>
         <Field
           {...form}
-          name="confirmPassword"
           label={translate("user_profiles.fields.confirmPassword")}
+          {...form.register("confirmPassword",
+            {
+              required: {
+                value: true,
+                message: (translate("user_profiles.validation.confirmPasswordRequired")),
+              },
+              validate: (value: string) => {
+                return value === form.getValues("password") || translate("user_profiles.validation.confirmPasswordNotMatch");
+              }
+            }
+          )}
         >
-          <Input type="password" />
+          <Input type="password" placeholder={"••••••••"} />
         </Field>
       </FormCardGrid>
     ),


### PR DESCRIPTION
This PR addresses the following issues:
- Fixed a bug where a user could be created even when the password and confirm password did not match. Validation now blocks submission if they differ.
- Made the head node IP field for SSH-type clusters read-only during editing, preventing unintended updates.
- Made SSH auth and kubeconfig fields uneditable when editing an existing cluste.
- Enabled editing of Worker Node replica count for Kubernetes-type clusters.
