### PR TITLE
fix: use clipboard-polyfill for clipboard actions, support http context

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 		"@types/js-yaml": "^4.0.9",
 		"ai": "^4.3.16",
 		"class-variance-authority": "^0.7.1",
+		"clipboard-polyfill": "^4.1.1",
 		"clsx": "^2.1.1",
 		"cmdk": "1.0.0",
 		"date-fns": "^4.1.0",

--- a/src/components/business/YamlExportDialog.tsx
+++ b/src/components/business/YamlExportDialog.tsx
@@ -39,6 +39,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
+import * as clipboard from "clipboard-polyfill";
 
 interface YamlExportDialogProps {
   trigger?: React.ReactNode;
@@ -122,7 +123,7 @@ export const YamlExportDialog = ({
 
   const handleCopyToClipboard = async () => {
     try {
-      await navigator.clipboard.writeText(yamlContent);
+      await clipboard.writeText(yamlContent);
       toast.success(t("components.yamlExport.copySuccess"), {
         description: t("components.yamlExport.copySuccessDescription"),
       });

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -715,6 +715,13 @@
 				"unknownError": "Unknown error"
 			}
 		},
+		"apiKey": {
+			"copySuccess": "Copied to clipboard",
+			"copySuccessDescription": "API key has been copied to your clipboard",
+			"errors": {
+				"copyFailed": "Failed to copy to clipboard"
+			}
+		},
 		"variablesInput": {
 			"key": "Key",
 			"value": "Value",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -715,6 +715,13 @@
 				"unknownError": "未知错误"
 			}
 		},
+		"apiKey": {
+			"copySuccess": "已复制到剪贴板",
+			"copySuccessDescription": "API 密钥已复制到您的剪贴板",
+			"errors": {
+				"copyFailed": "复制到剪贴板失败"
+			}
+		},
 		"variablesInput": {
 			"key": "键",
 			"value": "值",

--- a/src/pages/api-keys/list.tsx
+++ b/src/pages/api-keys/list.tsx
@@ -27,6 +27,8 @@ import { useMetadataColumns } from "@/components/theme/table/columns/metadata-co
 import { useApiKeyColumns } from "@/components/theme/table/columns/api-key-columns";
 import { defaultSorters } from "@/components/theme/table/sorter";
 import type { ApiKey } from "@/types";
+import * as clipboard from "clipboard-polyfill";
+import { toast } from "sonner";
 
 const CreateApiKeyForm = ({ onClose }: { onClose?: () => void }) => {
   const { t } = useTranslation();
@@ -48,11 +50,14 @@ const CreateApiKeyForm = ({ onClose }: { onClose?: () => void }) => {
 
   const copyToClipboard = async (text: string) => {
     try {
-      await navigator.clipboard.writeText(text);
+      await clipboard.writeText(text);
+      toast.success(t("components.apiKey.copySuccess"), {
+        description: t("components.apiKey.copySuccessDescription"),
+      });
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
-      console.error("Failed to copy text: ", err);
+      toast.error(t("components.apiKey.errors.copyFailed"));
     }
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,6 +1651,11 @@ class-variance-authority@^0.7.1:
   dependencies:
     clsx "^2.1.1"
 
+clipboard-polyfill@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/clipboard-polyfill/-/clipboard-polyfill-4.1.1.tgz#eaf074f91c0a55aa4c12fcfd4862d2cfb9a0cab9"
+  integrity sha512-nbvNLrcX0zviek5QHLFRAaLrx8y/s8+RF2stH43tuS+kP5XlHMrcD0UGBWq43Hwp6WuuK7KefRMP56S45ibZkA==
+
 clsx@^2.0.0, clsx@^2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz"


### PR DESCRIPTION
Use `clipboard-polyfill` instead of `navigate.clipboard` for better compatibility under http context.