### PR TITLE
fix: enables modification and deletion under all-workspace

### DIFF
--- a/src/components/theme/hooks/useDeleteHelper.tsx
+++ b/src/components/theme/hooks/useDeleteHelper.tsx
@@ -44,7 +44,7 @@ export const useDeleteHelper = (
   const { data } = useCan({
     resource: _resource?.name,
     action: "delete",
-    params: { id: recordItemId ?? id, resource: _resource },
+    params: { id: recordItemId ?? id, resource: _resource, meta: pickNotDeprecated(meta) },
     queryOptions: {
       enabled: accessControlEnabled,
     },

--- a/src/components/theme/providers/deleteProvider.tsx
+++ b/src/components/theme/providers/deleteProvider.tsx
@@ -27,6 +27,7 @@ export function DeleteActionModal(props: DeleteContextType) {
   const { can, isLoading, mutate } = useDeleteHelper(
     props.data?.resource,
     props.data?.row?.metadata.name,
+    props.data?.row?.metadata
   );
 
   const { t } = useTranslation();

--- a/src/components/theme/table/actions/delete.tsx
+++ b/src/components/theme/table/actions/delete.tsx
@@ -19,7 +19,8 @@ export function DeleteAction({
   onAfterHandle,
   ...props
 }: DeleteActionProps) {
-  const { can, reason } = useDeleteHelper(resource, row.id);
+  const meta = row.metadata;
+  const { can, reason } = useDeleteHelper(resource, row.id, meta);
   const deleteContext = useContext(DeleteContext);
 
   return (

--- a/src/components/theme/table/actions/edit.tsx
+++ b/src/components/theme/table/actions/edit.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from "@refinedev/core";
 import type { RowActionProps } from ".";
 import { RowAction } from ".";
 import { useGetEditUrl } from "@/components/theme/hooks";
@@ -15,14 +16,17 @@ export function EditAction({
   disabled,
   ...props
 }: EditActionProps) {
-  const edit = useGetEditUrl(resource, row.metadata.name);
+  const edit = useGetEditUrl(resource, row.metadata.name, row.metadata.workspace);
+  const navigation = useNavigation();
+  const editUrl = navigation.editUrl(resource, row.id, row.metadata);
+
 
   return (
     <RowAction
       {...props}
       disabled={!edit.can || disabled}
       title={!edit?.can ? edit?.reason : title}
-      to={edit.url}
+      to={editUrl}
     />
   );
 }


### PR DESCRIPTION
This PR fixes two related issues around missing metadata.workspace during resource operations:

### Bug 1: Delete fails when triggered from `all workspace` views

Fix:
	•	Ensure meta is passed to useDeleteHelper in <DeleteAction />
	•	Update DeleteContext.updateData(...) to persist meta
	•	Pass meta into the final mutate() call during confirmation

---

### Bug 2: Edit page fails to load due to missing metadata

Fix:
	•	Ensure meta is passed into navigation.editUrl() from <EditAction />