### PR TITLE
fix: update edit URL generation in EditAction component

### DIFF
--- a/src/components/theme/table/actions/edit.tsx
+++ b/src/components/theme/table/actions/edit.tsx
@@ -18,7 +18,7 @@ export function EditAction({
 }: EditActionProps) {
   const edit = useGetEditUrl(resource, row.metadata.name, row.metadata.workspace);
   const navigation = useNavigation();
-  const editUrl = navigation.editUrl(resource, row.id, row.metadata);
+  const editUrl = navigation.editUrl(resource, row.metadata.name, row.metadata);
 
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3755,7 +3755,7 @@ util-deprecate@^1.0.2:
 
 uuid@^11.1.0:
   version "11.1.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 vfile-message@^4.0.0:


### PR DESCRIPTION
Following up PR#52, change `EditAction` to use name id instead of numerical id for resource navigation. Now user can open and edit a resource under any space scope.