### PR TITLE
refactor: improve logo handling and loading state in ThemedTitle component

### DIFF
--- a/src/auth-provider/LoginPage.tsx
+++ b/src/auth-provider/LoginPage.tsx
@@ -69,7 +69,6 @@ export const LoginPage: React.FC<LoginPageProps> = ({
   const PageTitle =
     title === false ? null : (
       <div className="flex flex-col items-center">
-        <img alt="logo" src="/logo.png" className="w-20 h-20" />
         <div className="flex justify-center mb-8 text-xl">
           {title ?? <ThemedTitle collapsed={false} />}
         </div>

--- a/src/auth-provider/ThemedTitle.tsx
+++ b/src/auth-provider/ThemedTitle.tsx
@@ -12,15 +12,13 @@ export const ThemedTitle: React.FC<ThemedTitleProps> = ({
   text,
   icon,
 }) => {
-  const { brandName, isLoading } = useOemConfig();
-  let displayText = text || brandName;
-  if (isLoading) {
-    displayText = "...";
-  }
+  const { brandName, logoBase64, isLoading } = useOemConfig();
+  const displayText = isLoading ? "..." : text || brandName;
+  const displayIcon = icon ?? (<img alt="logo" src={(logoBase64 || "/logo.png")} className="w-[64px] h-[64px]" />);
 
   return (
-    <div className="flex items-center gap-2">
-      {icon && <div className="flex items-center justify-center">{icon}</div>}
+    <div className="flex flex-col items-center gap-2">
+      {displayIcon && (<div className="flex items-center justify-center">{displayIcon}</div>)}
       {!collapsed && <div className="font-bold text-xl">{displayText}</div>}
     </div>
   );


### PR DESCRIPTION
Use the OEM logo (if provided) on the login, signup, forget password, reset password page, instead of using the default Neutree logo all the time.