### PR TITLE
improve: add i18n support

### DIFF
--- a/src/components/business/ImageRegistryStatus.tsx
+++ b/src/components/business/ImageRegistryStatus.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from "@/lib/i18n";
 import type { ImageRegistry } from "@/types";
 
 export default function ImageRegistryStatus({
   phase,
 }: Partial<Pick<Exclude<ImageRegistry["status"], null>, "phase">>) {
+  const { t } = useTranslation();
   if (!phase) {
     return "-";
   }
@@ -13,11 +15,14 @@ export default function ImageRegistryStatus({
     Pending: "bg-yellow-100 text-yellow-800",
     Deleted: "bg-gray-100 text-gray-800",
   }[phase];
+
+  const translatedPhase = t(`status.phases.registry.${phase}`);
+
   return (
     <span
       className={`px-2 py-1 text-xs font-semibold rounded-lg ${classMapping}`}
     >
-      {phase}
+      {translatedPhase}
     </span>
   );
 }

--- a/src/components/business/ModelCatalogStatus.tsx
+++ b/src/components/business/ModelCatalogStatus.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "@/lib/i18n";
 import type { ModelCatalogPhase } from "@/types";
 
 interface ModelCatalogStatusProps {
@@ -5,6 +6,7 @@ interface ModelCatalogStatusProps {
 }
 
 const ModelCatalogStatus = ({ phase }: ModelCatalogStatusProps) => {
+  const { t } = useTranslation();
   if (!phase) {
     return "-";
   }
@@ -16,11 +18,13 @@ const ModelCatalogStatus = ({ phase }: ModelCatalogStatusProps) => {
     Deleted: "bg-gray-100 text-gray-800",
   }[phase];
 
+  const translatedPhase = t(`status.phases.catalog.${phase}`);
+
   return (
     <span
       className={`px-2 py-1 text-xs font-semibold rounded-lg ${classMapping}`}
     >
-      {phase}
+      {translatedPhase}
     </span>
   );
 };

--- a/src/components/business/ModelRegistryStatus.tsx
+++ b/src/components/business/ModelRegistryStatus.tsx
@@ -1,8 +1,10 @@
+import { useTranslation } from "@/lib/i18n";
 import type { ModelRegistry } from "@/types";
 
 export default function ModelRegistryStatus({
   phase,
 }: Partial<Pick<Exclude<ModelRegistry["status"], null>, "phase">>) {
+  const { t } = useTranslation();
   if (!phase) {
     return "-";
   }
@@ -13,11 +15,14 @@ export default function ModelRegistryStatus({
     Pending: "bg-yellow-100 text-yellow-800",
     Deleted: "bg-gray-100 text-gray-800",
   }[phase];
+
+  const translatedPhase = t(`status.phases.registry.${phase}`);
+
   return (
     <span
       className={`px-2 py-1 text-xs font-semibold rounded-lg ${classMapping}`}
     >
-      {phase}
+      {translatedPhase}
     </span>
   );
 }

--- a/src/components/business/ModelTask.tsx
+++ b/src/components/business/ModelTask.tsx
@@ -1,22 +1,24 @@
 import { Badge } from "@/components/ui/badge";
+import { useTranslation } from "@/lib/i18n";
 
 interface ModelTaskProps {
   task: string | null | undefined;
   variant?: "default" | "outline" | "secondary" | "destructive";
 }
 
+// Format task name for better display
+export const formatTaskName = (taskName: string) => {
+  return taskName
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+};
+
 const ModelTask = ({ task, variant = "outline" }: ModelTaskProps) => {
+  const { t } = useTranslation();
   if (!task) {
     return <span className="text-muted-foreground">-</span>;
   }
-
-  // Format task name for better display
-  const formatTaskName = (taskName: string) => {
-    return taskName
-      .split("-")
-      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(" ");
-  };
 
   // Define color variants for different task types
   const getTaskColor = (taskName: string) => {
@@ -43,7 +45,12 @@ const ModelTask = ({ task, variant = "outline" }: ModelTaskProps) => {
       variant={variant}
       className={`${customClassName} text-xs font-medium`}
     >
-      {formatTaskName(task)}
+      {(() => {
+        const translated = t(`models.tasks.${task}`);
+        return translated === `models.tasks.${task}`
+          ? formatTaskName(task)
+          : translated;
+      })()}
     </Badge>
   );
 };

--- a/src/components/business/ModelTaskFilter.tsx
+++ b/src/components/business/ModelTaskFilter.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { useTranslation } from "@/lib/i18n";
 import type { CrudFilter, LogicalFilter } from "@refinedev/core";
 import { ChevronDown } from "lucide-react";
 import { useMemo } from "react";
@@ -17,29 +18,31 @@ interface ModelTaskFilterProps {
   setFilters: (filters: CrudFilter[], behavior?: "merge" | "replace") => void;
 }
 
-const MODEL_TASK_OPTIONS: TableListFilterOption[] = [
-  {
-    label: "All",
-    value: "all",
-  },
-  {
-    label: "Text Generation",
-    value: "text-generation",
-  },
-  {
-    label: "Text Embedding",
-    value: "text-embedding",
-  },
-  {
-    label: "Text Rerank",
-    value: "text-rerank",
-  },
-].map((o) => ({
-  ...o,
-  value: JSON.stringify(o.value),
-}));
-
 export function ModelTaskFilter({ filters, setFilters }: ModelTaskFilterProps) {
+  const { t } = useTranslation();
+
+  const MODEL_TASK_OPTIONS: TableListFilterOption[] = [
+    {
+      label: t("components.ui.filter.selectAll"),
+      value: "all",
+    },
+    {
+      label: t("models.tasks.text-generation"),
+      value: "text-generation",
+    },
+    {
+      label: t("models.tasks.text-embedding"),
+      value: "text-embedding",
+    },
+    {
+      label: t("models.tasks.text-rerank"),
+      value: "text-rerank",
+    },
+  ].map((o) => ({
+    ...o,
+    value: JSON.stringify(o.value),
+  }));
+
   // Find the current task filter
   const taskFilter = useMemo(() => {
     return filters.find(
@@ -95,7 +98,9 @@ export function ModelTaskFilter({ filters, setFilters }: ModelTaskFilterProps) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-[200px]" align="start">
-        <DropdownMenuLabel>Filter by Task</DropdownMenuLabel>
+        <DropdownMenuLabel>
+          {t("components.ui.filter.modelTask.title")}
+        </DropdownMenuLabel>
         <DropdownMenuSeparator />
         {MODEL_TASK_OPTIONS.map((option) => (
           <DropdownMenuItem

--- a/src/components/theme/components/combobox.tsx
+++ b/src/components/theme/components/combobox.tsx
@@ -26,6 +26,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { useTranslation } from "@/lib/i18n";
 import { cn } from "@/lib/utils";
 import type {
   BaseOption,
@@ -50,6 +51,7 @@ type ComboboxProps = ComponentPropsWithoutRef<typeof Command> &
 
 export const Combobox = forwardRef<ElementRef<typeof Command>, ComboboxProps>(
   ({ ...props }, ref) => {
+    const { t } = useTranslation();
     const [open, setOpen] = useState(false);
 
     const value = () => {
@@ -78,17 +80,25 @@ export const Combobox = forwardRef<ElementRef<typeof Command>, ComboboxProps>(
               {value()
                 ? props.options?.find((option) => option.value === value())
                     ?.label
-                : (props.placeholder ?? "Select")}
+                : (props.placeholder ?? t("components.ui.combobox.select"))}
               <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
             </Button>
           </FormControl>
         </PopoverTrigger>
         <PopoverContent className="w-[400px] max-w-full p-0">
           <Command className="rounded-lg border shadow-md" ref={ref}>
-            <CommandInput placeholder="Type a command or search..." />
+            <CommandInput
+              placeholder={t(
+                "components.ui.combobox.placeholders.SearchPlaceholder",
+              )}
+            />
             <CommandList>
-              <CommandEmpty>No results found.</CommandEmpty>
-              <CommandGroup heading="Suggestions">
+              <CommandEmpty>
+                {t("components.ui.combobox.messages.noResults")}
+              </CommandEmpty>
+              <CommandGroup
+                heading={t("components.ui.combobox.headings.suggestions")}
+              >
                 <ScrollArea className="max-h-52 overflow-y-auto">
                   {props.options?.map((option) => (
                     <CommandItem

--- a/src/components/theme/components/form.tsx
+++ b/src/components/theme/components/form.tsx
@@ -2,6 +2,7 @@ import type { SaveButtonProps } from "@/components/theme/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Form as FormUI } from "@/components/ui/form";
+import { useTranslation } from "@/lib/i18n";
 import {
   type BaseRecord,
   type HttpError,
@@ -78,6 +79,7 @@ export const Form = <
   const routerType = useRouterType();
   const back = useBack();
   const { goBack } = useNavigation();
+  const { t } = useTranslation();
 
   const onBack =
     action !== "list" || typeof action !== "undefined"
@@ -115,7 +117,7 @@ export const Form = <
                 disabled={props.refineCore.formLoading}
                 variant="outline"
               >
-                Cancel
+                {t("buttons.cancel")}
               </Button>
             )}
 

--- a/src/components/theme/components/modeToggle.tsx
+++ b/src/components/theme/components/modeToggle.tsx
@@ -5,11 +5,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { MoonIcon, SunIcon } from "@radix-ui/react-icons";
+import { Half2Icon, MoonIcon, SunIcon } from "@radix-ui/react-icons";
 import { useTheme } from "next-themes";
+import { useTranslation } from "react-i18next";
 
 export const ModeToggle = () => {
   const { setTheme } = useTheme();
+  const { t } = useTranslation();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -21,13 +23,16 @@ export const ModeToggle = () => {
       </DropdownMenuTrigger>
       <DropdownMenuContent align={"end"}>
         <DropdownMenuItem onClick={() => setTheme("light")}>
-          Light
+          <SunIcon className="mr-2" />
+          {t("appearance.light")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("dark")}>
-          Dark
+          <MoonIcon className="mr-2" />
+          {t("appearance.dark")}
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("system")}>
-          System
+          <Half2Icon className="mr-2" />
+          {t("appearance.system")}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/src/components/theme/curds/show/index.tsx
+++ b/src/components/theme/curds/show/index.tsx
@@ -73,7 +73,7 @@ export const ShowPage: FC<ShowProps> & {
                   >
                     {canEdit && (
                       <EditAction
-                        title="Edit"
+                        title={translate("buttons.edit")}
                         row={record}
                         resource={resource?.name || ""}
                         icon={<Edit size={16} />}
@@ -83,7 +83,7 @@ export const ShowPage: FC<ShowProps> & {
                       <DeleteAction
                         row={record}
                         resource={resource?.name ?? ""}
-                        title="Delete"
+                        title={translate("buttons.delete")}
                         icon={<Trash2 size={16} />}
                       />
                     )}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -9,6 +9,18 @@
 		"dark": "Dark Mode",
 		"system": "Follow System"
 	},
+	"models": {
+		"scheduler": {
+			"powerOfTwo": "Power of two",
+			"consistentHashing": "Consistent hashing",
+			"unavailable": "Unavailable"
+		},
+		"tasks": {
+			"text-generation": "Text Generation",
+			"text-embedding": "Text Embedding",
+			"text-rerank": "Text Rerank"
+		}
+	},
 	"pages": {
 		"login": {
 			"title": "Sign in to your account",
@@ -402,9 +414,6 @@
 			"replica": "Replica",
 			"scheduler": "Scheduler",
 			"variables": "Variables"
-		},
-		"values": {
-			"powerOfTwo": "Power of two"
 		}
 	},
 	"image_registries": {
@@ -502,9 +511,7 @@
 			"selectSchedulerType": "Select Scheduler Type"
 		},
 		"options": {
-			"generic": "Generic",
-			"powerOfTwo": "Power of two",
-			"consistentHashing": "Consistent hashing"
+			"generic": "Generic"
 		},
 		"messages": {
 			"rayDashboardNotAvailable": "Ray dashboard is not available.",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -659,6 +659,12 @@
 				"title": "Sidebar",
 				"description": "Displays the mobile sidebar.",
 				"toggle": "Toggle Sidebar"
+			},
+			"filter": {
+				"selectAll": "All",
+				"modelTask": {
+					"title": "Filter by Task"
+				}
 			}
 		},
 		"yamlImport": {

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -4,6 +4,11 @@
 			"grafanaNotConfigured": "Grafana monitoring is not configured."
 		}
 	},
+	"appearance": {
+		"light": "Light Mode",
+		"dark": "Dark Mode",
+		"system": "Follow System"
+	},
 	"pages": {
 		"login": {
 			"title": "Sign in to your account",
@@ -870,6 +875,12 @@
 			"cluster": {
 				"Pending": "Pending",
 				"Running": "Running",
+				"Failed": "Failed",
+				"Deleted": "Deleted"
+			},
+			"registry": {
+				"Pending": "Pending",
+				"Connected": "Connected",
 				"Failed": "Failed",
 				"Deleted": "Deleted"
 			},

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -650,7 +650,16 @@
 	"components": {
 		"ui": {
 			"combobox": {
-				"select": "Select"
+				"select": "Select",
+				"placeholders": {
+					"SearchPlaceholder": "Type a command or search..."
+				},
+				"messages": {
+					"noResults": "No results found"
+				},
+				"headings": {
+					"suggestions": "Suggestions"
+				}
 			},
 			"dialog": {
 				"close": "Close"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -884,6 +884,12 @@
 				"Failed": "Failed",
 				"Deleted": "Deleted"
 			},
+			"catalog": {
+				"Pending": "Pending",
+				"Ready": "Ready",
+				"Failed": "Failed",
+				"Deleted": "Deleted"
+			},
 			"endpoint": {
 				"Pending": "Pending",
 				"Running": "Running",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -4,6 +4,11 @@
 			"grafanaNotConfigured": "Grafana 监控未配置。"
 		}
 	},
+	"appearance": {
+		"light": "浅色模式",
+		"dark": "深色模式",
+		"system": "跟随系统"
+	},
 	"pages": {
 		"login": {
 			"title": "登录您的账户",
@@ -870,6 +875,12 @@
 			"cluster": {
 				"Pending": "等待中",
 				"Running": "运行中",
+				"Failed": "失败",
+				"Deleted": "已删除"
+			},
+			"registry": {
+				"Pending": "等待中",
+				"Connected": "已连接",
 				"Failed": "失败",
 				"Deleted": "已删除"
 			},

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -650,7 +650,16 @@
 	"components": {
 		"ui": {
 			"combobox": {
-				"select": "选择"
+				"select": "选择",
+				"placeholders": {
+					"SearchPlaceholder": "输入命令或搜索..."
+				},
+				"messages": {
+					"noResults": "未找到结果"
+				},
+				"headings": {
+					"suggestions": "建议"
+				}
 			},
 			"dialog": {
 				"close": "关闭"

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -9,6 +9,18 @@
 		"dark": "深色模式",
 		"system": "跟随系统"
 	},
+	"models": {
+		"scheduler": {
+			"powerOfTwo": "二的幂",
+			"consistentHashing": "一致性哈希",
+			"unavailable": "不可用"
+		},
+		"tasks": {
+			"text-generation": "文本生成",
+			"text-embedding": "文本嵌入",
+			"text-rerank": "文本重排序"
+		}
+	},
 	"pages": {
 		"login": {
 			"title": "登录您的账户",
@@ -402,9 +414,6 @@
 			"replica": "副本",
 			"scheduler": "调度器",
 			"variables": "变量"
-		},
-		"values": {
-			"powerOfTwo": "二的幂"
 		}
 	},
 	"image_registries": {
@@ -502,9 +511,7 @@
 			"selectSchedulerType": "选择调度器类型"
 		},
 		"options": {
-			"generic": "通用",
-			"powerOfTwo": "二的幂",
-			"consistentHashing": "一致性哈希"
+			"generic": "通用"
 		},
 		"messages": {
 			"rayDashboardNotAvailable": "Ray 仪表板不可用。",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -884,6 +884,12 @@
 				"Failed": "失败",
 				"Deleted": "已删除"
 			},
+			"catalog": {
+				"Pending": "等待中",
+				"Ready": "已就绪",
+				"Failed": "失败",
+				"Deleted": "已删除"
+			},
 			"endpoint": {
 				"Pending": "等待中",
 				"Running": "运行中",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -659,6 +659,12 @@
 				"title": "侧边栏",
 				"description": "显示移动端侧边栏。",
 				"toggle": "切换侧边栏"
+			},
+			"filter": {
+				"selectAll": "全部",
+				"modelTask": {
+					"title": "按任务类型筛选"
+				}
 			}
 		},
 		"yamlImport": {

--- a/src/pages/endpoints/show.tsx
+++ b/src/pages/endpoints/show.tsx
@@ -298,7 +298,7 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
                 </ShowPage.Row>
                 <ShowPage.Row title={t("endpoints.fields.scheduler")}>
                   {t(
-                    `endpoints.options.${record.spec.deployment_options?.scheduler.type === "consistent_hash" ? "consistentHashing" : "powerOfTwo"}`,
+                    `models.scheduler.${record.spec.deployment_options?.scheduler.type === "consistent_hash" ? "consistentHashing" : "powerOfTwo"}`,
                   )}
                 </ShowPage.Row>
               </div>

--- a/src/pages/endpoints/show.tsx
+++ b/src/pages/endpoints/show.tsx
@@ -297,8 +297,9 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
                   {record.spec.replicas?.num ?? 1}
                 </ShowPage.Row>
                 <ShowPage.Row title={t("endpoints.fields.scheduler")}>
-                  {record.spec.deployment_options?.scheduler.type ??
-                    t("model_catalogs.values.powerOfTwo")}
+                  {t(
+                    `endpoints.options.${record.spec.deployment_options?.scheduler.type === "consistent_hash" ? "consistentHashing" : "powerOfTwo"}`,
+                  )}
                 </ShowPage.Row>
               </div>
             </CardContent>

--- a/src/pages/endpoints/use-endpoint-form.tsx
+++ b/src/pages/endpoints/use-endpoint-form.tsx
@@ -1,4 +1,5 @@
 import FormCardGrid from "@/components/business/FormCardGrid";
+import { formatTaskName } from "@/components/business/ModelTask";
 import VariablesInput, {
   type Schema,
 } from "@/components/business/VariablesInput";
@@ -975,7 +976,10 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                 options={(
                   engineTasks[form.getValues().spec.engine.engine] || []
                 ).map((v) => ({
-                  label: v,
+                  label:
+                    t(`models.tasks.${v}`) === `models.tasks.${v}`
+                      ? formatTaskName(v)
+                      : t(`models.tasks.${v}`),
                   value: v,
                 }))}
               />
@@ -999,9 +1003,9 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
               <Combobox
                 placeholder={t("endpoints.placeholders.selectSchedulerType")}
                 options={[
-                  { label: t("endpoints.options.powerOfTwo"), value: "pow2" },
+                  { label: t("models.scheduler.powerOfTwo"), value: "pow2" },
                   {
-                    label: t("endpoints.options.consistentHashing"),
+                    label: t("models.scheduler.consistentHashing"),
                     value: "consistent_hash",
                   },
                 ]}

--- a/src/pages/model-catalogs/show.tsx
+++ b/src/pages/model-catalogs/show.tsx
@@ -131,8 +131,14 @@ export const ModelCatalogsShow = () => {
                 typeof record.spec.deployment_options.scheduler === "object" &&
                 record.spec.deployment_options.scheduler &&
                 "type" in record.spec.deployment_options.scheduler
-                  ? String(record.spec.deployment_options.scheduler.type)
-                  : t("model_catalogs.values.powerOfTwo")}
+                  ? record.spec.deployment_options.scheduler.type ===
+                    "consistent_hash"
+                    ? t("models.scheduler.consistentHashing")
+                    : record.spec.deployment_options.scheduler.type ===
+                        "powerOfTwo"
+                      ? t("models.scheduler.powerOfTwo")
+                      : String(record.spec.deployment_options.scheduler.type)
+                  : t("models.scheduler.unavailable")}
               </ShowPage.Row>
             </div>
           </CardContent>


### PR DESCRIPTION
## Changes
- Registry Status: Added translation support for registry status phases
- Model Catalog Status: Added translation support for model catalog status phases
- Model Tasks: Added translation support for model tasks, use title case if task name isn't found in localization configs
- Appearance Selection: Added i18n support for theme selection UI
- Endpoint Scheduler Type: Added translation support for scheduler type options
- Form cancelation button: Added translation support 
- Table Filter Popup: Added translation support 
- Combo Box: Added translation support 
