### PR TITLE
feat: user creation by admin 

### DIFF
--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -123,22 +123,25 @@ export const dataProvider = (
 
     create: async ({ resource, variables, meta }) => {
       if (resource === "user_profiles") {
-        const { data, error } = await auth.signUp({
+        const userData = {
           email: (variables as { email: string }).email,
           password: (variables as { password: string }).password,
-          options: {
-            data: {
-              username: (variables as { name: string }).name,
-            },
+          username: (variables as { name: string }).name,
+        };
+
+        const userToken = "";
+
+        const response = await fetch("/api/v1/admin/users", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${userToken}`,
           },
+          body: JSON.stringify(userData),
         });
 
-        if (error) {
-          return handleError(error);
-        }
-
         return {
-          data: data.user,
+          data: await response.json(),
         };
       }
 

--- a/src/data-provider/index.ts
+++ b/src/data-provider/index.ts
@@ -129,7 +129,10 @@ export const dataProvider = (
           username: (variables as { name: string }).name,
         };
 
-        const userToken = "";
+        const {
+          data: { session },
+        } = await auth.getSession();
+        const userToken = session?.access_token || "";
 
         const response = await fetch("/api/v1/admin/users", {
           method: "POST",


### PR DESCRIPTION
# Add Support for Admin User Creation via Dedicated API Endpoint

This PR adds support for admin user creation through a new dedicated API endpoint (`/api/v1/admin/users`), enabling administrators to create user accounts.

## Changes Made

### Data Provider Updates
- **Enhanced `index.ts`**:
  - Added special handling for `user_profiles` resource creation
  - Integrated with new `/api/v1/admin/users` endpoint
  - Implemented proper authentication token retrieval using `auth.getSession()`
  - Added field mapping from form data to API payload:
    - `name` → `username`
    - `email` → `email`
    - `password` → `password`

## Dependencies
> ⚠️ **Important**: This PR needs to be merged together with `neutree-ai/neutree#111` which exposes the new `/api/v1/admin/users` API endpoint.