### PR TITLE
fix: update model mapping when switching endpoint ref (NEU-402)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -247,7 +247,7 @@
   "src/pages/external-endpoints/list.tsx": "1b58592b9a94b4853e701d9358b4394e",
   "src/pages/external-endpoints/show.tsx": "e054f192830c0a86929efd11a260f6ae",
   "src/domains/external-endpoint/types.ts": "919dea3f18a6795e2dde24e4a460a89e",
-  "src/domains/external-endpoint/hooks/use-external-endpoint-form.tsx": "2e4ae23b9b16b2dc25293eb3e481f0e6",
+  "src/domains/external-endpoint/hooks/use-external-endpoint-form.tsx": "62844d476c4b1eb1d601245fce39c4a1",
   "src/domains/external-endpoint/components/CurlExample.tsx": "5183a8958c58627f671b3d80313f016f",
   "src/domains/external-endpoint/components/ExternalEndpointStatus.tsx": "1c1e5325079d9c25ac1f5f14fa47383f",
   "src/domains/external-endpoint/components/ModelMappingEditor.tsx": "3333d4bdef28d7096e3554911c4ab652",

--- a/src/domains/external-endpoint/hooks/use-external-endpoint-form.test.tsx
+++ b/src/domains/external-endpoint/hooks/use-external-endpoint-form.test.tsx
@@ -92,6 +92,22 @@ vi.mock("@/domains/external-endpoint/components/TimeoutInput", () => ({
   ),
 }));
 
+vi.mock("@/foundation/components/FormCombobox", () => ({
+  FormCombobox: ({
+    onChange,
+    placeholder,
+  }: {
+    onChange?: (v: string) => void;
+    placeholder?: string;
+  }) => (
+    <input
+      data-testid="form-combobox-mock"
+      placeholder={placeholder}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  ),
+}));
+
 import { useExternalEndpointForm } from "./use-external-endpoint-form";
 
 function CreateForm() {
@@ -241,6 +257,46 @@ describe("useExternalEndpointForm", () => {
           "external_endpoints.placeholders.upstreamModelName",
         );
         expect((mappingInputs[0] as HTMLInputElement).value).toBe("");
+      });
+    });
+
+    it("updates model mapping when switching endpoint ref", async () => {
+      render(<CreateForm />);
+
+      // Switch to endpoint_ref type
+      const typeSelect = screen.getByTestId("form-select-mock");
+      fireEvent.change(typeSelect, { target: { value: "endpoint_ref" } });
+
+      // First endpoint ref returns models ["model-a", "model-b"]
+      mockConnectivityTest.mockResolvedValueOnce({
+        success: true,
+        models: ["model-a", "model-b"],
+      });
+
+      const combobox = await screen.findByTestId("form-combobox-mock");
+      fireEvent.change(combobox, { target: { value: "endpoint-1" } });
+
+      await waitFor(() => {
+        const inputs = screen.getAllByPlaceholderText(
+          "external_endpoints.placeholders.upstreamModelName",
+        );
+        expect((inputs[0] as HTMLInputElement).value).toBe("model-a");
+      });
+
+      // Switch to a different endpoint ref returning ["model-x"]
+      mockConnectivityTest.mockResolvedValueOnce({
+        success: true,
+        models: ["model-x"],
+      });
+
+      fireEvent.change(combobox, { target: { value: "endpoint-2" } });
+
+      await waitFor(() => {
+        const inputs = screen.getAllByPlaceholderText(
+          "external_endpoints.placeholders.upstreamModelName",
+        );
+        expect(inputs).toHaveLength(1);
+        expect((inputs[0] as HTMLInputElement).value).toBe("model-x");
       });
     });
 

--- a/src/domains/external-endpoint/hooks/use-external-endpoint-form.tsx
+++ b/src/domains/external-endpoint/hooks/use-external-endpoint-form.tsx
@@ -96,17 +96,12 @@ export const useExternalEndpointForm = ({
           ...prev,
           [index]: data.models!,
         }));
-        // Auto-fill model mapping if currently empty
-        const currentMapping = form.getValues(
-          `spec.upstreams.${index}.model_mapping`,
-        );
-        if (!currentMapping || Object.keys(currentMapping).length === 0) {
-          const mapping: Record<string, string> = {};
-          for (const model of data.models!) {
-            mapping[model] = model;
-          }
-          form.setValue(`spec.upstreams.${index}.model_mapping`, mapping);
+        // Auto-fill model mapping from the selected endpoint ref's models
+        const mapping: Record<string, string> = {};
+        for (const model of data.models!) {
+          mapping[model] = model;
         }
+        form.setValue(`spec.upstreams.${index}.model_mapping`, mapping);
       }
     },
     [connectivity, currentWorkspace, form],


### PR DESCRIPTION
## Summary
- When switching endpoint ref in the External Endpoint form, model mapping now updates to reflect the new endpoint's models instead of keeping the stale mapping from the previous ref
- Root cause: `handleEndpointRefChange` only auto-filled mapping when it was empty — now it always replaces with the new models
- Added test covering consecutive endpoint ref switches

## Test plan
- [x] Create an external endpoint with endpoint_ref type, select an endpoint → model mapping auto-fills
- [x] Switch to a different endpoint ref → model mapping updates to the new endpoint's models
- [x] Unit tests pass (`yarn test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)