### PR TITLE
fix: use default workspace in Quick Start when no workspace selected

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -284,7 +284,7 @@
   "src/domains/endpoint/components/PlaygroundLayout.tsx": "c4940cfc57dc4696b166ac65f5c769cb",
   "src/domains/cluster/components/ClusterUpgradeTip.tsx": "fd41e3d18ecd41c1efda9dc1d06da083",
   "src/pages/dashboard/QuickStartDialog.tsx": "141e2fd4d5a7b6d78d906ca7aa0703eb",
-  "src/foundation/hooks/use-quick-start.ts": "0d41b868c2357acbec6ba98230a0a3b4",
+  "src/foundation/hooks/use-quick-start.ts": "04189be863e68f0769b650db5a60b985",
   "src/foundation/components/ResourceResultList.tsx": "5b87054f8939e64a98ac67e886b68c64",
   "src/foundation/hooks/use-refine-field-array.ts": "8e3ff4422156f31e4dd5928bff116427",
   "src/domains/external-endpoint/components/TestConnectivityButton.tsx": "c4c97cc62ad41f004d08238c569e0054",

--- a/src/foundation/hooks/use-quick-start.test.ts
+++ b/src/foundation/hooks/use-quick-start.test.ts
@@ -29,8 +29,11 @@ vi.mock("@refinedev/core", () => ({
   }),
 }));
 
+let mockCurrentWorkspace: string = "test-ws";
+
 vi.mock("./use-workspace", () => ({
-  useWorkspace: () => ({ current: "test-ws" }),
+  ALL_WORKSPACES: "_all_",
+  useWorkspace: () => ({ current: mockCurrentWorkspace }),
 }));
 
 // --- Helpers ---
@@ -52,6 +55,7 @@ async function quickStartHook() {
 beforeEach(() => {
   vi.clearAllMocks();
   mockEnginesData = defaultEnginesData;
+  mockCurrentWorkspace = "test-ws";
   mockGetOne.mockRejectedValue(new Error("not found"));
   mockMutateAsync.mockResolvedValue({ data: {} });
 });
@@ -124,6 +128,18 @@ describe("useQuickStart", () => {
           workspace: "test-ws",
           workspaced: true,
         });
+      }
+    });
+
+    it("falls back to 'default' workspace when current is the _all_ sentinel", async () => {
+      mockCurrentWorkspace = "_all_";
+      const { result } = await quickStartHook();
+
+      await act(() => result.current.execute(TEST_INPUT));
+
+      for (const call of mockMutateAsync.mock.calls) {
+        expect(call[0].meta.workspace).toBe("default");
+        expect(call[0].values.metadata.workspace).toBe("default");
       }
     });
 

--- a/src/foundation/hooks/use-quick-start.ts
+++ b/src/foundation/hooks/use-quick-start.ts
@@ -1,6 +1,6 @@
 import { useCreate, useDataProvider, useSelect } from "@refinedev/core";
 import { useCallback, useMemo, useState } from "react";
-import { useWorkspace } from "@/foundation/hooks/use-workspace";
+import { ALL_WORKSPACES, useWorkspace } from "@/foundation/hooks/use-workspace";
 import type { Metadata } from "@/foundation/types/basic-types";
 
 /** Inline type to avoid L1→L2 dependency on endpoint types */
@@ -139,11 +139,19 @@ export function useQuickStart() {
   const { mutateAsync: createResource } = useCreate();
   const dataProvider = useDataProvider();
 
+  // `currentWorkspace` may be the `_all_` sentinel when no workspace is
+  // selected (fresh session with empty localStorage). That value is invalid
+  // as a real `metadata.workspace`, so fall back to "default".
+  const workspace =
+    currentWorkspace && currentWorkspace !== ALL_WORKSPACES
+      ? currentWorkspace
+      : "default";
+
   const engines = useSelect<EngineRef>({
     resource: "engines",
     meta: {
       idColumnName: "metadata->name",
-      workspace: currentWorkspace,
+      workspace,
       workspaced: true,
     },
   });
@@ -171,7 +179,7 @@ export function useQuickStart() {
           id: resourceName,
           meta: {
             idColumnName: "metadata->name",
-            workspace: currentWorkspace,
+            workspace,
             workspaced: true,
           },
         });
@@ -180,7 +188,7 @@ export function useQuickStart() {
         return false;
       }
     },
-    [dataProvider, currentWorkspace],
+    [dataProvider, workspace],
   );
 
   const execute = useCallback(
@@ -188,7 +196,6 @@ export function useQuickStart() {
       const steps = INITIAL_STEPS.map((s) => ({ ...s }));
       setState({ phase: "creating", steps });
 
-      const workspace = currentWorkspace || "default";
       const createMeta = {
         idColumnName: "metadata->name",
         workspace,
@@ -239,7 +246,7 @@ export function useQuickStart() {
 
       setState({ phase: "done", steps: [...steps] });
     },
-    [currentWorkspace, llamaCppVersion, checkResourceExists, createResource],
+    [workspace, llamaCppVersion, checkResourceExists, createResource],
   );
 
   const reset = useCallback(() => {


### PR DESCRIPTION
## Summary
- When a user opens the Quick Start dialog with no workspace selected (fresh session / empty localStorage — the default state in E2E runs), `useWorkspace().current` resolves to the `_all_` sentinel. That value was being passed straight through as `metadata.workspace`, and the backend rejects it: `Invalid metadata.workspace format: Workspace must consist of lowercase alphanumeric characters, '-' or '.'`. Manual usage didn't hit this because returning users always have a real workspace name persisted in localStorage from prior navigation.
- Normalize `ALL_WORKSPACES` to `default` once at the top of `useQuickStart`, and use that value everywhere — create payloads, the create `meta`, and the pre-flight `checkResourceExists` (which would otherwise silently filter against `_all_`).
- Added a regression test covering the `_all_` → `default` fallback.

## Test plan
- [x] `npx vitest run src/foundation/hooks/use-quick-start.test.ts` (15 passed)
- [x] `tsc -b` clean
- [x] Re-run the Quick Start E2E flow on a fresh browser context

🤖 Generated with [Claude Code](https://claude.com/claude-code)