### PR TITLE
fix: wrap long metadata names within column (NEU-319)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -140,7 +140,7 @@
   "src/foundation/components/ResourceForm.tsx": "c99578dfa73fb2d2a84bc45508329f20",
   "src/foundation/components/SaveButton.tsx": "ea4fd9a4181a12263bd5d48d8b1657d0",
   "src/foundation/components/ShowButton.tsx": "7ed3be7d36dbb8cf474279167ee047fc",
-  "src/foundation/components/ShowPage.tsx": "49a7d877ee60f0c61b3cc519fbb36956",
+  "src/foundation/components/ShowPage.tsx": "c0a2aa72aa853e1e8adcce1eedfc7aa7",
   "src/foundation/components/Table.tsx": "cf11ff21e637ff9ba20c5a37d82dd432",
   "src/foundation/components/TableSearch.tsx": "9db3e9145e21e1b61edda8484449ba35",
   "src/foundation/components/Timestamp.tsx": "dfe8682fb2f86e073f8e4c2e6903fbda",

--- a/src/foundation/components/ShowPage.tsx
+++ b/src/foundation/components/ShowPage.tsx
@@ -24,8 +24,8 @@ const Row = ({
 >) => {
   return (
     <>
-      <dl className="flex flex-wrap">
-        <div className="flex-auto pt-4">
+      <dl className="flex flex-wrap min-w-0">
+        <div className="flex-auto min-w-0 pt-4">
           <dt className="scroll-m-20 text-xs font-semibold tracking-tight">
             {title}
           </dt>


### PR DESCRIPTION
## Summary
- Long names like `aa-aaaa…aaa` overflowed the Name column on Show pages because the `<dl>` grid item lacked `min-w-0`, preventing `break-all` from shrinking the column
- Add `min-w-0` to `ShowPage.Row`'s `<dl>` and inner flex container so values wrap within their column

[NEU-319](http://jira.smartx.com/browse/NEU-319)

## Test plan
- [x] Open a resource Show page whose name contains a long unbroken token (e.g. `aa-aaaa…aaaa`)
- [x] Verify the name wraps inside the Name column and does not overlap the Workspace column
- [x] Spot-check other Show pages (endpoints, models, workspaces, users) for layout regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)