### PR TITLE
feat(model-usage): model usage analytics page

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -1,6 +1,6 @@
 {
   "vite.config.ts": "a2ebabd7035347e83eb48536602b2fe1",
-  "src/App.tsx": "b5ee1edc2d905ed33e7c53a556a09633",
+  "src/App.tsx": "487a8ca2dbe83b128fd03a10ab0c6ee5",
   "src/Root.tsx": "0bf1b5abed7cbc71c06832cc2de84f12",
   "src/index.tsx": "6eaed6f7788c9ba4ace41044c3cbc5a8",
   "src/pages/workspaces/create.tsx": "eda0d8545f33f74948967657ec231e35",
@@ -223,7 +223,7 @@
   "src/domains/cluster/components/ResourceProgressBar.tsx": "7d668caa651a0706b87651e40e89376f",
   "src/foundation/lib/clipboard.ts": "8ea6c6599de974dae258857f23378ae1",
   "src/foundation/hooks/use-copy-to-clipboard.ts": "c558065e2373c1264eb2faaf38fd2599",
-  "src/domains/api-key/hooks/use-api-key-usage.ts": "1bd6b3a589bf6fd2fb424af96597f423",
+  "src/domains/api-key/hooks/use-api-key-usage.ts": "3ee3d120e18fba0750ec22abc95089b6",
   "src/domains/api-key/components/CreateApiKeyForm.tsx": "21a8ea68d1d4b7552e5a95ac6a566c48",
   "src/domains/workspace/hooks/use-workspace-form.tsx": "74547a707ee26107480b3ec40820384b",
   "src/domains/user/hooks/use-user-form.tsx": "324a66384c19d18de4597bb39c2e4317",
@@ -295,5 +295,8 @@
   "src/pages/ai-traces/components/TraceStatsChart.tsx": "72d803582532b53b21c0bce895d0142f",
   "src/foundation/lib/api/ai-traces.ts": "d989ddca41c00c96b1803f69be83c0fc",
   "src/foundation/components/DateRangePicker.tsx": "7db897cba5bece0433e75fcd91d305b1",
+  "src/pages/model-usage/list.tsx": "380da2628599fd0bb3cc656b632a479c",
+  "src/domains/api-key/hooks/use-usage-by-dimension.ts": "180fbbc1c2b848f8b9d4172c85835344",
+  "src/domains/api-key/hooks/use-workspace-usage.ts": "b6d1bc5f44a709f8d0bd703f67c2937b",
   "src/components/ui/calendar.tsx": "67b3c096201e6f030437e9127db7c586"
 }

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -223,7 +223,7 @@
   "src/domains/cluster/components/ResourceProgressBar.tsx": "7d668caa651a0706b87651e40e89376f",
   "src/foundation/lib/clipboard.ts": "8ea6c6599de974dae258857f23378ae1",
   "src/foundation/hooks/use-copy-to-clipboard.ts": "c558065e2373c1264eb2faaf38fd2599",
-  "src/domains/api-key/hooks/use-api-key-usage.ts": "3ee3d120e18fba0750ec22abc95089b6",
+  "src/domains/api-key/hooks/use-api-key-usage.ts": "c7cc1f9ca1389e67a1b00b4bb7fbbac5",
   "src/domains/api-key/components/CreateApiKeyForm.tsx": "21a8ea68d1d4b7552e5a95ac6a566c48",
   "src/domains/workspace/hooks/use-workspace-form.tsx": "74547a707ee26107480b3ec40820384b",
   "src/domains/user/hooks/use-user-form.tsx": "324a66384c19d18de4597bb39c2e4317",
@@ -295,7 +295,7 @@
   "src/pages/ai-traces/components/TraceStatsChart.tsx": "72d803582532b53b21c0bce895d0142f",
   "src/foundation/lib/api/ai-traces.ts": "d989ddca41c00c96b1803f69be83c0fc",
   "src/foundation/components/DateRangePicker.tsx": "7db897cba5bece0433e75fcd91d305b1",
-  "src/pages/model-usage/list.tsx": "380da2628599fd0bb3cc656b632a479c",
+  "src/pages/model-usage/list.tsx": "bd680f4817e9b80433c50e2b185affbd",
   "src/domains/api-key/hooks/use-usage-by-dimension.ts": "180fbbc1c2b848f8b9d4172c85835344",
   "src/domains/api-key/hooks/use-workspace-usage.ts": "b6d1bc5f44a709f8d0bd703f67c2937b",
   "src/components/ui/calendar.tsx": "67b3c096201e6f030437e9127db7c586"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import "./variables.css";
 
 import {
   Activity,
+  BarChart3,
   BookOpen,
   Cpu,
   Database,
@@ -58,6 +59,11 @@ const AITracesList = lazy(() =>
 
 const ApiKeysList = lazy(() =>
   import("./pages/api-keys/list").then((m) => ({ default: m.ApiKeysList })),
+);
+const ModelUsageList = lazy(() =>
+  import("./pages/model-usage/list").then((m) => ({
+    default: m.ModelUsageList,
+  })),
 );
 const ApiKeysShow = lazy(() =>
   import("./pages/api-keys/show").then((m) => ({ default: m.ApiKeysShow })),
@@ -424,6 +430,14 @@ const resources: ResourceProps[] = [
     },
   },
   {
+    name: "model_usage",
+    list: "/:workspace/model-usage",
+    meta: {
+      icon: <BarChart3 />,
+      workspaced: true,
+    },
+  },
+  {
     name: "settings",
   },
   // {
@@ -619,6 +633,9 @@ function App({ i18nProvider }: { i18nProvider: I18nProvider }) {
                 </Route>
                 <Route path="/:workspace/ai-traces">
                   <Route index element={<AITracesList />} />
+                </Route>
+                <Route path="/:workspace/model-usage">
+                  <Route index element={<ModelUsageList />} />
                 </Route>
                 <Route path="/oem-configs">
                   <Route index element={<OemConfigShow />} />

--- a/src/domains/api-key/hooks/use-api-key-usage.ts
+++ b/src/domains/api-key/hooks/use-api-key-usage.ts
@@ -4,13 +4,17 @@ import { useUsageByDimension } from "./use-usage-by-dimension";
 export { POLL_INTERVAL_MS } from "./use-usage-by-dimension";
 
 // useApiKeyUsage returns one API key's per-day, per-dimension token usage.
+// The end bound is a fixed far-future date rather than "now": useUsageByDimension
+// requires a stable (memoized) params reference, so a mount-time `new Date()` would
+// freeze the upper bound and the 60s poll would stop reflecting usage accruing later
+// today. A far-future bound keeps params stable while always covering "up to now".
 export function useApiKeyUsage(apiKeyId: string | number | undefined) {
   const params = useMemo(
     () =>
       apiKeyId
         ? {
             p_start_date: "2025-01-01",
-            p_end_date: new Date().toISOString(),
+            p_end_date: "2100-01-01",
             p_api_key_id: apiKeyId,
           }
         : null,

--- a/src/domains/api-key/hooks/use-api-key-usage.ts
+++ b/src/domains/api-key/hooks/use-api-key-usage.ts
@@ -1,46 +1,20 @@
-import type { ApiUsageRecord } from "@/domains/api-key/types";
-import { useCustomMutation } from "@refinedev/core";
-import { useCallback, useEffect, useState } from "react";
+import { useMemo } from "react";
+import { useUsageByDimension } from "./use-usage-by-dimension";
 
-export const POLL_INTERVAL_MS = 60_000;
+export { POLL_INTERVAL_MS } from "./use-usage-by-dimension";
 
+// useApiKeyUsage returns one API key's per-day, per-dimension token usage.
 export function useApiKeyUsage(apiKeyId: string | number | undefined) {
-  const [usageData, setUsageData] = useState<ApiUsageRecord[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
-  const { mutateAsync } = useCustomMutation();
-
-  const fetchUsageData = useCallback(async () => {
-    if (!apiKeyId) return;
-
-    setIsLoading(true);
-    setError(null);
-    try {
-      const res = await mutateAsync({
-        url: "/rpc/get_usage_by_dimension",
-        method: "post",
-        values: {
-          p_start_date: "2025-01-01",
-          p_end_date: new Date().toISOString(),
-          p_api_key_id: apiKeyId,
-        },
-      });
-      setUsageData(res.data as ApiUsageRecord[]);
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error(String(err)));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [apiKeyId, mutateAsync]);
-
-  useEffect(() => {
-    fetchUsageData();
-  }, [fetchUsageData]);
-
-  useEffect(() => {
-    const interval = setInterval(fetchUsageData, POLL_INTERVAL_MS);
-    return () => clearInterval(interval);
-  }, [fetchUsageData]);
-
-  return { usageData, isLoading, error };
+  const params = useMemo(
+    () =>
+      apiKeyId
+        ? {
+            p_start_date: "2025-01-01",
+            p_end_date: new Date().toISOString(),
+            p_api_key_id: apiKeyId,
+          }
+        : null,
+    [apiKeyId],
+  );
+  return useUsageByDimension(params);
 }

--- a/src/domains/api-key/hooks/use-usage-by-dimension.ts
+++ b/src/domains/api-key/hooks/use-usage-by-dimension.ts
@@ -1,0 +1,46 @@
+import { useCustomMutation } from "@refinedev/core";
+import { useCallback, useEffect, useState } from "react";
+import type { ApiUsageRecord } from "@/domains/api-key/types";
+
+export const POLL_INTERVAL_MS = 60_000;
+
+// useUsageByDimension polls the get_usage_by_dimension RPC and returns the rows.
+// Pass null to disable fetching (before a required id/workspace is known).
+// `params` MUST be a stable (memoized) reference — it keys both the fetch and
+// the 60s poll, so an unmemoized object would refetch on every render.
+export function useUsageByDimension(params: Record<string, unknown> | null) {
+  const [usageData, setUsageData] = useState<ApiUsageRecord[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const { mutateAsync } = useCustomMutation();
+
+  const fetchUsageData = useCallback(async () => {
+    if (!params) return;
+
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await mutateAsync({
+        url: "/rpc/get_usage_by_dimension",
+        method: "post",
+        values: params,
+      });
+      setUsageData(res.data as ApiUsageRecord[]);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [params, mutateAsync]);
+
+  useEffect(() => {
+    fetchUsageData();
+  }, [fetchUsageData]);
+
+  useEffect(() => {
+    const interval = setInterval(fetchUsageData, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [fetchUsageData]);
+
+  return { usageData, isLoading, error, refetch: fetchUsageData };
+}

--- a/src/domains/api-key/hooks/use-workspace-usage.ts
+++ b/src/domains/api-key/hooks/use-workspace-usage.ts
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import { useUsageByDimension } from "./use-usage-by-dimension";
+
+// useWorkspaceUsage returns a whole workspace's per-day, per-API-key, per-model
+// token usage (scoped to the caller's own API keys by the RPC's auth.uid()
+// filter). Same RPC as useApiKeyUsage, keyed by workspace + date range.
+export function useWorkspaceUsage(
+  workspace: string | undefined,
+  startDate: string,
+  endDate: string,
+) {
+  const params = useMemo(
+    () =>
+      workspace
+        ? {
+            p_start_date: startDate,
+            p_end_date: endDate,
+            p_workspace: workspace,
+          }
+        : null,
+    [workspace, startDate, endDate],
+  );
+  return useUsageByDimension(params);
+}

--- a/src/domains/role/hooks/use-permission-dependencies.test.ts
+++ b/src/domains/role/hooks/use-permission-dependencies.test.ts
@@ -830,7 +830,7 @@ describe("usePermissionDependencies", () => {
 
       // Workspaced views with no permission_action entries (API keys and the
       // observability pages) are not RBAC resources — exclude from comparison.
-      const permissionless = new Set(["api_key", "ai_trace"]);
+      const permissionless = new Set(["api_key", "ai_trace", "model_usage"]);
       const filtered = workspacedFromApp.filter((r) => !permissionless.has(r));
 
       expect([...WORKSPACED_RESOURCES].sort()).toEqual(filtered.sort());

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1308,6 +1308,7 @@
 		"title": "Model Usage",
 		"refresh": "Refresh",
 		"empty": "No usage in the selected window.",
+		"clearFocusDate": "Clear focused date",
 		"filters": {
 			"apiKey": "API key",
 			"allApiKeys": "All API keys",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1,9 +1,6 @@
 {
 	"nativeName": "English",
 	"common": {
-		"dateRange": {
-			"lastDays": "Last {{days}} days"
-		},
 		"fields": {
 			"resources": "Resources",
 			"gpu": "GPU",
@@ -60,6 +57,11 @@
 			"skipped": "Skipped (already exists)",
 			"creating": "Creating...",
 			"error": "Error"
+		},
+		"dateRange": {
+			"lastDays": "Last {{days}} days",
+			"from": "From",
+			"to": "To"
 		}
 	},
 	"appearance": {
@@ -1301,5 +1303,53 @@
 	},
 	"file": {
 		"title": "File"
+	},
+	"model_usage": {
+		"title": "Model Usage",
+		"refresh": "Refresh",
+		"empty": "No usage in the selected window.",
+		"filters": {
+			"apiKey": "API key",
+			"allApiKeys": "All API keys",
+			"model": "Model",
+			"endpointType": "Type",
+			"allTypes": "All types"
+		},
+		"apiKey": "API key",
+		"model": "Model",
+		"promptTokens": "Prompt",
+		"completionTokens": "Completion",
+		"totalTokens": "Total",
+		"byApiKey": "By API key",
+		"byModel": "By model",
+		"range": {
+			"7": "Last 7 days",
+			"30": "Last 30 days",
+			"90": "Last 90 days"
+		},
+		"daily": {
+			"title": "Daily tokens",
+			"totalTokens": "{{total}} total",
+			"tooltip": {
+				"prompt": "Prompt",
+				"completion": "Completion",
+				"total": "Total"
+			},
+			"titleByKey": "Daily tokens by API key",
+			"titleByModel": "Daily tokens by model",
+			"totalLabel": "total tokens"
+		},
+		"detail": {
+			"title": "Daily detail",
+			"date": "Date",
+			"type": "Type",
+			"endpoint": "Endpoint",
+			"internal": "Internal",
+			"external": "External"
+		},
+		"chart": {
+			"line": "Line chart",
+			"bar": "Bar chart"
+		}
 	}
 }

--- a/src/pages/model-usage/list.tsx
+++ b/src/pages/model-usage/list.tsx
@@ -412,14 +412,18 @@ export const ModelUsageList = () => {
           onChange={(e) => setModel(e.target.value)}
         />
         {focusDate ? (
-          <Badge
+          <Button
+            type="button"
             variant="secondary"
-            className="h-9 gap-1 px-3 font-normal cursor-pointer"
+            size="sm"
+            className="h-9 gap-1 px-3 font-normal"
+            aria-label={t("model_usage.clearFocusDate")}
+            title={t("model_usage.clearFocusDate")}
             onClick={() => setFocusDate("")}
           >
             {formatTick(focusDate)}
             <X className="size-3.5" />
-          </Badge>
+          </Button>
         ) : null}
       </div>
 

--- a/src/pages/model-usage/list.tsx
+++ b/src/pages/model-usage/list.tsx
@@ -1,0 +1,718 @@
+import { useList, useParsed } from "@refinedev/core";
+import {
+  BarChart3,
+  LineChart as LineChartIcon,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useWorkspaceUsage } from "@/domains/api-key/hooks/use-workspace-usage";
+import type { ApiUsageRecord } from "@/domains/api-key/types";
+import {
+  type DateRange,
+  DateRangePicker,
+  trailingRange,
+} from "@/foundation/components/DateRangePicker";
+import { ListPage } from "@/foundation/components/ListPage";
+import { Loader } from "@/foundation/components/Loader";
+import { useTranslation } from "@/foundation/lib/i18n";
+import { formatTokens } from "@/foundation/lib/unit";
+import { cn } from "@/foundation/lib/utils";
+
+type NamedTotals = {
+  key: string;
+  name: string;
+  prompt: number;
+  completion: number;
+  total: number;
+};
+
+// A point on the daily line chart: `date` plus one numeric key per series
+// (an API key in "all keys" mode, or a model when a single key is selected).
+type DailyRow = {
+  date: string;
+  [series: string]: number | string;
+};
+
+// A chart series: stable `key` (used as the recharts dataKey + legend toggle
+// identity) and a human `name` for the legend/tooltip.
+type Series = { key: string; name: string };
+
+// Distinct colors for the per-series lines; cycles if there are more series
+// than colors.
+const SERIES_COLORS = [
+  "hsl(217 91% 60%)",
+  "hsl(142 71% 45%)",
+  "hsl(38 92% 50%)",
+  "hsl(271 81% 56%)",
+  "hsl(0 84% 60%)",
+  "hsl(199 89% 48%)",
+  "hsl(330 81% 60%)",
+  "hsl(160 84% 39%)",
+  "hsl(48 96% 53%)",
+  "hsl(240 5% 50%)",
+];
+
+const CHART_MARGIN = { top: 4, right: 8, bottom: 0, left: 4 };
+
+export const ModelUsageList = () => {
+  const { t } = useTranslation();
+  const { params } = useParsed();
+  const workspace = (params?.workspace as string) ?? "";
+
+  const [range, setRange] = useState<DateRange>(() => trailingRange(30));
+  const [apiKeyId, setApiKeyId] = useState<string>("");
+  const [endpointType, setEndpointType] = useState<string>("");
+  const [model, setModel] = useState("");
+  // Chart display mode — line (trend per series) or stacked bar (daily volume).
+  const [chartType, setChartType] = useState<"line" | "bar">("line");
+  // Series toggled off via the (clickable) chart legend.
+  const [hidden, setHidden] = useState<Set<string>>(() => new Set());
+  // Day focused by clicking a chart point — narrows the detail table.
+  const [focusDate, setFocusDate] = useState<string>("");
+
+  const { usageData, isLoading, error, refetch } = useWorkspaceUsage(
+    workspace,
+    range.start,
+    range.end,
+  );
+
+  // Workspace API keys for the filter dropdown (matches the trace list).
+  const { data: keysData } = useList<{
+    id: string;
+    metadata?: { name?: string };
+  }>({
+    resource: "api_keys",
+    pagination: { mode: "off" },
+    meta: { workspace },
+    queryOptions: { enabled: Boolean(workspace) },
+  });
+  const keys = keysData?.data ?? [];
+
+  const filtered = useMemo(
+    () =>
+      usageData.filter(
+        (r) =>
+          (!apiKeyId || r.api_key_id === apiKeyId) &&
+          (!endpointType || r.endpoint_type === endpointType) &&
+          (!model ||
+            (r.model_name ?? "")
+              .toLowerCase()
+              .includes(model.trim().toLowerCase())),
+      ),
+    [usageData, apiKeyId, endpointType, model],
+  );
+
+  // With "All API keys" each line is an API key; once a key is picked we drill
+  // into that key's per-model usage over time.
+  const groupByModel = Boolean(apiKeyId);
+  const { data: dailyData, series } = useMemo(
+    () => aggregateDaily(filtered, groupByModel),
+    [filtered, groupByModel],
+  );
+
+  const byKey = useMemo(
+    () =>
+      aggregateBy(
+        filtered,
+        (r) => r.api_key_id,
+        (r) => r.api_key_name,
+      ),
+    [filtered],
+  );
+  const byModel = useMemo(
+    () =>
+      aggregateBy(
+        filtered,
+        (r) => r.model_name ?? "-",
+        (r) => r.model_name ?? "-",
+      ),
+    [filtered],
+  );
+
+  // Detail rows, optionally narrowed to the day clicked in the chart.
+  const detailRows = useMemo(() => {
+    const rows = focusDate
+      ? filtered.filter((r) => r.date === focusDate)
+      : filtered;
+    return [...rows].sort(
+      (a, b) => b.date.localeCompare(a.date) || (b.usage ?? 0) - (a.usage ?? 0),
+    );
+  }, [filtered, focusDate]);
+
+  const totalTokens = filtered.reduce((sum, r) => sum + (r.usage ?? 0), 0);
+  const seriesName = (key: string) =>
+    series.find((s) => s.key === key)?.name ?? key;
+
+  // Clicking a day in either chart focuses (or clears) the detail table.
+  const onPick = (e: { activeLabel?: string | number }) => {
+    const day = typeof e?.activeLabel === "string" ? e.activeLabel : "";
+    if (day) setFocusDate((prev) => (prev === day ? "" : day));
+  };
+
+  const toggleSeries = (key: string) => {
+    if (!key) return;
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      return next;
+    });
+  };
+
+  // Axes / grid / tooltip / legend are identical across line and bar modes, so
+  // share them as a keyed child array between the two chart elements (recharts
+  // flattens arrays of children when detecting axis/legend components).
+  const commonAxes = [
+    <CartesianGrid
+      key="grid"
+      strokeDasharray="3 3"
+      vertical={false}
+      stroke="hsl(var(--border))"
+    />,
+    <XAxis
+      key="x"
+      dataKey="date"
+      tickFormatter={formatTick}
+      tickLine={false}
+      axisLine={false}
+      fontSize={11}
+      interval="preserveStartEnd"
+    />,
+    <YAxis
+      key="y"
+      tickFormatter={(v) => formatTokens(v) ?? ""}
+      tickLine={false}
+      axisLine={false}
+      fontSize={11}
+      width={48}
+    />,
+    <Tooltip key="tip" content={<UsageTooltip seriesName={seriesName} />} />,
+    <Legend
+      key="legend"
+      wrapperStyle={{ fontSize: 11 }}
+      onClick={(o) => toggleSeries(String(o.dataKey ?? ""))}
+      formatter={(_val, entry) => {
+        const key = String(entry?.dataKey ?? "");
+        return (
+          <span
+            style={{
+              cursor: "pointer",
+              opacity: hidden.has(key) ? 0.35 : 1,
+            }}
+          >
+            {seriesName(key)}
+          </span>
+        );
+      }}
+    />,
+  ];
+
+  return (
+    <ListPage
+      title={t("model_usage.title")}
+      canCreate={false}
+      breadcrumb={false}
+      extra={
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => refetch()}
+          disabled={isLoading}
+        >
+          <RefreshCw className={cn("size-4", isLoading && "animate-spin")} />
+          {t("model_usage.refresh")}
+        </Button>
+      }
+    >
+      <div className="border rounded-md p-4 mb-4">
+        <div className="flex items-baseline justify-between mb-2">
+          <span className="text-sm font-medium">
+            {groupByModel
+              ? t("model_usage.daily.titleByModel")
+              : t("model_usage.daily.titleByKey")}
+          </span>
+          <div className="flex items-center gap-3">
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-xl font-semibold tabular-nums">
+                {formatTokens(totalTokens)}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {t("model_usage.daily.totalLabel")}
+              </span>
+            </div>
+            <div className="inline-flex rounded-md border p-0.5">
+              <Button
+                type="button"
+                variant={chartType === "line" ? "secondary" : "ghost"}
+                size="sm"
+                className="h-7 px-2"
+                aria-label={t("model_usage.chart.line")}
+                title={t("model_usage.chart.line")}
+                onClick={() => setChartType("line")}
+              >
+                <LineChartIcon className="size-4" />
+              </Button>
+              <Button
+                type="button"
+                variant={chartType === "bar" ? "secondary" : "ghost"}
+                size="sm"
+                className="h-7 px-2"
+                aria-label={t("model_usage.chart.bar")}
+                title={t("model_usage.chart.bar")}
+                onClick={() => setChartType("bar")}
+              >
+                <BarChart3 className="size-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+        <div className="h-[240px]">
+          {isLoading && dailyData.length === 0 ? (
+            <div className="flex h-full items-center justify-center">
+              <Loader className="w-8 text-muted-foreground" />
+            </div>
+          ) : dailyData.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              {t("model_usage.empty")}
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              {chartType === "bar" ? (
+                <BarChart
+                  data={dailyData}
+                  margin={CHART_MARGIN}
+                  onClick={onPick}
+                >
+                  {commonAxes}
+                  {series.map((s, i) => (
+                    <Bar
+                      key={s.key}
+                      dataKey={s.key}
+                      name={s.name}
+                      stackId="usage"
+                      hide={hidden.has(s.key)}
+                      fill={SERIES_COLORS[i % SERIES_COLORS.length]}
+                      radius={
+                        i === series.length - 1 ? [3, 3, 0, 0] : undefined
+                      }
+                    />
+                  ))}
+                </BarChart>
+              ) : (
+                <LineChart
+                  data={dailyData}
+                  margin={CHART_MARGIN}
+                  onClick={onPick}
+                >
+                  {commonAxes}
+                  {series.map((s, i) => (
+                    <Line
+                      key={s.key}
+                      type="monotone"
+                      dataKey={s.key}
+                      name={s.name}
+                      hide={hidden.has(s.key)}
+                      stroke={SERIES_COLORS[i % SERIES_COLORS.length]}
+                      strokeWidth={2}
+                      dot={{ r: 2 }}
+                      activeDot={{ r: 4 }}
+                      connectNulls
+                    />
+                  ))}
+                </LineChart>
+              )}
+            </ResponsiveContainer>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        <DateRangePicker value={range} onChange={setRange} />
+        <Select
+          value={apiKeyId || "all"}
+          onValueChange={(v) => {
+            const next = v === "all" ? "" : v;
+            setApiKeyId(next);
+            // A single key reads best as a stacked bar of its daily model mix;
+            // "All keys" reads best as per-key trend lines.
+            setChartType(next ? "bar" : "line");
+          }}
+        >
+          <SelectTrigger className="w-[200px]">
+            <SelectValue placeholder={t("model_usage.filters.apiKey")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">
+              {t("model_usage.filters.allApiKeys")}
+            </SelectItem>
+            {keys.map((k) => (
+              <SelectItem key={k.id} value={k.id}>
+                {k.metadata?.name ?? k.id}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select
+          value={endpointType || "all"}
+          onValueChange={(v) => setEndpointType(v === "all" ? "" : v)}
+        >
+          <SelectTrigger className="w-[160px]">
+            <SelectValue placeholder={t("model_usage.filters.endpointType")} />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">
+              {t("model_usage.filters.allTypes")}
+            </SelectItem>
+            <SelectItem value="endpoint">
+              {t("model_usage.detail.internal")}
+            </SelectItem>
+            <SelectItem value="external-endpoint">
+              {t("model_usage.detail.external")}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <Input
+          className="w-[200px]"
+          placeholder={t("model_usage.filters.model")}
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+        />
+        {focusDate ? (
+          <Badge
+            variant="secondary"
+            className="h-9 gap-1 px-3 font-normal cursor-pointer"
+            onClick={() => setFocusDate("")}
+          >
+            {formatTick(focusDate)}
+            <X className="size-3.5" />
+          </Badge>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div className="text-sm text-destructive mb-2">{error.message}</div>
+      ) : null}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <UsageTable
+          title={t("model_usage.byApiKey")}
+          nameHeader={t("model_usage.apiKey")}
+          rows={byKey}
+        />
+        <UsageTable
+          title={t("model_usage.byModel")}
+          nameHeader={t("model_usage.model")}
+          rows={byModel}
+        />
+      </div>
+
+      <div className="mt-4">
+        <DetailTable rows={detailRows} />
+      </div>
+    </ListPage>
+  );
+};
+
+// DetailTable is the per-day breakdown (date / type / endpoint / model /
+// prompt / completion / total) — one row per usage record, the granularity the
+// PM asked to keep from the old API-key detail view.
+const DetailTable = ({ rows }: { rows: ApiUsageRecord[] }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="border rounded-md">
+      <div className="px-4 py-2 text-sm font-medium border-b">
+        {t("model_usage.detail.title")}
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-[110px]">
+              {t("model_usage.detail.date")}
+            </TableHead>
+            <TableHead className="w-[140px]">
+              {t("model_usage.apiKey")}
+            </TableHead>
+            <TableHead className="w-[90px]">
+              {t("model_usage.detail.type")}
+            </TableHead>
+            <TableHead>{t("model_usage.detail.endpoint")}</TableHead>
+            <TableHead>{t("model_usage.model")}</TableHead>
+            <TableHead className="text-right">
+              {t("model_usage.promptTokens")}
+            </TableHead>
+            <TableHead className="text-right">
+              {t("model_usage.completionTokens")}
+            </TableHead>
+            <TableHead className="text-right">
+              {t("model_usage.totalTokens")}
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={8}
+                className="text-center py-8 text-muted-foreground"
+              >
+                {t("model_usage.empty")}
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((r, i) => (
+              <TableRow
+                key={`${r.date}-${r.api_key_id}-${r.endpoint_name}-${r.model_name}-${i}`}
+              >
+                <TableCell className="font-mono text-xs">
+                  {formatTick(r.date)}
+                </TableCell>
+                <TableCell className="text-sm truncate max-w-[140px]">
+                  {r.api_key_name || (
+                    <span className="text-muted-foreground">-</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <EndpointTypeBadge type={r.endpoint_type} />
+                </TableCell>
+                <TableCell className="text-sm truncate max-w-[200px]">
+                  {r.endpoint_name || (
+                    <span className="text-muted-foreground">-</span>
+                  )}
+                </TableCell>
+                <TableCell className="text-sm truncate max-w-[200px]">
+                  {r.model_name || (
+                    <span className="text-muted-foreground">-</span>
+                  )}
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs">
+                  {formatTokens(r.prompt_tokens ?? 0)}
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs">
+                  {formatTokens(r.completion_tokens ?? 0)}
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs font-medium">
+                  {formatTokens(r.usage ?? 0)}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+const EndpointTypeBadge = ({ type }: { type: string | null }) => {
+  const { t } = useTranslation();
+  if (type === "external-endpoint") {
+    return <Badge variant="outline">{t("model_usage.detail.external")}</Badge>;
+  }
+  if (type === "endpoint") {
+    return (
+      <Badge variant="secondary">{t("model_usage.detail.internal")}</Badge>
+    );
+  }
+  return <span className="text-muted-foreground">-</span>;
+};
+
+const UsageTable = ({
+  title,
+  nameHeader,
+  rows,
+}: {
+  title: string;
+  nameHeader: string;
+  rows: NamedTotals[];
+}) => {
+  const { t } = useTranslation();
+  return (
+    <div className="border rounded-md">
+      <div className="px-4 py-2 text-sm font-medium border-b">{title}</div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{nameHeader}</TableHead>
+            <TableHead className="text-right">
+              {t("model_usage.promptTokens")}
+            </TableHead>
+            <TableHead className="text-right">
+              {t("model_usage.completionTokens")}
+            </TableHead>
+            <TableHead className="text-right">
+              {t("model_usage.totalTokens")}
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={4}
+                className="text-center py-8 text-muted-foreground"
+              >
+                {t("model_usage.empty")}
+              </TableCell>
+            </TableRow>
+          ) : (
+            rows.map((r) => (
+              <TableRow key={r.key}>
+                <TableCell className="truncate max-w-[160px]">
+                  {r.name || <span className="text-muted-foreground">-</span>}
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs">
+                  {formatTokens(r.prompt)}
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs">
+                  {formatTokens(r.completion)}
+                </TableCell>
+                <TableCell className="text-right font-mono text-xs font-medium">
+                  {formatTokens(r.total)}
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+const UsageTooltip = ({
+  active,
+  payload,
+  label,
+  seriesName,
+}: {
+  active?: boolean;
+  payload?: Array<{ dataKey: string; value: number; color: string }>;
+  label?: string;
+  seriesName: (key: string) => string;
+}) => {
+  const { t } = useTranslation();
+  if (!active || !payload || payload.length === 0) return null;
+  const rows = payload.filter((p) => (p.value ?? 0) > 0);
+  if (rows.length === 0) return null;
+  const total = rows.reduce((sum, p) => sum + (p.value ?? 0), 0);
+  return (
+    <div className="rounded border bg-popover px-2 py-1 text-xs shadow">
+      <div className="font-medium mb-1">{label}</div>
+      {rows.map((p) => (
+        <div
+          key={p.dataKey}
+          className="flex items-center gap-1.5 text-muted-foreground"
+        >
+          <span
+            className="inline-block size-2 rounded-sm"
+            style={{ backgroundColor: p.color }}
+          />
+          <span className="truncate max-w-[160px]">
+            {seriesName(p.dataKey)}
+          </span>
+          <span className="ml-auto font-mono">{formatTokens(p.value)}</span>
+        </div>
+      ))}
+      <div className="mt-1 flex border-t pt-1">
+        <span>{t("model_usage.daily.tooltip.total")}</span>
+        <span className="ml-auto font-mono">{formatTokens(total)}</span>
+      </div>
+    </div>
+  );
+};
+
+// aggregateDaily buckets usage into per-day totals for each series — one series
+// per API key, or per model when `byModel` is set — for a multi-line chart.
+// Returns the chart rows and the series list (sorted by total desc).
+function aggregateDaily(
+  rows: ApiUsageRecord[],
+  byModel: boolean,
+): { data: DailyRow[]; series: Series[] } {
+  const byDate = new Map<string, Record<string, number>>();
+  const totals = new Map<string, number>();
+  const names = new Map<string, string>();
+  for (const r of rows) {
+    const key = byModel ? (r.model_name ?? "-") : r.api_key_id;
+    const name = byModel ? (r.model_name ?? "-") : r.api_key_name;
+    names.set(key, name);
+    const day = byDate.get(r.date) ?? {};
+    day[key] = (day[key] ?? 0) + (r.usage ?? 0);
+    byDate.set(r.date, day);
+    totals.set(key, (totals.get(key) ?? 0) + (r.usage ?? 0));
+  }
+  const series = [...totals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([key]) => ({ key, name: names.get(key) ?? key }));
+  const data = [...byDate.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, perSeries]) => {
+      const row: DailyRow = { date };
+      for (const s of series) {
+        row[s.key] = perSeries[s.key] ?? 0;
+      }
+      return row;
+    });
+  return { data, series };
+}
+
+function aggregateBy(
+  rows: ApiUsageRecord[],
+  keyOf: (r: ApiUsageRecord) => string,
+  nameOf: (r: ApiUsageRecord) => string,
+): NamedTotals[] {
+  const byKey = new Map<string, NamedTotals>();
+  for (const r of rows) {
+    const k = keyOf(r);
+    const cur = byKey.get(k) ?? {
+      key: k,
+      name: nameOf(r),
+      prompt: 0,
+      completion: 0,
+      total: 0,
+    };
+    cur.prompt += r.prompt_tokens ?? 0;
+    cur.completion += r.completion_tokens ?? 0;
+    cur.total += r.usage ?? 0;
+    byKey.set(k, cur);
+  }
+  return [...byKey.values()].sort((a, b) => b.total - a.total);
+}
+
+// Converts a YYYY-MM-DD date into a compact M/D axis tick.
+function formatTick(date: string): string {
+  const parts = date.split("-");
+  if (parts.length !== 3) return date;
+  return `${Number(parts[1])}/${Number(parts[2])}`;
+}


### PR DESCRIPTION
## Summary

Splits the **Model Usage** feature out of the `feat/ai-inference-trace` demo branch into a standalone branch based on `main`, as a draft for review.

Adds a new **Model Usage** analytics page (`/:workspace/model-usage`) that visualizes token consumption for the current workspace:

- Per-day, per-API-key and per-model token usage over a selectable date range.
- Line / bar chart views plus a daily detail table (prompt / completion / total tokens).
- Filters by API key, model and endpoint type (internal / external).

## Backend

No server changes are required — the page consumes the existing `get_usage_by_dimension` PostgREST RPC, which is already present in `main` (migrations `002`, `018`, `054`). The whole-workspace view is scoped to the caller's own API keys by the RPC's `auth.uid()` filter.

## Changes

- `pages/model-usage/list.tsx` — the page (charts via `recharts`, table, filters).
- `domains/api-key/hooks/use-usage-by-dimension.ts` — shared hook polling the RPC (60s).
- `domains/api-key/hooks/use-api-key-usage.ts` — refactored onto the shared hook.
- `domains/api-key/hooks/use-workspace-usage.ts` — whole-workspace view hook.
- `foundation/components/DateRangePicker.tsx` + `components/ui/calendar.tsx` — date-range primitives (adds `react-day-picker`).
- `App.tsx` — route + resource registration.
- `locales/en-US.json` — `model_usage.*` and `common.dateRange.*` keys.

## Validation

Ran the CI checks locally (sandbox, `node:22-bookworm`):

- `yarn typecheck` ✅
- `yarn dep-check` ✅
- `yarn knip` ✅
- `node tools/i18n-tracker.cjs` ✅
- `node tools/check-i18n-keys.cjs` ✅

Browser/visual verification against a live backend is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
