### PR TITLE
feat: label cluster version section

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -233,7 +233,7 @@
   "src/domains/model-registry/hooks/use-model-registry-form.tsx": "e8a9470b28bcabdd47e52bfe77996c48",
   "src/domains/image-registry/lib/transform-image-registry-values.ts": "29354ba58a40bf0f421bc03b6a774cee",
   "src/domains/image-registry/hooks/use-image-registry-form.tsx": "81488170f914365f28b54064916fe8c5",
-  "src/domains/cluster/hooks/use-cluster-form.tsx": "cb1a4fd5635f1fdc894ff90c3565b85e",
+  "src/domains/cluster/hooks/use-cluster-form.tsx": "710aebcc112f56f215a9f7b09eeefdc8",
   "src/foundation/types/resource-types.ts": "828c217b8408bcac60799ab7fdb4189f",
   "src/foundation/hooks/use-variables-input.ts": "4b89bf232a2e5ae081417eb32cd07b27",
   "src/foundation/components/VariablesInput.tsx": "322ef95b0efb9795b935e37ab3b79ead",

--- a/src/domains/cluster/hooks/use-cluster-form.test.tsx
+++ b/src/domains/cluster/hooks/use-cluster-form.test.tsx
@@ -74,6 +74,15 @@ function CreateForm() {
   );
 }
 
+function VersionFieldsForm() {
+  const { form, versionFields } = useClusterForm({ action: "create" });
+  return (
+    <FormProvider {...form}>
+      <form>{versionFields}</form>
+    </FormProvider>
+  );
+}
+
 function EditForm() {
   const { form, typeFields, providerFields, routerFields, authFields } =
     useClusterForm({ action: "edit" });
@@ -98,6 +107,12 @@ function selectType(label: string) {
 }
 
 describe("useClusterForm", () => {
+  it("labels the version section as cluster version", () => {
+    render(<VersionFieldsForm />);
+
+    expect(screen.getByText("clusters.sections.clusterVersion")).toBeTruthy();
+  });
+
   describe("edit mode — NodeIPsField props", () => {
     it("passes headIpDisabled=true without disabled in edit mode", () => {
       nodeIPsFieldProps.mockClear();

--- a/src/domains/cluster/hooks/use-cluster-form.tsx
+++ b/src/domains/cluster/hooks/use-cluster-form.tsx
@@ -163,7 +163,7 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
       </FormCardGrid>
     ),
     versionFields: (
-      <FormCardGrid>
+      <FormCardGrid title={t("clusters.sections.clusterVersion")}>
         <FormFieldGroup
           {...form}
           name="spec.version"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -399,6 +399,7 @@
 			"amd_gpu": "AMD GPU"
 		},
 		"sections": {
+			"clusterVersion": "Cluster Version",
 			"clusterType": "Cluster Type",
 			"provider": "Provider",
 			"headNode": "Head Node",


### PR DESCRIPTION
## Issues

- NEU-459: Add an explicit Cluster Version description to the cluster create/edit form version area.

## Changes

- Added a `Cluster Version` section title to the cluster form version card.
- Added the English locale key for the new section title.
- Added focused test coverage for the version section label.

## Test Plan

### Unit test

- `npx -y node@22 ./node_modules/vitest/vitest.mjs run src/domains/cluster/hooks/use-cluster-form.test.tsx` — passed, 6 tests.
- Pre-commit hook under Node 22 — passed `yarn typecheck`, `yarn dep-check`, `yarn knip`, `lint-staged`, i18n tracker, and i18n key checks.

### DB test

- Not required: UI-only text/section-label change with no database interaction.

### E2E test

- Skipped: classified as Trivial because the change is limited to UI labeling and has no deployed-system behavior impact. Manual testing is not required.

## Classification

- Trivial: small UI label/localization change; docs MR, TestRail sync, and E2E validation are skipped by the Neutree workflow.