### PR TITLE
fix(endpoint): keep scroll position when logs auto-refresh (NEU-457)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -196,7 +196,7 @@
   "src/domains/endpoint/components/RerankPlayground.tsx": "a4409b6861a882c89aecb9aec8c878e3",
   "src/domains/endpoint/components/ResourcesCard.tsx": "ff5145157bffaa74000b0994f14c04f2",
   "src/domains/endpoint/components/SliderWithInput.tsx": "79e861ce4a0846107bdad89c93389131",
-  "src/domains/endpoint/components/VirtualLog.tsx": "3699a7fcf2256dd95241412bb43bf99a",
+  "src/domains/endpoint/components/VirtualLog.tsx": "27086754a748869249911de248b3536f",
   "src/domains/cluster/types.ts": "7d2cdf2d46d1302000d6b5d25b281241",
   "src/domains/cluster/lib/get-ray-dashboard-proxy.ts": "a4a3c75f58c68ee9dca572ad3a70c62b",
   "src/domains/cluster/hooks/use-cluster-monitor-panels.ts": "18f9cf1e6422f66493f6d182c18c746c",

--- a/src/domains/endpoint/components/VirtualLog.test.tsx
+++ b/src/domains/endpoint/components/VirtualLog.test.tsx
@@ -1,0 +1,99 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Shared spies/handles between the react-window mock and the test body.
+const h = vi.hoisted(() => ({
+  scrollToItem: vi.fn(),
+  onScroll: { current: null as null | ((p: unknown) => void) },
+}));
+
+// Mock react-window's FixedSizeList with a minimal class component so we can
+// (a) capture the imperative `scrollToItem` call the component makes through
+// the ref, and (b) drive `onScroll` manually to simulate user scrolling.
+vi.mock("react-window", async () => {
+  const React = await import("react");
+  class List extends React.Component<{ onScroll?: (p: unknown) => void }> {
+    scrollToItem = h.scrollToItem;
+    render() {
+      h.onScroll.current = this.props.onScroll ?? null;
+      return null;
+    }
+  }
+  return { FixedSizeList: List };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "light" }),
+}));
+
+import { VirtualLog } from "./VirtualLog";
+
+const makeLog = (n: number) =>
+  Array.from({ length: n }, (_, i) => `line ${i + 1}`).join("\n");
+
+// Simulate a real (non-programmatic) user scroll to a given offset.
+const userScrollTo = (scrollOffset: number) =>
+  h.onScroll.current?.({
+    scrollDirection: "backward",
+    scrollOffset,
+    scrollUpdateWasRequested: false,
+  });
+
+describe("VirtualLog tail-following", () => {
+  beforeEach(() => {
+    h.scrollToItem.mockClear();
+  });
+
+  it("auto-scrolls to the latest line on initial render", () => {
+    render(<VirtualLog log={makeLog(3)} />);
+    expect(h.scrollToItem).toHaveBeenCalledWith(2, "end");
+  });
+
+  it("stops following the tail once the user scrolls up", () => {
+    // Enough lines that the content is taller than the viewport, otherwise
+    // every offset counts as "at bottom".
+    const { rerender } = render(<VirtualLog log={makeLog(100)} />);
+    h.scrollToItem.mockClear();
+
+    // User scrolls up to inspect earlier output.
+    userScrollTo(0);
+
+    // Auto-refresh delivers new lines.
+    rerender(<VirtualLog log={makeLog(105)} />);
+
+    expect(h.scrollToItem).not.toHaveBeenCalled();
+  });
+
+  it("keeps following the tail while the user is pinned to the bottom", () => {
+    const { rerender } = render(<VirtualLog log={makeLog(100)} />);
+    h.scrollToItem.mockClear();
+
+    // User is at the bottom (large offset clamps to the tail).
+    userScrollTo(1_000_000);
+
+    // Auto-refresh delivers new lines.
+    rerender(<VirtualLog log={makeLog(105)} />);
+
+    expect(h.scrollToItem).toHaveBeenCalledWith(104, "end");
+  });
+
+  it("auto-scrolls to the tail when switching from reverse back to normal order", () => {
+    // Start in reverse order, where the latest line is at the top.
+    const { rerender } = render(<VirtualLog log={makeLog(100)} reverse />);
+    h.scrollToItem.mockClear();
+
+    // The user scrolls within reverse mode. This must NOT clobber the
+    // pinned-to-bottom state, which is only meaningful in normal order.
+    userScrollTo(0);
+
+    // Switch back to normal order: we expect to jump to the latest line,
+    // matching the previous unconditional behavior.
+    rerender(<VirtualLog log={makeLog(100)} reverse={false} />);
+
+    expect(h.scrollToItem).toHaveBeenCalledWith(99, "end");
+  });
+});

--- a/src/domains/endpoint/components/VirtualLog.tsx
+++ b/src/domains/endpoint/components/VirtualLog.tsx
@@ -250,11 +250,17 @@ export const VirtualLog: FC<VirtualLogProps> = ({
 
     // Track whether the user is pinned to the bottom so auto-refresh only
     // follows the tail when they haven't scrolled up to read older lines.
-    const maxScrollOffset = Math.max(
-      0,
-      processedLines.length * lineHeight - listHeight,
-    );
-    isAtBottomRef.current = scrollOffset >= maxScrollOffset - lineHeight;
+    // The "pinned to bottom" concept only applies to normal (non-reversed)
+    // order, so we only update it there. In reverse mode the latest line sits
+    // at the top, so scrolling would otherwise wrongly flip this to false and
+    // suppress the expected auto-scroll after switching back to normal order.
+    if (!reverse) {
+      const maxScrollOffset = Math.max(
+        0,
+        processedLines.length * lineHeight - listHeight,
+      );
+      isAtBottomRef.current = scrollOffset >= maxScrollOffset - lineHeight;
+    }
 
     if (!onScrollBottom) return;
 

--- a/src/domains/endpoint/components/VirtualLog.tsx
+++ b/src/domains/endpoint/components/VirtualLog.tsx
@@ -116,6 +116,15 @@ export const VirtualLog: FC<VirtualLogProps> = ({
   const listRef = useRef<List>(null);
 
   /**
+   * Tracks whether the user is currently pinned to the bottom of the log.
+   * Starts true so the very first render auto-scrolls to the latest line.
+   * While true, new log content (e.g. from auto-refresh) keeps following the
+   * tail; once the user scrolls up to read older lines it becomes false and we
+   * stop yanking them back down on every refresh.
+   */
+  const isAtBottomRef = useRef(true);
+
+  /**
    * Process log lines:
    * 1. Split lines
    * 2. Filter by time window (if provided)
@@ -236,10 +245,18 @@ export const VirtualLog: FC<VirtualLogProps> = ({
    * Handle scroll to detect when user reaches bottom/top for infinite loading
    */
   const handleScroll = (props: ListOnScrollProps) => {
-    if (!onScrollBottom) return;
-
     const { scrollDirection, scrollOffset, scrollUpdateWasRequested } = props;
     if (scrollUpdateWasRequested) return; // Skip programmatic scrolls
+
+    // Track whether the user is pinned to the bottom so auto-refresh only
+    // follows the tail when they haven't scrolled up to read older lines.
+    const maxScrollOffset = Math.max(
+      0,
+      processedLines.length * lineHeight - listHeight,
+    );
+    isAtBottomRef.current = scrollOffset >= maxScrollOffset - lineHeight;
+
+    if (!onScrollBottom) return;
 
     if (!reverse) {
       // Normal order: detect bottom
@@ -257,12 +274,14 @@ export const VirtualLog: FC<VirtualLogProps> = ({
   };
 
   /**
-   * Auto-scroll to latest logs when in normal mode
+   * Auto-scroll to latest logs when in normal mode, but only while the user is
+   * already following the tail. If they scrolled up to inspect earlier output,
+   * preserve their position across auto-refreshes instead of jumping down.
    */
   useEffect(() => {
     if (!listRef.current || !processedLines.length) return;
 
-    if (!reverse) {
+    if (!reverse && isAtBottomRef.current) {
       // Scroll to bottom for latest logs
       listRef.current.scrollToItem(processedLines.length - 1, "end");
     }


### PR DESCRIPTION
## Problem (NEU-457)

On the inference engine log page, when the user scrolls up to read earlier output, the 10s auto-refresh (`useStreamingLogs`) yanks them back to the bottom on every cycle, so the lines they were reading have to be scrolled to again.

## Root cause

`VirtualLog` unconditionally auto-scrolled to the latest line whenever `processedLines.length` changed:

```ts
useEffect(() => {
  if (!reverse) listRef.current.scrollToItem(processedLines.length - 1, "end");
}, [processedLines.length, reverse]);
```

Since auto-refresh replaces the log content every 10s, this fired on every refresh regardless of where the user was.

## Fix

Implement the standard "stick to bottom" tailing behavior:

- Track whether the user is pinned to the bottom of the virtualized list in `isAtBottomRef` (updated from real, non-programmatic scroll events).
- Auto-scroll to the tail **only while the user is already at the bottom**. Once they scroll up to inspect older lines, their position is preserved across auto-refreshes.
- Initial value is `true` so the first render still jumps to the latest line.

Scope is limited to `VirtualLog.tsx`; no API or behavior change for users who stay at the tail.

## Verification

- `yarn typecheck` (tsc -b) passes.
- `biome lint` passes on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)