### PR TITLE
fix(model-usage): treat "All workspaces" as no workspace filter

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -297,6 +297,6 @@
   "src/foundation/components/DateRangePicker.tsx": "7db897cba5bece0433e75fcd91d305b1",
   "src/pages/model-usage/list.tsx": "bd680f4817e9b80433c50e2b185affbd",
   "src/domains/api-key/hooks/use-usage-by-dimension.ts": "180fbbc1c2b848f8b9d4172c85835344",
-  "src/domains/api-key/hooks/use-workspace-usage.ts": "b6d1bc5f44a709f8d0bd703f67c2937b",
+  "src/domains/api-key/hooks/use-workspace-usage.ts": "5f008c9efecb5f75398ae4fb67414d69",
   "src/components/ui/calendar.tsx": "67b3c096201e6f030437e9127db7c586"
 }

--- a/src/domains/api-key/hooks/use-workspace-usage.test.ts
+++ b/src/domains/api-key/hooks/use-workspace-usage.test.ts
@@ -1,0 +1,71 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockMutateAsync = vi.fn();
+
+vi.mock("@refinedev/core", () => ({
+  useCustomMutation: () => ({ mutateAsync: mockMutateAsync }),
+}));
+
+import { ALL_WORKSPACES } from "@/foundation/hooks/use-workspace";
+import { useWorkspaceUsage } from "./use-workspace-usage";
+
+describe("useWorkspaceUsage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not fetch when no workspace is selected", () => {
+    const { result } = renderHook(() =>
+      useWorkspaceUsage(undefined, "2025-01-01", "2025-02-01"),
+    );
+
+    expect(result.current.usageData).toEqual([]);
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("forwards a concrete workspace as the p_workspace filter", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ data: [] });
+
+    renderHook(() => useWorkspaceUsage("default", "2025-01-01", "2025-02-01"));
+
+    await act(async () => {});
+
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/rpc/get_usage_by_dimension",
+        method: "post",
+        values: {
+          p_start_date: "2025-01-01",
+          p_end_date: "2025-02-01",
+          p_workspace: "default",
+        },
+      }),
+    );
+  });
+
+  it("omits p_workspace for the 'All workspaces' sentinel", async () => {
+    mockMutateAsync.mockResolvedValueOnce({ data: [] });
+
+    renderHook(() =>
+      useWorkspaceUsage(ALL_WORKSPACES, "2025-01-01", "2025-02-01"),
+    );
+
+    await act(async () => {});
+
+    expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    const call = mockMutateAsync.mock.calls[0][0];
+    expect(call.values).toEqual({
+      p_start_date: "2025-01-01",
+      p_end_date: "2025-02-01",
+    });
+    // The literal "_all_" must never reach the backend, or the RPC's
+    // `workspace = p_workspace` filter would match nothing.
+    expect(call.values).not.toHaveProperty("p_workspace");
+  });
+});

--- a/src/domains/api-key/hooks/use-workspace-usage.ts
+++ b/src/domains/api-key/hooks/use-workspace-usage.ts
@@ -1,9 +1,19 @@
 import { useMemo } from "react";
+import { ALL_WORKSPACES } from "@/foundation/hooks/use-workspace";
 import { useUsageByDimension } from "./use-usage-by-dimension";
 
 // useWorkspaceUsage returns a whole workspace's per-day, per-API-key, per-model
-// token usage (scoped to the caller's own API keys by the RPC's auth.uid()
-// filter). Same RPC as useApiKeyUsage, keyed by workspace + date range.
+// token usage (scoped to the caller's visible API keys by the RPC's auth.uid()
+// + permission filter). Same RPC as useApiKeyUsage, keyed by workspace + date
+// range.
+//
+// "All workspaces" (ALL_WORKSPACES / "_all_") is a UI-only sentinel, not a real
+// workspace name. The RPC treats p_workspace as a narrowing filter
+// (`p_workspace IS NULL OR workspace = p_workspace`), so forwarding "_all_"
+// verbatim would match no workspace and return an empty page. Instead we omit
+// p_workspace entirely, which makes the RPC aggregate across every workspace the
+// caller is entitled to — mirroring how the data provider drops the workspace
+// filter for ALL_WORKSPACES on standard list queries.
 export function useWorkspaceUsage(
   workspace: string | undefined,
   startDate: string,
@@ -15,7 +25,7 @@ export function useWorkspaceUsage(
         ? {
             p_start_date: startDate,
             p_end_date: endDate,
-            p_workspace: workspace,
+            ...(workspace === ALL_WORKSPACES ? {} : { p_workspace: workspace }),
           }
         : null,
     [workspace, startDate, endDate],


### PR DESCRIPTION
## Problem

On the **Model Usage** page, the top workspace selector forwards its value
straight to the `get_usage_by_dimension` RPC as `p_workspace`. When the user
picks **"All workspaces"**, that value is the UI-only sentinel `"_all_"`
(`ALL_WORKSPACES`), which is not a real workspace name.

The RPC uses `p_workspace` as a *narrowing* filter:

```sql
(p_workspace IS NULL OR COALESCE(e.workspace, ee.workspace, 'unknown') = p_workspace)
```

So `"_all_"` matches no workspace → the page renders empty.

## Expected behavior

"All workspaces" should mean **no workspace filter**: aggregate token usage
across every workspace the caller is entitled to see (the RPC already scopes
rows by `auth.uid()` + `workspace:usage-read` permission). It must **not** be a
literal workspace value sent to the backend.

## Fix

In `useWorkspaceUsage`, omit `p_workspace` from the RPC params when the selected
workspace is the `ALL_WORKSPACES` sentinel, so the RPC takes its
`p_workspace IS NULL` branch and returns all entitled usage.

This mirrors the data provider, which already drops the workspace filter for
`ALL_WORKSPACES` on standard list queries (`meta.workspace !== ALL_WORKSPACES`).

## Tests

Added `use-workspace-usage.test.ts`:
- concrete workspace → forwarded as `p_workspace`
- `ALL_WORKSPACES` → `p_workspace` omitted entirely
- no selection → no fetch

`tsc -b`, `biome check`, and the new unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)