### PR TITLE
fix(external-endpoint): align model mapping column order on detail page (NEU-414)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -245,7 +245,7 @@
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",
   "src/pages/external-endpoints/edit.tsx": "e6fdd4684d41f910da1e2ca2ddf4cbd9",
   "src/pages/external-endpoints/list.tsx": "1b58592b9a94b4853e701d9358b4394e",
-  "src/pages/external-endpoints/show.tsx": "e054f192830c0a86929efd11a260f6ae",
+  "src/pages/external-endpoints/show.tsx": "4c394bfbcc85bcb87e30e3342d694427",
   "src/domains/external-endpoint/types.ts": "919dea3f18a6795e2dde24e4a460a89e",
   "src/domains/external-endpoint/hooks/use-external-endpoint-form.tsx": "62844d476c4b1eb1d601245fce39c4a1",
   "src/domains/external-endpoint/components/CurlExample.tsx": "5183a8958c58627f671b3d80313f016f",

--- a/src/pages/external-endpoints/show.tsx
+++ b/src/pages/external-endpoints/show.tsx
@@ -99,10 +99,10 @@ export const ExternalEndpointsShow = () => {
                       <thead>
                         <tr className="border-b bg-muted/50">
                           <th className="w-1/2 px-4 py-2 text-left font-medium">
-                            {t("external_endpoints.fields.exposedModelName")}
+                            {t("external_endpoints.fields.upstreamModelName")}
                           </th>
                           <th className="w-1/2 px-4 py-2 text-left font-medium">
-                            {t("external_endpoints.fields.upstreamModelName")}
+                            {t("external_endpoints.fields.exposedModelName")}
                           </th>
                         </tr>
                       </thead>
@@ -114,10 +114,10 @@ export const ExternalEndpointsShow = () => {
                               className="border-b last:border-0"
                             >
                               <td className="px-4 py-2">
-                                <code className="text-sm">{exposed}</code>
+                                <code className="text-sm">{upstreamModel}</code>
                               </td>
                               <td className="px-4 py-2">
-                                <code className="text-sm">{upstreamModel}</code>
+                                <code className="text-sm">{exposed}</code>
                               </td>
                             </tr>
                           ),


### PR DESCRIPTION
## Problem (NEU-414)

The External Endpoint **edit form** and **detail page** display the model-mapping columns in opposite order, which is confusing:

- **Edit form** (`ModelMappingEditor`, set in NEU-401 for the upstream→exposed auto-sync UX): **Upstream Model Name | Exposed Model Name**
- **Detail page** (`show.tsx`): **Exposed Model Name | Upstream Model Name**

## Fix

Swap the detail-page mapping table to **Upstream | Exposed**, matching the edit form. This keeps the editor's auto-sync UX (upstream is the primary input) and makes the column order consistent between editing and viewing.

Only the column order on the detail page changes — no data-model or logic change. The mapping is still `Record<exposed, upstream>`; the cells now render `upstreamModel` then `exposed`.

## Scope

- `src/pages/external-endpoints/show.tsx` — swap the two `<th>` headers and the two `<td>` cells.
- `.i18n-tracker.lock` — re-mark the file reviewed (reuses existing keys `upstreamModelName` / `exposedModelName`, no new strings).

## Verification

- `tsc -b` typecheck, biome, depcruise, knip all pass (pre-commit hooks).
- Pure presentational reorder of existing i18n keys / bound values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)