### PR TITLE
fix(calendar): align range-picker nav and fix range corner rounding (NEUTREE-INFERENCE-TRACE-6)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -298,5 +298,5 @@
   "src/pages/model-usage/list.tsx": "bd680f4817e9b80433c50e2b185affbd",
   "src/domains/api-key/hooks/use-usage-by-dimension.ts": "180fbbc1c2b848f8b9d4172c85835344",
   "src/domains/api-key/hooks/use-workspace-usage.ts": "5f008c9efecb5f75398ae4fb67414d69",
-  "src/components/ui/calendar.tsx": "67b3c096201e6f030437e9127db7c586"
+  "src/components/ui/calendar.tsx": "dfedaf90a75014faab50dfb32b28c5b2"
 }

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -18,41 +18,49 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
-        months: "flex flex-col sm:flex-row gap-2",
+        // `months` is the positioning context for the nav. react-day-picker v10
+        // renders <Nav> here (a sibling of the month), so anchoring the prev/next
+        // buttons to it keeps them inside the calendar caption row instead of
+        // escaping up to the popover.
+        months: "relative flex flex-col sm:flex-row gap-2",
         month: "flex flex-col gap-4",
-        month_caption: "flex justify-center pt-1 relative items-center",
+        month_caption: "flex h-7 items-center justify-center",
         caption_label: "text-sm font-medium",
-        nav: "flex items-center gap-1",
+        nav: "absolute inset-x-0 top-0 flex h-7 items-center justify-between px-1",
         button_previous: cn(
           buttonVariants({ variant: "outline" }),
-          "absolute left-1 top-1 size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
         ),
         button_next: cn(
           buttonVariants({ variant: "outline" }),
-          "absolute right-1 top-1 size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+          "size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
         ),
         month_grid: "w-full border-collapse space-y-1",
         weekdays: "flex",
         weekday:
           "text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]",
         week: "flex w-full mt-2",
+        // In v10 the range/selected/today modifier classes land on the day <td>
+        // (not the button), so rounding is applied here directly. Round only the
+        // outer ends of the range — including a row's first/last cell so a window
+        // that wraps weeks stays clean.
         day: cn(
           "relative p-0 text-center text-sm focus-within:relative focus-within:z-20",
-          "[&:has([aria-selected])]:bg-accent",
-          "[&:has([aria-selected].range-start)]:rounded-l-md",
-          "[&:has([aria-selected].range-end)]:rounded-r-md",
+          "[&[aria-selected]:first-child]:rounded-l-md [&[aria-selected]:last-child]:rounded-r-md",
         ),
         day_button: cn(
           buttonVariants({ variant: "ghost" }),
           "size-8 p-0 font-normal aria-selected:opacity-100",
         ),
-        range_start: "range-start",
-        range_end: "range-end",
-        range_middle:
-          "aria-selected:bg-accent aria-selected:text-accent-foreground rounded-none",
+        range_start: "rounded-l-md",
+        range_end: "rounded-r-md",
+        range_middle: "bg-accent text-accent-foreground",
         selected:
           "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        today: "bg-accent text-accent-foreground rounded-md",
+        // Only style "today" when it isn't part of the selection, otherwise its
+        // full rounding/background fights the range boundary styles.
+        today:
+          "[&:not([aria-selected])]:bg-accent [&:not([aria-selected])]:text-accent-foreground [&:not([aria-selected])]:rounded-md",
         outside: "text-muted-foreground opacity-50",
         disabled: "text-muted-foreground opacity-50",
         hidden: "invisible",


### PR DESCRIPTION
## Problem

On the inference (AI traces) page, the `DateRangePicker` calendar popover had two visual issues:

1. **Header not aligned / overlapping** — the prev/next nav arrows overlapped the quick-preset row (最近 7 天 / 30 天 / 90 天) at the top of the popover.
2. **Range highlight corners wrong** — the rounded corners of the selected date range were off (most visibly on *today*, the range end).

## Root cause (react-day-picker v10)

- The nav buttons were `absolute … top-1` but no ancestor was positioned, so they anchored to the Radix `PopoverContent` and landed at the top of the popover, over the preset row.
- Range rounding used `[&:has([aria-selected].range-start)]` / `.range-end` descendant selectors. In rdp v10 the `range-start` / `range-end` / `today` / `selected` modifier classes are applied to the day `<td>` itself (not a descendant), so those selectors never matched — only `today` (which carried its own `rounded-md`) ended up rounded, on all four corners, breaking the range-end corner.

## Fix (`src/components/ui/calendar.tsx`)

- Make `months` the positioning context (`relative`) and lay the `nav` across the caption row (`absolute inset-x-0 top-0 … justify-between`), so the arrows flank the month label.
- Apply range rounding/colors directly on the day cell where v10 puts the modifier classes: round only the range ends (incl. a row's first/last cell so a window that wraps weeks stays clean), and suppress the `today` style when the day is part of the selection.

## Verification

Rendered the picker (popover open, range Jun 6–12, today = Jun 12) in a sandbox and screenshotted: nav arrows align in the caption row with no overlap, and the range has clean rounded ends. `tsc -b` and `biome check` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)