### PR TITLE
ci: add UI nightly tag workflows

### DIFF
--- a/.github/workflows/cleanup-nightly.yaml
+++ b/.github/workflows/cleanup-nightly.yaml
@@ -1,0 +1,93 @@
+name: Cleanup Nightly Tags
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+    inputs:
+      retention_days:
+        description: "Keep nightly tags for N days"
+        required: false
+        default: "7"
+        type: string
+      dry_run:
+        description: "Only print what would be deleted"
+        required: false
+        default: "false"
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    env:
+      RETENTION_DAYS: ${{ github.event.inputs.retention_days }}
+      DRY_RUN: ${{ github.event.inputs.dry_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Delete old nightly git tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          RETENTION_DAYS="${RETENTION_DAYS:-7}"
+          DRY_RUN="${DRY_RUN:-false}"
+          CUTOFF_DATE=$(date -u -d "${RETENTION_DAYS} days ago" +%Y%m%d)
+          echo "Cutoff date: ${CUTOFF_DATE} (keep last ${RETENTION_DAYS} days)"
+          git fetch --tags --prune
+          mapfile -t TAGS < <(git tag -l '*-nightly-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]')
+          for tag in "${TAGS[@]}"; do
+            if [[ "${tag}" =~ -nightly-([0-9]{8})$ ]]; then
+              tag_date="${BASH_REMATCH[1]}"
+              if [[ "${tag_date}" < "${CUTOFF_DATE}" ]]; then
+                echo "Delete tag ${tag}"
+                if [[ "${DRY_RUN}" != "true" ]]; then
+                  git tag -d "${tag}"
+                  git push origin ":refs/tags/${tag}"
+                fi
+              fi
+            fi
+          done
+          echo "CUTOFF_DATE=${CUTOFF_DATE}" >> "$GITHUB_ENV"
+
+      - name: Delete old nightly GitHub releases
+        uses: actions/github-script@v8
+        env:
+          DRY_RUN: ${{ env.DRY_RUN }}
+          CUTOFF_DATE: ${{ env.CUTOFF_DATE }}
+        with:
+          script: |
+            const dryRun = process.env.DRY_RUN === 'true';
+            const cutoff = process.env.CUTOFF_DATE;
+            const nightlyRe = /-nightly-(\d{8})$/;
+            let page = 1;
+            while (true) {
+              const { data: releases } = await github.rest.repos.listReleases({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+                page,
+              });
+              if (!releases.length) break;
+              for (const release of releases) {
+                const match = nightlyRe.exec(release.tag_name || '');
+                if (!match) continue;
+                const tagDate = match[1];
+                if (tagDate < cutoff) {
+                  core.info(`Delete release ${release.id} (${release.tag_name})`);
+                  if (!dryRun) {
+                    await github.rest.repos.deleteRelease({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      release_id: release.id,
+                    });
+                  }
+                }
+              }
+              page += 1;
+            }

--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -2,7 +2,7 @@ name: Create Nightly Tag
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 22 * * *"
   workflow_dispatch:
 
 permissions:
@@ -22,7 +22,7 @@ jobs:
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
       - name: Create Nightly Tag
         run: |
-          DATE=$(date +'%Y%m%d')
+          DATE=$(TZ=Asia/Shanghai date +'%Y%m%d')
           TAG="v1.1.0-nightly-${DATE}"
           git tag "${TAG}" -m "${TAG}"
           git push origin "${TAG}"

--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -1,4 +1,4 @@
-name: Create Nightly Tag
+name: create nightly tag
 
 on:
   schedule:

--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -22,7 +22,7 @@ jobs:
           git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
       - name: Create Nightly Tag
         run: |
-          DATE=$(TZ=Asia/Shanghai date +'%Y%m%d')
+          DATE=$(date +'%Y%m%d')
           TAG="v1.1.0-nightly-${DATE}"
           git tag "${TAG}" -m "${TAG}"
           git push origin "${TAG}"

--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -1,0 +1,28 @@
+name: Create Nightly Tag
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  create_daily_tag:
+    runs-on: ubuntu-latest
+    name: Create Nightly Tag
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Configure Git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+      - name: Create Nightly Tag
+        run: |
+          DATE=$(date +'%Y%m%d')
+          TAG="v1.1.0-nightly-${DATE}"
+          git tag "${TAG}" -m "${TAG}"
+          git push origin "${TAG}"


### PR DESCRIPTION
## Summary
- Add scheduled UI nightly tag creation for v1.1.0 using `v1.1.0-nightly-YYYYMMDD`.
- Run the UI tag job at 22:00 UTC so the UI tag is created before the downstream neutree and neutree-enterprise nightly jobs.
- Add nightly tag and release cleanup with configurable retention and dry-run support.
- Keep internal orchestration notes out of the commit.

## Test Plan
### Unit test
- Not run. Workflow-only change; no application code changed.

### DB test
- Not run. No database changes.

### E2E test
- Not required for this workflow-only change.

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/daily-build.yaml .github/workflows/cleanup-nightly.yaml`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: ok" }' .github/workflows/daily-build.yaml .github/workflows/cleanup-nightly.yaml`
- `git diff origin/main..HEAD --check`