### PR TITLE
fix(ai-traces): show traces for the All workspaces selection

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -290,7 +290,7 @@
   "src/domains/external-endpoint/components/TestConnectivityButton.tsx": "c4c97cc62ad41f004d08238c569e0054",
   "src/domains/external-endpoint/hooks/use-test-connectivity.ts": "71fed924f6125ed6cfbbc8891b96c282",
   "src/domains/external-endpoint/hooks/use-model-mapping-rows.ts": "8acf1e3078e104a09eaa7ce60bb41b56",
-  "src/pages/ai-traces/list.tsx": "681afba0c025cf9b88755d193edc7b25",
+  "src/pages/ai-traces/list.tsx": "1865463d98f0fdbee7b7e9fb5419a486",
   "src/pages/ai-traces/components/TraceDetailDrawer.tsx": "c88cb4acc0d3e138398bf7a18f4c4fd2",
   "src/pages/ai-traces/components/TraceStatsChart.tsx": "72d803582532b53b21c0bce895d0142f",
   "src/foundation/lib/api/ai-traces.ts": "d989ddca41c00c96b1803f69be83c0fc",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1172,6 +1172,7 @@
 		},
 		"columns": {
 			"time": "Time",
+			"workspace": "Workspace",
 			"endpoint": "Endpoint",
 			"app": "App",
 			"model": "Model",

--- a/src/pages/ai-traces/list.tsx
+++ b/src/pages/ai-traces/list.tsx
@@ -29,6 +29,7 @@ import {
 import { ListPage } from "@/foundation/components/ListPage";
 import { Loader } from "@/foundation/components/Loader";
 import Timestamp from "@/foundation/components/Timestamp";
+import { ALL_WORKSPACES } from "@/foundation/hooks/use-workspace";
 import { type AITrace, fetchAITraces } from "@/foundation/lib/api/ai-traces";
 import { useTranslation } from "@/foundation/lib/i18n";
 import { formatTokens } from "@/foundation/lib/unit";
@@ -42,6 +43,10 @@ export const AITracesList = () => {
   const { t } = useTranslation();
   const { params } = useParsed();
   const workspace = (params?.workspace as string) ?? "";
+  // "All workspaces" aggregates traces across workspaces, so show a workspace
+  // column to disambiguate rows (it is redundant on a single-workspace view).
+  const isAllWorkspaces = workspace === ALL_WORKSPACES;
+  const colSpan = isAllWorkspaces ? 11 : 10;
 
   const [endpointName, setEndpointName] = useState("");
   const [endpointType, setEndpointType] = useState<string>("");
@@ -248,6 +253,11 @@ export const AITracesList = () => {
               <TableHead className="w-[180px]">
                 {t("ai_traces.columns.time")}
               </TableHead>
+              {isAllWorkspaces && (
+                <TableHead className="w-[140px]">
+                  {t("ai_traces.columns.workspace")}
+                </TableHead>
+              )}
               <TableHead>{t("ai_traces.columns.endpoint")}</TableHead>
               <TableHead className="w-[120px]">
                 {t("ai_traces.columns.app")}
@@ -276,7 +286,7 @@ export const AITracesList = () => {
           <TableBody>
             {isLoading && (
               <TableRow>
-                <TableCell colSpan={10} className="text-center py-12">
+                <TableCell colSpan={colSpan} className="text-center py-12">
                   <Loader className="mx-auto w-8 text-muted-foreground" />
                 </TableCell>
               </TableRow>
@@ -284,7 +294,7 @@ export const AITracesList = () => {
             {!isLoading && items.length === 0 && (
               <TableRow>
                 <TableCell
-                  colSpan={10}
+                  colSpan={colSpan}
                   className="text-center py-12 text-muted-foreground"
                 >
                   {t("ai_traces.empty")}
@@ -303,6 +313,13 @@ export const AITracesList = () => {
                     format="YYYY-MM-DD HH:mm:ss"
                   />
                 </TableCell>
+                {isAllWorkspaces && (
+                  <TableCell className="text-sm truncate max-w-[140px]">
+                    {row.workspace || (
+                      <span className="text-muted-foreground">-</span>
+                    )}
+                  </TableCell>
+                )}
                 <TableCell>
                   <div className="text-sm">{row.endpoint_name || "-"}</div>
                   <div className="text-xs text-muted-foreground">

--- a/src/pages/ai-traces/list.tsx
+++ b/src/pages/ai-traces/list.tsx
@@ -303,7 +303,9 @@ export const AITracesList = () => {
             )}
             {items.map((row) => (
               <TableRow
-                key={row.request_id}
+                // request_id is unique only within a workspace; the All view
+                // mixes workspaces, so qualify the key to avoid collisions.
+                key={`${row.workspace}/${row.request_id}`}
                 className="cursor-pointer hover:bg-muted/50"
                 onClick={() => setSelected(row)}
               >


### PR DESCRIPTION
## Problem

The Inference Trace page is a workspaced resource, so the workspace selector shows **All workspaces**. Selecting it set the route param to the UI sentinel `_all_`, which was sent to the trace API (`fetchAITraces` puts the workspace in the URL path) as a literal workspace. The list and the activity chart then came back empty (`workspace:="_all_"` matches nothing).

## Change

Backend companion PR (neutree #416) now treats `_all_` as a cross-workspace aggregate scoped to the workspaces the caller may read. On the UI side:

- Detect the `_all_` selection (`workspace === ALL_WORKSPACES`).
- Render an extra **Workspace** column — only in the All-workspaces view — so rows from different workspaces are distinguishable; it stays hidden on a single-workspace view where it would be redundant.
- `colSpan` of the loading / empty rows tracks the column count.
- Add the `ai_traces.columns.workspace` locale key.

The detail drawer already fetches a single trace by the row's concrete `workspace`, so it works unchanged for rows surfaced in the aggregate view.

## Testing

- `yarn typecheck` (`tsc -b`) — pass.
- `biome lint` on changed files — clean.

Depends on neutree#416 for the aggregate to actually return data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)