### PR TITLE
i18n(en): rename Inference Trace to Access Log

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1150,8 +1150,8 @@
 		"title": "Observability"
 	},
 	"ai_traces": {
-		"title": "Inference Trace",
-		"empty": "No traces in the selected window.",
+		"title": "Access Log",
+		"empty": "No access logs in the selected window.",
 		"refresh": "Refresh",
 		"stats": {
 			"title": "Requests (last 7 days)",
@@ -1184,7 +1184,7 @@
 			"finishReason": "Finish"
 		},
 		"detail": {
-			"title": "Trace detail",
+			"title": "Access log detail",
 			"time": "Time",
 			"status": "Status",
 			"endpoint": "Endpoint",
@@ -1243,7 +1243,7 @@
 		"pull": "Pull",
 		"system_admin": "System Admin",
 		"read-credentials": "Read Credentials",
-		"trace-read": "Trace Read",
+		"trace-read": "Access Log Read",
 		"usage-read": "Usage Read",
 		"requiredBy": "Required by: {{actions}}"
 	},


### PR DESCRIPTION
## What

Rename the "Inference Trace" feature copy to "Access Log" (访问日志) per NEUTREE-INFERENCE-TRACE-7.

## Changes

- Nav/page title: `Inference Trace` → `Access Log`
- Empty state: `No traces in the selected window.` → `No access logs in the selected window.`
- Detail drawer title: `Trace detail` → `Access log detail`
- Permission label `trace-read`: `Trace Read` → `Access Log Read`

Copy-only change; no behavior or key changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)