### PR TITLE
i18n: rename Inference Trace to Access Log

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1150,8 +1150,8 @@
 		"title": "Observability"
 	},
 	"ai_traces": {
-		"title": "Inference Trace",
-		"empty": "No traces in the selected window.",
+		"title": "Access Log",
+		"empty": "No access logs in the selected window.",
 		"refresh": "Refresh",
 		"stats": {
 			"title": "Requests (last 7 days)",
@@ -1184,7 +1184,7 @@
 			"finishReason": "Finish"
 		},
 		"detail": {
-			"title": "Trace detail",
+			"title": "Access log detail",
 			"time": "Time",
 			"status": "Status",
 			"endpoint": "Endpoint",
@@ -1243,7 +1243,7 @@
 		"pull": "Pull",
 		"system_admin": "System Admin",
 		"read-credentials": "Read Credentials",
-		"trace-read": "Trace Read",
+		"trace-read": "Access Log Read",
 		"usage-read": "Usage Read",
 		"requiredBy": "Required by: {{actions}}"
 	},


### PR DESCRIPTION
## What

Rename the user-facing **"Inference Trace"** term to **"Access Log"** in the `ai_traces` feature for clearer copy.

Affected strings:
- `ai_traces.title`: Inference Trace → Access Log
- `ai_traces.empty`: empty-state message
- `ai_traces.detail.title`: detail panel title
- `permissions.trace-read` label: Trace Read → Access Log Read

The i18n key `ai_traces` and the `trace-read` permission key are unchanged — only display copy.

## Why

NEUTREE-INFERENCE-TRACE-7: "Inference Trace" was unclear; "Access Log" better describes the inference request log view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)