### PR TITLE
NEU-478 hide monitor tab for static endpoints

### DIFF
--- a/src/domains/endpoint/hooks/use-endpoint-monitor-panels.test.ts
+++ b/src/domains/endpoint/hooks/use-endpoint-monitor-panels.test.ts
@@ -5,6 +5,7 @@ import { useEndpointMonitorPanels } from "./use-endpoint-monitor-panels";
 type UseHookArgs = {
   clusterType?: string;
   engineType?: string;
+  hasGpuResources?: boolean;
 };
 
 describe("useEndpointMonitorPanels", () => {
@@ -19,7 +20,7 @@ describe("useEndpointMonitorPanels", () => {
 
   it("should return endpoint panel for ssh cluster", () => {
     const { result } = renderHook(() =>
-      useEndpointMonitorPanels({ clusterType: "ssh" }),
+      useEndpointMonitorPanels({ clusterType: "ssh", hasGpuResources: true }),
     );
 
     expect(result.current.panels).toEqual(["endpoint"]);
@@ -30,7 +31,7 @@ describe("useEndpointMonitorPanels", () => {
 
   it("should return vllm panel for vllm engine", () => {
     const { result } = renderHook(() =>
-      useEndpointMonitorPanels({ engineType: "vllm" }),
+      useEndpointMonitorPanels({ engineType: "vllm", hasGpuResources: true }),
     );
 
     expect(result.current.panels).toEqual(["vllm"]);
@@ -41,7 +42,7 @@ describe("useEndpointMonitorPanels", () => {
 
   it("should return sglang panel for sglang engine", () => {
     const { result } = renderHook(() =>
-      useEndpointMonitorPanels({ engineType: "sglang" }),
+      useEndpointMonitorPanels({ engineType: "sglang", hasGpuResources: true }),
     );
 
     expect(result.current.panels).toEqual(["sglang"]);
@@ -52,7 +53,11 @@ describe("useEndpointMonitorPanels", () => {
 
   it("should return both panels for ssh cluster with vllm engine", () => {
     const { result } = renderHook(() =>
-      useEndpointMonitorPanels({ clusterType: "ssh", engineType: "vllm" }),
+      useEndpointMonitorPanels({
+        clusterType: "ssh",
+        engineType: "vllm",
+        hasGpuResources: true,
+      }),
     );
 
     expect(result.current.panels).toEqual(["vllm", "endpoint"]);
@@ -63,7 +68,11 @@ describe("useEndpointMonitorPanels", () => {
 
   it("should return both panels for ssh cluster with sglang engine", () => {
     const { result } = renderHook(() =>
-      useEndpointMonitorPanels({ clusterType: "ssh", engineType: "sglang" }),
+      useEndpointMonitorPanels({
+        clusterType: "ssh",
+        engineType: "sglang",
+        hasGpuResources: true,
+      }),
     );
 
     expect(result.current.panels).toEqual(["sglang", "endpoint"]);
@@ -74,7 +83,11 @@ describe("useEndpointMonitorPanels", () => {
 
   it("should allow user to select panel", () => {
     const { result } = renderHook(() =>
-      useEndpointMonitorPanels({ clusterType: "ssh", engineType: "vllm" }),
+      useEndpointMonitorPanels({
+        clusterType: "ssh",
+        engineType: "vllm",
+        hasGpuResources: true,
+      }),
     );
 
     expect(result.current.selectedPanel).toBe("vllm");
@@ -89,7 +102,11 @@ describe("useEndpointMonitorPanels", () => {
   it("should fallback to first panel if selected panel is invalid", () => {
     const { result, rerender } = renderHook(
       ({ clusterType, engineType }: UseHookArgs) =>
-        useEndpointMonitorPanels({ clusterType, engineType }),
+        useEndpointMonitorPanels({
+          clusterType,
+          engineType,
+          hasGpuResources: true,
+        }),
       {
         initialProps: { clusterType: "ssh", engineType: "vllm" } as UseHookArgs,
       },
@@ -110,7 +127,11 @@ describe("useEndpointMonitorPanels", () => {
   it("should fallback to first panel when sglang panel is no longer available", () => {
     const { result, rerender } = renderHook(
       ({ clusterType, engineType }: UseHookArgs) =>
-        useEndpointMonitorPanels({ clusterType, engineType }),
+        useEndpointMonitorPanels({
+          clusterType,
+          engineType,
+          hasGpuResources: true,
+        }),
       {
         initialProps: {
           clusterType: "ssh",
@@ -129,5 +150,20 @@ describe("useEndpointMonitorPanels", () => {
 
     // Should fallback to first available panel
     expect(result.current.selectedPanel).toBe("endpoint");
+  });
+
+  it("should hide monitor panels when endpoint does not request GPU resources", () => {
+    const { result } = renderHook(() =>
+      useEndpointMonitorPanels({
+        clusterType: "ssh",
+        engineType: "vllm",
+        hasGpuResources: false,
+      }),
+    );
+
+    expect(result.current.panels).toEqual([]);
+    expect(result.current.selectedPanel).toBeNull();
+    expect(result.current.showMonitorTab).toBe(false);
+    expect(result.current.showSelector).toBe(false);
   });
 });

--- a/src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts
+++ b/src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts
@@ -6,6 +6,7 @@ export type EndpointMonitorPanelType = "endpoint" | "vllm" | "sglang";
 interface UseEndpointMonitorPanelsProps {
   clusterType?: string;
   engineType?: string;
+  hasGpuResources?: boolean;
 }
 
 /**
@@ -14,8 +15,13 @@ interface UseEndpointMonitorPanelsProps {
 export const useEndpointMonitorPanels = ({
   clusterType,
   engineType,
+  hasGpuResources,
 }: UseEndpointMonitorPanelsProps) => {
   const panels = useMemo(() => {
+    if (!hasGpuResources) {
+      return [];
+    }
+
     const list: EndpointMonitorPanelType[] = [];
     // Rule 1: If engine is vllm, always have vllm related panels (default for SSH)
     if (engineType === "vllm") {
@@ -30,7 +36,7 @@ export const useEndpointMonitorPanels = ({
       list.push("endpoint");
     }
     return list;
-  }, [clusterType, engineType]);
+  }, [clusterType, engineType, hasGpuResources]);
 
   const [userSelectedPanel, setUserSelectedPanel] =
     useState<EndpointMonitorPanelType | null>(null);

--- a/src/pages/endpoints/show.tsx
+++ b/src/pages/endpoints/show.tsx
@@ -146,6 +146,7 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
   const clusterType = clusterData?.data?.[0]?.spec?.type;
   const isSSHCluster = clusterType === "ssh";
   const shouldShowRayDashboard = isSSHCluster;
+  const hasGpuResources = Boolean(record?.spec.resources?.gpu);
 
   const {
     panels,
@@ -156,6 +157,7 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
   } = useEndpointMonitorPanels({
     clusterType,
     engineType: record?.spec.engine.engine,
+    hasGpuResources,
   });
 
   const { deployments } = useEndpointLogSources(record ?? null);


### PR DESCRIPTION
## Summary
- hide Endpoint Monitor panels unless the endpoint requests GPU resources
- pass endpoint GPU resource presence from the detail page into monitor panel selection
- add coverage for SSH vLLM endpoints without GPU resources

## Verification
- sandbox: yarn test src/domains/endpoint/hooks/use-endpoint-monitor-panels.test.ts
- sandbox: yarn typecheck
- sandbox: yarn biome lint src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts src/domains/endpoint/hooks/use-endpoint-monitor-panels.test.ts src/pages/endpoints/show.tsx

## Notes
- sandbox: yarn lint still fails on existing unrelated diagnostics, including tools/check-i18n-keys.cjs noAssignInExpressions and src/foundation/providers/data-provider/utils/handle-error.ts missing parseInt radix.