### PR TITLE
fix: show allocated endpoint resources from status

### DIFF
--- a/src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx
+++ b/src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx
@@ -6,25 +6,10 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-const vgpuRequestedResources = {
-  cpu: 2,
-  memory: 8,
-  gpu: null,
-  accelerator: {
-    type: "nvidia_gpu",
-    product: "Tesla-T4",
-    virtualization: {
-      memory_mib: 8192,
-      core_percent: 0,
-    },
-  },
-};
-
 describe("EndpointRuntimeResourcesCard", () => {
   it("renders virtual allocated resource summary and replica groups", () => {
     const { container } = render(
       <EndpointRuntimeResourcesCard
-        requestedResources={vgpuRequestedResources}
         resources={{
           summary: {
             products: {
@@ -109,26 +94,14 @@ describe("EndpointRuntimeResourcesCard", () => {
 
   it("renders nothing when runtime resources are empty", () => {
     const { container } = render(
-      <EndpointRuntimeResourcesCard
-        requestedResources={vgpuRequestedResources}
-        resources={null}
-      />,
+      <EndpointRuntimeResourcesCard resources={null} />,
     );
     expect(container.childElementCount).toBe(0);
   });
 
-  it("renders nothing for full-card resources", () => {
+  it("renders allocated resources when status resources are present", () => {
     const { container } = render(
       <EndpointRuntimeResourcesCard
-        requestedResources={{
-          cpu: 2,
-          memory: 8,
-          gpu: null,
-          accelerator: {
-            type: "nvidia_gpu",
-            product: "Tesla-T4",
-          },
-        }}
         resources={{
           summary: {
             products: {
@@ -157,6 +130,10 @@ describe("EndpointRuntimeResourcesCard", () => {
         }}
       />,
     );
-    expect(container.childElementCount).toBe(0);
+    expect(container.firstElementChild?.className).toContain("border-t");
+    expect(
+      screen.getByText("endpoints.sections.allocatedResources"),
+    ).toBeTruthy();
+    expect(screen.getByText("1 replica / 1 allocated card")).toBeTruthy();
   });
 });

--- a/src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx
+++ b/src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx
@@ -5,14 +5,11 @@ import {
   getEndpointReplicaResourceGroups,
   getEndpointResourceSummaryRows,
 } from "@/domains/endpoint/lib/resource-status";
-import { hasVgpuResources } from "@/domains/endpoint/lib/vgpu";
 import { formatMiBAsGiB, formatToDecimal } from "@/foundation/lib/unit";
 import { cn } from "@/foundation/lib/utils";
 import type { EndpointResourceStatus } from "@/foundation/types/resource-types";
-import type { ResourceSpec } from "@/foundation/types/serving-types";
 
 type EndpointRuntimeResourcesCardProps = {
-  requestedResources: ResourceSpec | null | undefined;
   resources: EndpointResourceStatus | null | undefined;
 };
 
@@ -49,14 +46,9 @@ const ResourceValue = ({
 );
 
 export default function EndpointRuntimeResourcesCard({
-  requestedResources,
   resources,
 }: EndpointRuntimeResourcesCardProps) {
   const { t } = useTranslation();
-
-  if (!hasVgpuResources(requestedResources)) {
-    return null;
-  }
 
   const summaryRows = getEndpointResourceSummaryRows(resources);
   const replicaGroups = getEndpointReplicaResourceGroups(resources);

--- a/src/pages/endpoints/show.tsx
+++ b/src/pages/endpoints/show.tsx
@@ -331,7 +331,6 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
                 </ShowPage.Row>
               </div>
               <EndpointRuntimeResourcesCard
-                requestedResources={record.spec.resources}
                 resources={record.status?.resources}
               />
             </CardContent>


### PR DESCRIPTION
## Summary
- render Endpoint allocated resources based on status.resources content instead of requested resource vGPU heuristics
- update runtime resources card tests to cover rendering whenever allocated status resources are present

## Verification
- yarn test src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx src/domains/endpoint/lib/resource-status.test.ts
- yarn typecheck
- yarn biome lint src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx src/pages/endpoints/show.tsx