### PR TITLE
feat(api-key): validate limit fields as positive integers

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -311,8 +311,8 @@
   "src/domains/cluster/lib/accelerator-virtualization.ts": "24f5619a2206dfc0b1da6757428fb149",
   "src/domains/api-key/components/ApiKeyLimitsCard.tsx": "7ba4bf6ffa0e80a47d242903b68fcadd",
   "src/domains/api-key/components/ApiKeyPerformanceCard.tsx": "986c799c7c0ca0993eb7c99ae3880a12",
-  "src/domains/api-key/components/ApiKeyPolicyFields.tsx": "a497e28db1b73d61bb1e4991b507eac4",
+  "src/domains/api-key/components/ApiKeyPolicyFields.tsx": "567c9e880ab320747a52f36f0e07e245",
   "src/domains/api-key/components/ApiKeyRankingOverview.tsx": "195d9f1d66efb631da3a763c2ad8da61",
   "src/domains/api-key/components/ModelMultiSelect.tsx": "7cc524720fdcadde0d72f3cd49afe1bb",
-  "src/domains/api-key/hooks/use-api-key-policy.ts": "670a24db6c6c96a2c4478f671a4ab73d"
+  "src/domains/api-key/hooks/use-api-key-policy.ts": "3ad79a753e3852f99adc69e13891ccf1"
 }

--- a/src/domains/api-key/components/ApiKeyPolicyFields.tsx
+++ b/src/domains/api-key/components/ApiKeyPolicyFields.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { ModelMultiSelect } from "@/domains/api-key/components/ModelMultiSelect";
 import {
+  isPositiveIntLimit,
   QUOTA_PERIODS,
   useWorkspaceModels,
 } from "@/domains/api-key/hooks/use-api-key-policy";
@@ -28,6 +29,12 @@ export const ApiKeyPolicyFields = ({
   const selectedModels = ((form.watch("models") as { value: string }[]) ?? [])
     .map((m) => m.value)
     .filter(Boolean);
+  // Each numeric limit is optional, but a provided value must be a positive
+  // integer (rejects 0 / negatives / decimals) so it can't be silently dropped.
+  const positiveIntRule = {
+    validate: (v: string) =>
+      isPositiveIntLimit(v) || t("api_keys.limits.invalidPositiveInt"),
+  };
 
   return (
     <div className="space-y-3">
@@ -45,10 +52,11 @@ export const ApiKeyPolicyFields = ({
               {...form}
               name="quota_limit"
               label={t("api_keys.limits.tokenLimit")}
+              rules={positiveIntRule}
             >
               <Input
                 type="number"
-                min={0}
+                min={1}
                 placeholder={t("api_keys.limits.optional")}
               />
             </FormFieldGroup>
@@ -78,19 +86,29 @@ export const ApiKeyPolicyFields = ({
 
         <div className="flex items-end gap-2">
           <div className="flex-1">
-            <FormFieldGroup {...form} name="rps" label={t("api_keys.limits.rps")}>
+            <FormFieldGroup
+              {...form}
+              name="rps"
+              label={t("api_keys.limits.rps")}
+              rules={positiveIntRule}
+            >
               <Input
                 type="number"
-                min={0}
+                min={1}
                 placeholder={t("api_keys.limits.optional")}
               />
             </FormFieldGroup>
           </div>
           <div className="flex-1">
-            <FormFieldGroup {...form} name="rpm" label={t("api_keys.limits.rpm")}>
+            <FormFieldGroup
+              {...form}
+              name="rpm"
+              label={t("api_keys.limits.rpm")}
+              rules={positiveIntRule}
+            >
               <Input
                 type="number"
-                min={0}
+                min={1}
                 placeholder={t("api_keys.limits.optional")}
               />
             </FormFieldGroup>
@@ -100,10 +118,11 @@ export const ApiKeyPolicyFields = ({
               {...form}
               name="concurrency"
               label={t("api_keys.limits.concurrency")}
+              rules={positiveIntRule}
             >
               <Input
                 type="number"
-                min={0}
+                min={1}
                 placeholder={t("api_keys.limits.optional")}
               />
             </FormFieldGroup>

--- a/src/domains/api-key/hooks/use-api-key-policy.test.ts
+++ b/src/domains/api-key/hooks/use-api-key-policy.test.ts
@@ -3,10 +3,30 @@ import type { ApiKeyLimits } from "@/domains/api-key/types";
 import {
   apiKeyPolicyDefaults,
   buildApiKeyLimits,
+  isPositiveIntLimit,
   limitsToForm,
   rateSummary,
   summarizeApiKeyLimits,
 } from "./use-api-key-policy";
+
+describe("isPositiveIntLimit", () => {
+  it("treats empty / whitespace as valid (optional, unset)", () => {
+    expect(isPositiveIntLimit("")).toBe(true);
+    expect(isPositiveIntLimit("   ")).toBe(true);
+  });
+
+  it("accepts positive integers", () => {
+    expect(isPositiveIntLimit("1")).toBe(true);
+    expect(isPositiveIntLimit("500000")).toBe(true);
+  });
+
+  it("rejects zero, negatives, decimals and non-numeric input", () => {
+    expect(isPositiveIntLimit("0")).toBe(false);
+    expect(isPositiveIntLimit("-1")).toBe(false);
+    expect(isPositiveIntLimit("1.5")).toBe(false);
+    expect(isPositiveIntLimit("abc")).toBe(false);
+  });
+});
 
 describe("buildApiKeyLimits", () => {
   it("emits an empty object when all limits are empty", () => {

--- a/src/domains/api-key/hooks/use-api-key-policy.ts
+++ b/src/domains/api-key/hooks/use-api-key-policy.ts
@@ -41,6 +41,18 @@ const num = (s: string): number | undefined => {
   return Number(v);
 };
 
+// Validate an optional positive-integer limit field. Empty = unset (valid); any
+// provided value must be a positive integer, so 0 / negatives / decimals /
+// non-numeric input are rejected at the form rather than silently dropped (which
+// would turn an intended "0 = disable" into "no limit"). Mirrors the backend
+// validate_api_key_limits RPC guard.
+export const isPositiveIntLimit = (s: string): boolean => {
+  const v = String(s ?? "").trim();
+  if (v === "") return true;
+  const n = Number(v);
+  return Number.isInteger(n) && n > 0;
+};
+
 // Build the limits object from the form. `disabled` is preserved separately (it
 // is toggled via its own action, not this form), so callers pass it through.
 export function buildApiKeyLimits(

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -941,6 +941,7 @@
 			"modelsSelected": "{{count}} model(s) selected",
 			"noModels": "No models available",
 			"tokensUnit": "tokens",
+			"invalidPositiveInt": "Must be a positive integer",
 			"none": "No limits set for this key.",
 			"consumptionTitle": "Resource consumption",
 			"remainingLabel": "remaining",


### PR DESCRIPTION
## What

Validate the API key numeric limit fields (token quota, RPS, RPM, concurrency) as
positive integers in the create + edit forms.

Previously these fields silently dropped non-positive values, so entering `0` to
disable a limit turned it into "no limit" with no feedback. Now an invalid value
blocks submit with an inline error instead of being silently discarded.

## Changes

- `isPositiveIntLimit(string)` in `use-api-key-policy.ts`: empty = unset (valid);
  any provided value must be a positive integer (rejects `0`, negatives, decimals,
  non-numeric). Mirrors the backend `validate_api_key_limits` guard.
- `ApiKeyPolicyFields`: attach a `validate` rule to `quota_limit` / `rps` / `rpm` /
  `concurrency` so React Hook Form blocks submit and renders the inline message
  (`api_keys.limits.invalidPositiveInt`); number inputs `min={1}`.
- New i18n key `api_keys.limits.invalidPositiveInt`.
- Unit tests for `isPositiveIntLimit`.

## Verification

`yarn typecheck`, `dep-check`, `knip`, i18n-tracker scan + `check-i18n-keys`, and
`vitest` (api-key policy suite, 15 tests) all pass.

Companion backend PR adds the authoritative RPC-layer validation (neutree-ai/neutree#439).
