### PR TITLE
fix: remove resource plan header badge

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -239,7 +239,7 @@
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "1d23880bb99098fadec0cc37dbc0e947",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "1fbcace2caf7b431c0b95451a60eedd8",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "6e96c2e8b7985bc14c31deca286be7cb",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "b2466d871f8436202bb1e6011ec61ecd",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -239,7 +239,7 @@
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "1d23880bb99098fadec0cc37dbc0e947",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "6e96c2e8b7985bc14c31deca286be7cb",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "beb0706ab0538a477930b7b080ee5a03",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "b2466d871f8436202bb1e6011ec61ecd",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -2108,6 +2108,11 @@ describe("useEndpointForm", () => {
       expect(getAcceleratorCardText()).toContain(
         "endpoints.messages.vgpuResourcesInsufficient",
       );
+      expect(
+        within(screen.getByTestId("endpoint-resource-plan-header")).queryByText(
+          "endpoints.messages.vgpuResourcesInsufficient",
+        ),
+      ).toBeNull();
     });
 
     it("shows configured vGPU core request when available core is zero", async () => {
@@ -2188,6 +2193,11 @@ describe("useEndpointForm", () => {
           "endpoints.messages.fullGpuResourcesInsufficient",
         );
       });
+      expect(
+        within(screen.getByTestId("endpoint-resource-plan-header")).queryByText(
+          "endpoints.messages.fullGpuResourcesInsufficient",
+        ),
+      ).toBeNull();
     });
 
     it("checks only additional full cards while editing an existing endpoint", async () => {

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -1961,6 +1961,11 @@ describe("useEndpointForm", () => {
       expect(
         screen.queryByTestId("endpoint-resource-summary-strip"),
       ).toBeNull();
+      expect(
+        within(screen.getByTestId("endpoint-resource-plan-header")).queryByText(
+          "endpoints.fields.matchingGpuCards",
+        ),
+      ).toBeNull();
       expect(screen.getByTestId("endpoint-current-request-panel")).toBeTruthy();
       expect(
         screen.getByTestId("endpoint-current-request-grid").className,

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -935,7 +935,10 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                 data-testid="endpoint-resource-plan-card"
                 className="grid overflow-hidden rounded-xl border bg-background shadow-sm"
               >
-                <div className="flex items-start justify-between gap-3 border-b p-4">
+                <div
+                  data-testid="endpoint-resource-plan-header"
+                  className="flex items-start justify-between gap-3 border-b p-4"
+                >
                   <div className="min-w-0">
                     <h3 className="text-base font-semibold">
                       {t("endpoints.sections.resourcePlan")}
@@ -945,27 +948,18 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                     </p>
                   </div>
                   {selectedAccelerator?.type &&
-                    selectedAccelerator?.product && (
+                    selectedAccelerator?.product &&
+                    !(isVgpuAllocationMode
+                      ? isVgpuCapacityExceeded
+                      : isFullGpuCapacityExceeded) && (
                       <Badge
                         variant="outline"
                         className={cn(
                           "shrink-0 font-normal",
-                          getCapacityBadgeClassName(
-                            isVgpuAllocationMode
-                              ? isVgpuCapacityExceeded
-                              : isFullGpuCapacityExceeded,
-                          ),
+                          getCapacityBadgeClassName(false),
                         )}
                       >
-                        {isVgpuAllocationMode
-                          ? isVgpuCapacityExceeded
-                            ? t("endpoints.messages.vgpuResourcesInsufficient")
-                            : t("endpoints.fields.matchingGpuCards")
-                          : isFullGpuCapacityExceeded
-                            ? t(
-                                "endpoints.messages.fullGpuResourcesInsufficient",
-                              )
-                            : t("endpoints.fields.matchingGpuCards")}
+                        {t("endpoints.fields.matchingGpuCards")}
                       </Badge>
                     )}
                 </div>

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -947,21 +947,6 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                       {t("endpoints.descriptions.basicResources")}
                     </p>
                   </div>
-                  {selectedAccelerator?.type &&
-                    selectedAccelerator?.product &&
-                    !(isVgpuAllocationMode
-                      ? isVgpuCapacityExceeded
-                      : isFullGpuCapacityExceeded) && (
-                      <Badge
-                        variant="outline"
-                        className={cn(
-                          "shrink-0 font-normal",
-                          getCapacityBadgeClassName(false),
-                        )}
-                      >
-                        {t("endpoints.fields.matchingGpuCards")}
-                      </Badge>
-                    )}
                 </div>
                 <div
                   data-testid="endpoint-resource-request-grid"


### PR DESCRIPTION
## Issues

The Resource Plan header renders a status badge for the selected GPU/vGPU plan. In shortage cases this duplicates `fullGpuResourcesInsufficient` / `vgpuResourcesInsufficient` from the Current Request area, and in normal cases it shows `Matching Cards`, which keeps the same duplicated status surface in the header.

## Changes

- Remove the Resource Plan header badge entirely, including `Matching Cards`, `fullGpuResourcesInsufficient`, and `vgpuResourcesInsufficient` from that header row.
- Keep the existing Current Request resource shortage warnings unchanged.
- Add regression assertions that the Resource Plan header does not render `Matching Cards`, `vgpuResourcesInsufficient`, or `fullGpuResourcesInsufficient`.

## Test Plan

### Unit test

- `PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$PATH" yarn test src/domains/endpoint/hooks/use-endpoint-form.test.tsx -t "uses the productized resource configuration layout|shows full-card capacity warnings|shows virtual card capacity warnings"`; 3 tests passed.
- `PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$PATH" yarn test src/domains/endpoint/hooks/use-endpoint-form.test.tsx`; 42 tests passed, with existing React act warnings.
- `PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$PATH" yarn typecheck`; passed.
- `node tools/i18n-tracker.cjs`; passed.
- `./node_modules/.bin/biome lint .i18n-tracker.lock src/domains/endpoint/hooks/use-endpoint-form.tsx src/domains/endpoint/hooks/use-endpoint-form.test.tsx`; passed with existing warnings in test lines inherited from `origin/main`.
- `./node_modules/.bin/biome format .i18n-tracker.lock src/domains/endpoint/hooks/use-endpoint-form.tsx src/domains/endpoint/hooks/use-endpoint-form.test.tsx`; passed.
- `git diff --check`; passed.

### DB test

- Not required. This is a UI-only display change with no API, storage, or migration changes.

### E2E test

- Not required. This is a narrow UI-only display change covered by endpoint form regression tests.