### PR TITLE
fix: show resource units in card titles

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -307,7 +307,7 @@
   "src/domains/cluster/components/ClusterComponentStatusList.tsx": "66a9bbcf60d41422b91cc84733a0fe39",
   "src/foundation/lib/gpu-device-resources.ts": "6f359bb109861529aff476affda1be2d",
   "src/foundation/components/GpuDeviceResourcesView.tsx": "59fef5bb066810a55e6c7e82f2f9c1ac",
-  "src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.tsx": "92c8ad14dcce853cb91732c0773196f3",
+  "src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.tsx": "033cdefcb53195738d35b2107bdd6e2b",
   "src/domains/cluster/lib/accelerator-virtualization.ts": "24f5619a2206dfc0b1da6757428fb149",
   "src/domains/api-key/components/ApiKeyLimitsCard.tsx": "7ba4bf6ffa0e80a47d242903b68fcadd",
   "src/domains/api-key/components/ApiKeyPerformanceCard.tsx": "986c799c7c0ca0993eb7c99ae3880a12",

--- a/src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.test.tsx
+++ b/src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { ClusterResourceInfo } from "@/foundation/types/resource-types";
 import { EndpointClusterGpuResourcesPanel } from "./EndpointClusterGpuResourcesPanel";
@@ -23,12 +23,24 @@ const translations: Record<string, string> = {
   "clusters.messages.copyUuidSuccess": "GPU UUID copied",
   "clusters.options.allocated": "Allocated",
   "clusters.options.allGpuProducts": "All GPU Products",
+  "clusters.options.free": "Free",
+  "clusters.options.total": "Total",
   "clusters.options.unhealthy": "Unhealthy",
   "clusters.options.usable": "Usable",
+  "clusters.options.used": "Used",
+  "endpoints.fields.physicalGpu": "Card Count",
   "endpoints.sections.clusterDeviceResources": "Cluster Resources",
 };
 
 const t = (key: string) => translations[key] ?? key;
+
+const findByExactLabel = (cards: HTMLElement[], label: string) => {
+  const card = cards.find((item) => within(item).queryByText(label));
+
+  expect(card).toBeTruthy();
+
+  return card as HTMLElement;
+};
 
 const resourceInfo: ClusterResourceInfo = {
   allocatable: {
@@ -122,5 +134,49 @@ describe("EndpointClusterGpuResourcesPanel", () => {
     ).toBeTruthy();
     expect(screen.getAllByLabelText("Usable")).toHaveLength(1);
     expect(screen.getAllByLabelText("Allocated")).toHaveLength(1);
+  });
+
+  it("shows resource units in card titles instead of appending them to every value", () => {
+    render(
+      <EndpointClusterGpuResourcesPanel
+        resourceInfo={resourceInfo}
+        currentCluster="cluster-a"
+        selectedAccelerator={{ type: "nvidia_gpu", product: "Tesla-T4" }}
+        virtualizationEnabled={true}
+        t={t}
+      />,
+    );
+
+    const nodeCards = screen.getAllByTestId("endpoint-node-resource-pill");
+    const cpuCard = findByExactLabel(nodeCards, "CPU");
+    const memoryCard = findByExactLabel(nodeCards, "Memory");
+    const summaryCards = screen.getAllByTestId(
+      "endpoint-resource-summary-card",
+    );
+    const cardCountCard = findByExactLabel(summaryCards, "Card Count");
+    const vramCard = findByExactLabel(summaryCards, "Memory Usage");
+    const coreCard = findByExactLabel(summaryCards, "Core Usage");
+
+    expect(within(cpuCard).getByText("cores")).toBeTruthy();
+    expect(within(memoryCard).getByText("GiB")).toBeTruthy();
+    expect(within(vramCard).getByText("GiB")).toBeTruthy();
+    expect(within(cardCountCard).queryByText("cores")).toBeNull();
+    expect(within(cardCountCard).queryByText("GiB")).toBeNull();
+    expect(within(coreCard).queryByText("cores")).toBeNull();
+    expect(within(coreCard).queryByText("GiB")).toBeNull();
+
+    expect(within(cpuCard).queryByText("32.0 cores")).toBeNull();
+    expect(within(memoryCard).queryByText("128.0 GiB")).toBeNull();
+    expect(within(cpuCard).getByText("32.0")).toBeTruthy();
+    expect(within(memoryCard).getByText("128.0")).toBeTruthy();
+    expect(vramCard.textContent).not.toContain("7.5 / 30.0 GiB");
+    expect(
+      within(vramCard).getByText((text) => text.includes("7.5 / 30.0")),
+    ).toBeTruthy();
+    expect(coreCard.textContent).not.toContain("cores");
+    expect(coreCard.textContent).not.toContain("GiB");
+    expect(
+      within(coreCard).getByText((text) => text.includes("50.0 / 200.0")),
+    ).toBeTruthy();
   });
 });

--- a/src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.tsx
+++ b/src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.tsx
@@ -86,6 +86,8 @@ const formatPoolValue = (
     ? "-"
     : `${formatCount(scaleMetricValue(value, valueScale))}${unit}`;
 
+const formatUnitLabel = (unit: string | undefined) => unit?.trim() ?? "";
+
 const toPercentValue = (
   used: number | null | undefined,
   total: number | null | undefined,
@@ -203,6 +205,32 @@ type ResourceSummaryMetric = {
   variant?: "accelerator" | "system";
 };
 
+function ResourceMetricLabel({
+  label,
+  unit,
+  className,
+}: {
+  label: string;
+  unit?: string;
+  className?: string;
+}) {
+  const unitLabel = formatUnitLabel(unit);
+
+  return (
+    <div
+      className={cn("flex min-w-0 items-baseline gap-1.5", className)}
+      title={label}
+    >
+      <span className="min-w-0 truncate">{label}</span>
+      {unitLabel && (
+        <span className="shrink-0 text-[11px] font-medium text-muted-foreground">
+          {unitLabel}
+        </span>
+      )}
+    </div>
+  );
+}
+
 function ResourceSummaryCard({
   metric,
   t,
@@ -215,14 +243,10 @@ function ResourceSummaryCard({
   const usageText = formatUsage(
     metric.used,
     metric.total,
-    metric.unit,
+    "",
     metric.valueScale,
   );
-  const freeText = formatPoolValue(
-    metric.available,
-    metric.unit,
-    metric.valueScale,
-  );
+  const freeText = formatPoolValue(metric.available, "", metric.valueScale);
   const isAccelerator = metric.variant === "accelerator";
   const usageClasses = isAccelerator
     ? acceleratorUsageClasses
@@ -234,9 +258,11 @@ function ResourceSummaryCard({
       className="grid min-w-0 gap-2 rounded-lg border bg-background px-2.5 py-2"
     >
       <div className="flex min-w-0 items-baseline justify-between gap-2">
-        <span className="min-w-0 truncate text-xs font-semibold">
-          {metric.label}
-        </span>
+        <ResourceMetricLabel
+          label={metric.label}
+          unit={metric.unit}
+          className="text-xs font-semibold"
+        />
         <span
           data-testid="endpoint-resource-summary-percent"
           className="shrink-0 text-xs font-normal tabular-nums text-muted-foreground"
@@ -298,17 +324,9 @@ function NodeResourcePill({
   metric: ResourceSummaryMetric;
   t: (key: string, options?: { defaultValue?: string }) => string;
 }) {
-  const totalText = formatPoolValue(
-    metric.total,
-    metric.unit,
-    metric.valueScale,
-  );
-  const usedText = formatPoolValue(metric.used, metric.unit, metric.valueScale);
-  const freeText = formatPoolValue(
-    metric.available,
-    metric.unit,
-    metric.valueScale,
-  );
+  const totalText = formatPoolValue(metric.total, "", metric.valueScale);
+  const usedText = formatPoolValue(metric.used, "", metric.valueScale);
+  const freeText = formatPoolValue(metric.available, "", metric.valueScale);
   const isAccelerator = metric.variant === "accelerator";
 
   return (
@@ -321,9 +339,11 @@ function NodeResourcePill({
           : "border-border bg-muted/20",
       )}
     >
-      <div className="truncate text-xs font-semibold" title={metric.label}>
-        {metric.label}
-      </div>
+      <ResourceMetricLabel
+        label={metric.label}
+        unit={metric.unit}
+        className="text-xs font-semibold"
+      />
       <div className="mt-1 grid grid-cols-3 gap-1 text-[11px] leading-tight text-muted-foreground">
         <span>{t("clusters.options.total")}</span>
         <span>{t("clusters.options.used")}</span>

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -1485,7 +1485,20 @@ describe("useEndpointForm", () => {
       expect(screen.getAllByText("Tesla-T4").length).toBeGreaterThan(0);
       expect(screen.queryByText("clusters.fields.vgpuMemoryUsage")).toBeNull();
 
-      for (const expectedFreeValue of ["12.0 cores", "48.0 GiB", "15.0 GiB"]) {
+      expect(
+        within(clusterSection).getAllByText("cores").length,
+      ).toBeGreaterThan(0);
+      expect(within(clusterSection).getAllByText("GiB").length).toBeGreaterThan(
+        0,
+      );
+      expect(
+        within(clusterSection).queryByText((text) =>
+          ["12.0 cores", "48.0 GiB", "15.0 GiB"].some((value) =>
+            text.includes(value),
+          ),
+        ),
+      ).toBeNull();
+      for (const expectedFreeValue of ["12.0", "48.0", "15.0"]) {
         expect(
           within(clusterSection)
             .getAllByTestId("endpoint-resource-summary-free-value")
@@ -1494,27 +1507,27 @@ describe("useEndpointForm", () => {
       }
       expect(
         within(clusterSection).getAllByText((text) =>
-          text.includes("4.0 / 16.0 cores"),
+          text.includes("4.0 / 16.0"),
         ).length,
       ).toBeGreaterThan(0);
       expect(
         within(clusterSection).getAllByText((text) =>
-          text.includes("16.0 / 64.0 GiB"),
+          text.includes("16.0 / 64.0"),
         ).length,
       ).toBeGreaterThan(0);
       expect(
         within(clusterSection).getAllByText((text) =>
-          text.includes("15.0 / 30.0 GiB"),
+          text.includes("15.0 / 30.0"),
         ).length,
       ).toBeTruthy();
       expect(
-        screen.getAllByText((text) => text.includes("15.0 / 30.0 GiB")).length,
+        screen.getAllByText((text) => text.includes("15.0 / 30.0")).length,
       ).toBeGreaterThan(0);
       expect(
         screen.getAllByText((text) => text.includes("50.0 / 200.0")).length,
       ).toBeGreaterThan(0);
-      expect(screen.getAllByText("7.5 GiB").length).toBeGreaterThan(0);
-      expect(screen.getAllByText("15.0 GiB").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("7.5").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("15.0").length).toBeGreaterThan(0);
       expect(
         screen.getAllByText((text) => text.includes("50.0")).length,
       ).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- Move endpoint cluster resource card units from individual values into the card title.
- Keep total/used/free values numeric for CPU, memory, accelerator memory, and accelerator core resource cards.
- Update endpoint resource form/component tests and the i18n tracker lock.

## Test Plan
### Unit test
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH yarn test src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.test.tsx`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH yarn test src/domains/endpoint/hooks/use-endpoint-form.test.tsx`
- `PATH=$HOME/.nvm/versions/node/v22.22.1/bin:$PATH yarn typecheck`
- Commit hook passed with Node 22: `tsc -b`, `depcruise`, `knip`, `lint-staged` / Biome, and i18n tracker checks.

### DB test
- Not required. This is a UI-only display change with no database or schema changes.

### E2E test
- Manual verification against `http://localhost:5174/` proxied to `http://10.255.1.54:3000`.
- Logged in with the private E2E profile and opened `/#/default/endpoints/create`.
- Selected cluster `t4`; confirmed `CPU (cores)` and `Memory (GiB)` render units in card titles and total/used/free values remain numeric.
- The remote cluster has `virtualizationEnabled=false`, so VRAM/Core Usage cards were not available for manual verification in that environment; the VRAM/Core display path is covered by component/form tests.
- Manual screenshot saved locally as `endpoint-cluster-resource-remote-5174.png` and not committed.