### PR TITLE
Fix cluster cache path contrast in dark mode

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -38,7 +38,7 @@
   "src/pages/clusters/create.tsx": "ee6e135f119688d2f7a72c3ecd2cd42a",
   "src/pages/clusters/edit.tsx": "ecb3a6e4f04286c161d3872d9e91bfa9",
   "src/pages/clusters/list.tsx": "71b3323f97b02b4391464719cc3aa521",
-  "src/pages/clusters/show.tsx": "4cf0a385edd011ab6b722d4db4f88de2",
+  "src/pages/clusters/show.tsx": "7c1450d47f76639f3963093d9632a58f",
   "src/pages/api-keys/list.tsx": "7b244d69fe0da3cfdaa56ea4f3aee8f9",
   "src/pages/api-keys/show.tsx": "3ecbea3750b6bc421c97fb673084dd5f",
   "src/components/ui/alert-dialog.tsx": "fd2a0854b18d61d21fe0e8effd7e4cd9",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -38,7 +38,7 @@
   "src/pages/clusters/create.tsx": "ee6e135f119688d2f7a72c3ecd2cd42a",
   "src/pages/clusters/edit.tsx": "ecb3a6e4f04286c161d3872d9e91bfa9",
   "src/pages/clusters/list.tsx": "71b3323f97b02b4391464719cc3aa521",
-  "src/pages/clusters/show.tsx": "7c1450d47f76639f3963093d9632a58f",
+  "src/pages/clusters/show.tsx": "47da3a9dc8eee0bfd0e21c57877107eb",
   "src/pages/api-keys/list.tsx": "7b244d69fe0da3cfdaa56ea4f3aee8f9",
   "src/pages/api-keys/show.tsx": "3ecbea3750b6bc421c97fb673084dd5f",
   "src/components/ui/alert-dialog.tsx": "fd2a0854b18d61d21fe0e8effd7e4cd9",

--- a/src/pages/clusters/show.tsx
+++ b/src/pages/clusters/show.tsx
@@ -412,7 +412,7 @@ export const ClustersShow = () => {
                                   "clusters.fields.modelCache.cacheType",
                                 )}
                               >
-                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary text-secondary-foreground">
                                   {cacheType === "nfs"
                                     ? t("clusters.options.nfs")
                                     : cacheType === "pvc"
@@ -428,7 +428,7 @@ export const ClustersShow = () => {
                                       "clusters.fields.modelCache.nfsServer",
                                     )}
                                   >
-                                    <code className="text-sm bg-gray-100 text-gray-900 px-2 py-1 rounded">
+                                    <code className="text-sm bg-muted text-foreground px-2 py-1 rounded">
                                       {cache.nfs.server}
                                     </code>
                                   </ShowPage.Row>
@@ -438,7 +438,7 @@ export const ClustersShow = () => {
                                       "clusters.fields.modelCache.cachePath",
                                     )}
                                   >
-                                    <code className="text-sm bg-gray-100 text-gray-900 px-2 py-1 rounded">
+                                    <code className="text-sm bg-muted text-foreground px-2 py-1 rounded">
                                       {cache.nfs.path}
                                     </code>
                                   </ShowPage.Row>
@@ -451,7 +451,7 @@ export const ClustersShow = () => {
                                     "clusters.fields.modelCache.cachePath",
                                   )}
                                 >
-                                  <code className="text-sm bg-gray-100 text-gray-900 px-2 py-1 rounded">
+                                  <code className="text-sm bg-muted text-foreground px-2 py-1 rounded">
                                     {cache.host_path.path}
                                   </code>
                                 </ShowPage.Row>

--- a/src/pages/clusters/show.tsx
+++ b/src/pages/clusters/show.tsx
@@ -428,7 +428,7 @@ export const ClustersShow = () => {
                                       "clusters.fields.modelCache.nfsServer",
                                     )}
                                   >
-                                    <code className="text-sm bg-gray-100 px-2 py-1 rounded">
+                                    <code className="text-sm bg-gray-100 text-gray-900 px-2 py-1 rounded">
                                       {cache.nfs.server}
                                     </code>
                                   </ShowPage.Row>
@@ -438,7 +438,7 @@ export const ClustersShow = () => {
                                       "clusters.fields.modelCache.cachePath",
                                     )}
                                   >
-                                    <code className="text-sm bg-gray-100 px-2 py-1 rounded">
+                                    <code className="text-sm bg-gray-100 text-gray-900 px-2 py-1 rounded">
                                       {cache.nfs.path}
                                     </code>
                                   </ShowPage.Row>
@@ -451,7 +451,7 @@ export const ClustersShow = () => {
                                     "clusters.fields.modelCache.cachePath",
                                   )}
                                 >
-                                  <code className="text-sm bg-gray-100 px-2 py-1 rounded">
+                                  <code className="text-sm bg-gray-100 text-gray-900 px-2 py-1 rounded">
                                     {cache.host_path.path}
                                   </code>
                                 </ShowPage.Row>


### PR DESCRIPTION
## Summary
- Fix model cache server/path code chips on the cluster detail page so their text remains readable in dark mode.
- Covers hostPath and NFS model cache path displays.

## Context
Slack report: dark mode made the cluster model cache path nearly invisible.

## Verification
- git diff --check
- Not run in this workspace: yarn typecheck/lint/build, per project instruction to run heavy UI checks in sandbox/CI.