### PR TITLE
NEU-487 Move logs and usage under Model Gateway

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -1,6 +1,6 @@
 {
   "vite.config.ts": "a2ebabd7035347e83eb48536602b2fe1",
-  "src/App.tsx": "8189345081fbaef22d0a59222c8534eb",
+  "src/App.tsx": "b336dbf076e5374ca53532b55109606a",
   "src/Root.tsx": "0bf1b5abed7cbc71c06832cc2de84f12",
   "src/index.tsx": "6eaed6f7788c9ba4ace41044c3cbc5a8",
   "src/pages/workspaces/create.tsx": "eda0d8545f33f74948967657ec231e35",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -356,15 +356,12 @@ const resources: ResourceProps[] = [
     },
   },
   {
-    name: "observability",
-  },
-  {
     name: "ai_traces",
     list: "/:workspace/ai-traces",
     meta: {
       icon: <Activity />,
       workspaced: true,
-      parent: "observability",
+      parent: "model_gateway",
     },
   },
   {
@@ -373,7 +370,7 @@ const resources: ResourceProps[] = [
     meta: {
       icon: <BarChart3 />,
       workspaced: true,
-      parent: "observability",
+      parent: "model_gateway",
     },
   },
   {


### PR DESCRIPTION
## Summary
- move Access Log and Model Usage navigation resources under Model Gateway
- remove the now-empty Observability navigation group
- keep API Keys under Access Control

## Context
Slack/Jira decision: Access Log and Model Usage belong to Model Gateway; API Key remains independent.

## Test plan
- git diff --check
- GitHub Actions `Test` workflow passed
