### PR TITLE
NEU-493: add access log expand and collapse controls

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -291,7 +291,7 @@
   "src/domains/external-endpoint/hooks/use-test-connectivity.ts": "71fed924f6125ed6cfbbc8891b96c282",
   "src/domains/external-endpoint/hooks/use-model-mapping-rows.ts": "8acf1e3078e104a09eaa7ce60bb41b56",
   "src/pages/ai-traces/list.tsx": "7b992eb94deae481da5bab68c5cd0aa7",
-  "src/pages/ai-traces/components/TraceDetailDrawer.tsx": "2ab6ea7b549a2dd22e1bf6cdb9a30de0",
+  "src/pages/ai-traces/components/TraceDetailDrawer.tsx": "f0e3bfa1160a5f7137d8c4c40ad132c8",
   "src/pages/ai-traces/components/TraceStatsChart.tsx": "72d803582532b53b21c0bce895d0142f",
   "src/foundation/lib/api/ai-traces.ts": "cc7341072da09afbecf02835bd0a572a",
   "src/foundation/components/DateRangePicker.tsx": "7db897cba5bece0433e75fcd91d305b1",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1404,6 +1404,8 @@
 			"noWrap": "No wrap",
 			"collapse": "Collapse",
 			"expand": "Expand",
+			"collapseAll": "Collapse all",
+			"expandAll": "Expand all",
 			"searchPlaceholder": "Search in body…",
 			"clearSearch": "Clear search",
 			"matchCount": "{{current}} / {{total}}",

--- a/src/pages/ai-traces/components/TraceDetailDrawer.tsx
+++ b/src/pages/ai-traces/components/TraceDetailDrawer.tsx
@@ -182,6 +182,11 @@ type ExpansionSignal = {
   version: number;
 };
 
+const isOpenForExpansionSignal = (
+  action: ExpansionSignal["action"],
+  version: number,
+) => version === 0 || action === "expand";
+
 const BodySection = ({
   title,
   body,
@@ -525,11 +530,19 @@ const MessageCard = ({
 }) => {
   const { t } = useTranslation();
   const [showRaw, setShowRaw] = useState(false);
-  const [open, setOpen] = useState(true);
+  const { action: expansionAction, version: expansionVersion } =
+    expansionSignal;
+  const expansionOpen = isOpenForExpansionSignal(
+    expansionAction,
+    expansionVersion,
+  );
+  const [open, setOpen] = useState(() =>
+    isOpenForExpansionSignal(expansionAction, expansionVersion),
+  );
   useEffect(() => {
-    if (expansionSignal.version === 0) return;
-    setOpen(expansionSignal.action === "expand");
-  }, [expansionSignal]);
+    if (expansionVersion === 0) return;
+    setOpen(expansionOpen);
+  }, [expansionOpen, expansionVersion]);
 
   return (
     <Collapsible
@@ -684,11 +697,19 @@ const AccentBlock = ({
   children: React.ReactNode;
   expansionSignal: ExpansionSignal;
 }) => {
-  const [open, setOpen] = useState(true);
+  const { action: expansionAction, version: expansionVersion } =
+    expansionSignal;
+  const expansionOpen = isOpenForExpansionSignal(
+    expansionAction,
+    expansionVersion,
+  );
+  const [open, setOpen] = useState(() =>
+    isOpenForExpansionSignal(expansionAction, expansionVersion),
+  );
   useEffect(() => {
-    if (expansionSignal.version === 0) return;
-    setOpen(expansionSignal.action === "expand");
-  }, [expansionSignal]);
+    if (expansionVersion === 0) return;
+    setOpen(expansionOpen);
+  }, [expansionOpen, expansionVersion]);
 
   return (
     <Collapsible

--- a/src/pages/ai-traces/components/TraceDetailDrawer.tsx
+++ b/src/pages/ai-traces/components/TraceDetailDrawer.tsx
@@ -8,7 +8,7 @@ import {
   WrapText,
   X,
 } from "lucide-react";
-import { Fragment, useId, useMemo, useState } from "react";
+import { Fragment, useEffect, useId, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -177,6 +177,10 @@ const MetaRow = ({
 
 type BodyKind = "request" | "response";
 type ViewMode = "formatted" | "raw";
+type ExpansionSignal = {
+  action: "collapse" | "expand";
+  version: number;
+};
 
 const BodySection = ({
   title,
@@ -203,6 +207,10 @@ const BodySection = ({
   const [wrap, setWrap] = useState(false);
   const [query, setQuery] = useState("");
   const [activeMatch, setActiveMatch] = useState(0);
+  const [expansionSignal, setExpansionSignal] = useState<ExpansionSignal>({
+    action: "expand",
+    version: 0,
+  });
 
   const effectiveView: ViewMode = hasFormatted ? view : "raw";
 
@@ -230,6 +238,12 @@ const BodySection = ({
       return next;
     });
   };
+  const setAllFormattedOpen = (action: ExpansionSignal["action"]) => {
+    setExpansionSignal((current) => ({
+      action,
+      version: current.version + 1,
+    }));
+  };
 
   return (
     <Collapsible
@@ -256,18 +270,46 @@ const BodySection = ({
 
         <div className="ml-auto flex items-center gap-1">
           {hasFormatted && (
-            <div className="flex rounded-md border p-0.5">
-              <ToggleChip
-                active={effectiveView === "formatted"}
-                onClick={() => setView("formatted")}
-                label={t("ai_traces.detail.viewFormatted")}
-              />
-              <ToggleChip
-                active={effectiveView === "raw"}
-                onClick={() => setView("raw")}
-                label={t("ai_traces.detail.viewRaw")}
-              />
-            </div>
+            <>
+              {effectiveView === "formatted" && (
+                <>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2"
+                    onClick={() => setAllFormattedOpen("collapse")}
+                    aria-label={t("ai_traces.detail.collapseAll")}
+                  >
+                    <ChevronRight />
+                    {t("ai_traces.detail.collapseAll")}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2"
+                    onClick={() => setAllFormattedOpen("expand")}
+                    aria-label={t("ai_traces.detail.expandAll")}
+                  >
+                    <ChevronDown />
+                    {t("ai_traces.detail.expandAll")}
+                  </Button>
+                </>
+              )}
+              <div className="flex rounded-md border p-0.5">
+                <ToggleChip
+                  active={effectiveView === "formatted"}
+                  onClick={() => setView("formatted")}
+                  label={t("ai_traces.detail.viewFormatted")}
+                />
+                <ToggleChip
+                  active={effectiveView === "raw"}
+                  onClick={() => setView("raw")}
+                  label={t("ai_traces.detail.viewRaw")}
+                />
+              </div>
+            </>
           )}
           <Button
             type="button"
@@ -357,6 +399,7 @@ const BodySection = ({
             query={query}
             activeMatch={safeActive}
             wrap={wrap}
+            expansionSignal={expansionSignal}
           />
         ) : (
           <RawView
@@ -426,11 +469,13 @@ const ConversationView = ({
   query,
   activeMatch,
   wrap,
+  expansionSignal,
 }: {
   messages: ChatMessage[];
   query: string;
   activeMatch: number;
   wrap: boolean;
+  expansionSignal: ExpansionSignal;
 }) => {
   // Match indices are assigned in document order across every rendered text
   // node, so we accumulate a running offset as we walk the messages.
@@ -447,12 +492,21 @@ const ConversationView = ({
               query={query}
               activeMatch={activeMatch - cursor}
               wrap={wrap}
+              expansionSignal={expansionSignal}
             />
           );
           cursor += occ;
           return node;
         });
-        return <MessageCard key={mi} msg={msg} wrap={wrap} blocks={blocks} />;
+        return (
+          <MessageCard
+            key={mi}
+            msg={msg}
+            wrap={wrap}
+            blocks={blocks}
+            expansionSignal={expansionSignal}
+          />
+        );
       })}
     </div>
   );
@@ -462,14 +516,21 @@ const MessageCard = ({
   msg,
   blocks,
   wrap,
+  expansionSignal,
 }: {
   msg: ChatMessage;
   blocks: React.ReactNode;
   wrap: boolean;
+  expansionSignal: ExpansionSignal;
 }) => {
   const { t } = useTranslation();
   const [showRaw, setShowRaw] = useState(false);
   const [open, setOpen] = useState(true);
+  useEffect(() => {
+    if (expansionSignal.version === 0) return;
+    setOpen(expansionSignal.action === "expand");
+  }, [expansionSignal]);
+
   return (
     <Collapsible
       open={open}
@@ -546,11 +607,13 @@ const BlockView = ({
   query,
   activeMatch,
   wrap,
+  expansionSignal,
 }: {
   block: ContentBlock;
   query: string;
   activeMatch: number;
   wrap: boolean;
+  expansionSignal: ExpansionSignal;
 }) => {
   const { t } = useTranslation();
   const labelKey =
@@ -585,7 +648,11 @@ const BlockView = ({
   const accent = BLOCK_ACCENT[block.kind];
   if (accent) {
     return (
-      <AccentBlock accent={accent} label={label}>
+      <AccentBlock
+        accent={accent}
+        label={label}
+        expansionSignal={expansionSignal}
+      >
         {body}
       </AccentBlock>
     );
@@ -610,12 +677,19 @@ const AccentBlock = ({
   accent,
   label,
   children,
+  expansionSignal,
 }: {
   accent: string;
   label: string;
   children: React.ReactNode;
+  expansionSignal: ExpansionSignal;
 }) => {
   const [open, setOpen] = useState(true);
+  useEffect(() => {
+    if (expansionSignal.version === 0) return;
+    setOpen(expansionSignal.action === "expand");
+  }, [expansionSignal]);
+
   return (
     <Collapsible
       open={open}
@@ -1057,7 +1131,12 @@ function parseSSEResponse(text: string): ChatMessage[] {
   if (assistant) blocks.push({ kind: "text", text: assistant });
   for (const index of toolOrder) {
     const entry = toolAcc.get(index);
-    if (entry) blocks.push({ kind: "tool_use", label: entry.name, text: entry.args || "{}" });
+    if (entry)
+      blocks.push({
+        kind: "tool_use",
+        label: entry.name,
+        text: entry.args || "{}",
+      });
   }
   // SSE has no per-message wire shape — surface the full stream as the raw.
   return blocks.length > 0 ? [{ role: "assistant", blocks, raw: text }] : [];


### PR DESCRIPTION
## Summary
- Add request/response body level Expand all and Collapse all controls in access log detail formatted view.
- Wire the controls through formatted chat messages and nested tool/thinking blocks while preserving per-item manual toggles.
- Add locale labels for the new controls.

## Verification
- PASS: npx biome check src/pages/ai-traces/components/TraceDetailDrawer.tsx src/locales/en-US.json (sandbox)
- PASS: git diff --check (sandbox)
- NOTE: npm run typecheck was attempted in sandbox after npm install; it failed on pre-existing/unrelated type errors in endpoint/auth/api files, not in this change.