### PR TITLE
fix: omit router version from k8s create payload

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -233,7 +233,7 @@
   "src/domains/model-registry/hooks/use-model-registry-form.tsx": "7209947c2079b41b6b83c9051a5235e2",
   "src/domains/image-registry/lib/transform-image-registry-values.ts": "d317d857ad5092eae0770bab89240ec6",
   "src/domains/image-registry/hooks/use-image-registry-form.tsx": "ca7795582e54f820a3fb26492a68c13c",
-  "src/domains/cluster/hooks/use-cluster-form.tsx": "ebd56c933e83996386d67e57e608df23",
+  "src/domains/cluster/hooks/use-cluster-form.tsx": "760541d2f85c5a4d3ea72d07efb6b387",
   "src/foundation/types/resource-types.ts": "35e5676ea62d78f48a7b6f63509c03d5",
   "src/foundation/hooks/use-variables-input.ts": "4e7645dd01994e5fd252bc3e2ad7676f",
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",

--- a/e2e/tests/clusters-create.spec.ts
+++ b/e2e/tests/clusters-create.spec.ts
@@ -873,6 +873,61 @@ test.describe("clusters - create", () => {
     );
 
     test(
+      "K8s: create payload does not include router version",
+      { tag: "@C2728017" },
+      async ({ clusters, apiHelper }) => {
+        const name = `test-k8s-router-ver-${Date.now()}`;
+        try {
+          await clusters.page.route(
+            "**/api/v1/clusters/available_versions?**",
+            async (route) => {
+              await route.fulfill({
+                contentType: "application/json",
+                body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+              });
+            },
+          );
+          await clusters.goToCreate();
+
+          await clusters.form.fillInput("metadata.name", name);
+          await clusters.form.selectComboboxOption(
+            "spec.image_registry",
+            irName.value,
+          );
+          await clusters.form.selectOption("spec.type", "Kubernetes");
+          await clusters.form.fillTextarea(
+            "spec.config.kubernetes_config.kubeconfig",
+            "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+          );
+          await expect(
+            clusters.form
+              .field("spec.version")
+              .locator('button[role="combobox"]'),
+          ).toHaveText("v1.0.1");
+
+          const requestPromise = clusters.page.waitForRequest(
+            (r) => r.url().includes("/clusters") && r.method() === "POST",
+          );
+          await clusters.form.submit();
+          const request = await requestPromise;
+          const body = JSON.parse(request.postData() || "{}");
+
+          expect(body.spec?.version).toBe("v1.0.1");
+          expect(
+            body.spec?.config?.kubernetes_config?.router,
+          ).not.toHaveProperty("version");
+          expect(body.spec?.config?.kubernetes_config?.router).toMatchObject({
+            access_mode: "LoadBalancer",
+            replicas: 2,
+            resources: { cpu: "1", memory: "1Gi" },
+          });
+        } finally {
+          await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+        }
+      },
+    );
+
+    test(
       "K8s: empty replicas → submit fails",
       { tag: "@C2612768" },
       async ({ clusters }) => {

--- a/src/domains/cluster/hooks/use-cluster-form.test.tsx
+++ b/src/domains/cluster/hooks/use-cluster-form.test.tsx
@@ -153,6 +153,7 @@ function selectType(label: string) {
 
 describe("useClusterForm", () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
     formInstance = null;
   });
 
@@ -219,6 +220,31 @@ describe("useClusterForm", () => {
       expect(
         screen.queryByTestId("field-spec.config.ssh_config.auth.ssh_user"),
       ).toBeNull();
+    });
+
+    it("does not seed router version when switching to kubernetes", async () => {
+      vi.stubEnv("VITE_DEFAULT_CLUSTER_VERSION", "v1.0.1");
+      render(<CreateForm />);
+
+      selectType("clusters.options.kubernetes");
+
+      await waitFor(() => {
+        expect(
+          formInstance?.getValues(
+            "spec.config.kubernetes_config.router.access_mode",
+          ),
+        ).toBe("LoadBalancer");
+      });
+
+      const router = formInstance?.getValues(
+        "spec.config.kubernetes_config.router",
+      );
+      expect(router).toMatchObject({
+        access_mode: "LoadBalancer",
+        replicas: 2,
+        resources: { cpu: "1", memory: "1Gi" },
+      });
+      expect(router).not.toHaveProperty("version");
     });
 
     it("shows accelerator virtualization only for kubernetes clusters", async () => {

--- a/src/domains/cluster/hooks/use-cluster-form.tsx
+++ b/src/domains/cluster/hooks/use-cluster-form.tsx
@@ -247,7 +247,6 @@ export const useClusterForm = ({ action }: { action: "create" | "edit" }) => {
                   kubernetes_config: {
                     kubeconfig: "",
                     router: {
-                      version: import.meta.env.VITE_DEFAULT_CLUSTER_VERSION,
                       access_mode: "LoadBalancer",
                       replicas: 2,
                       resources: {


### PR DESCRIPTION
## Issues

NEU-498

## Summary

- Stop seeding `spec.config.kubernetes_config.router.version` from `VITE_DEFAULT_CLUSTER_VERSION` when switching the cluster form to Kubernetes.
- Keep cluster `spec.version`, Quick Start defaults, and other router defaults unchanged.
- Add unit and E2E request-payload coverage for the omitted router version.
- Mark `use-cluster-form.tsx` as i18n-reviewed because the source file changed without adding user-facing text.

## Test Plan

### Unit test

- `npx -y -p node@22 -p yarn@1.22.22 yarn test src/domains/cluster/hooks/use-cluster-form.test.tsx src/domains/cluster/lib/transform-cluster-values.test.ts`
- `npx -y -p node@22 -p yarn@1.22.22 yarn typecheck`
- `node tools/i18n-tracker.cjs --git 1`
- `git diff --check`
- `npx -y @biomejs/biome@2.4.7 lint --config-path /Users/huangwei/go/src/neutree-ai/ui/.worktrees/fix-NEU-498/biome.json /Users/huangwei/go/src/neutree-ai/ui/.worktrees/fix-NEU-498/src/domains/cluster/hooks/use-cluster-form.tsx /Users/huangwei/go/src/neutree-ai/ui/.worktrees/fix-NEU-498/src/domains/cluster/hooks/use-cluster-form.test.tsx /Users/huangwei/go/src/neutree-ai/ui/.worktrees/fix-NEU-498/e2e/tests/clusters-create.spec.ts`
  - Local `yarn lint` is blocked by the installed Biome binary failing to spawn with system error -88; changed-file lint completed with no errors and two pre-existing non-null assertion warnings in the touched test file.

### DB test

- N/A - no DB or migration changes.

### E2E test

- Manual C2728018: created a temporary K8s cluster with `spec.version=v1.0.1` and no `router.version`; cluster reached `Running`; Kubernetes router Deployment/Pods used image `192.168.22.100/neutree-e2e-test/neutree/router:v1.0.1`; temporary cluster and image registry were force-deleted.
- Code-backed C2728017: `BASE_URL=http://127.0.0.1:5173 E2E_PROFILE_PATH=... npx -y -p node@22 -p yarn@1.22.22 yarn test:e2e --grep "router version"` passed: auth setup + C2728017. TestRail reporter returned 400 because C2728017 is not part of run 6567, but Playwright exited 0.