### PR TITLE
fix: silent endpoint log refresh to avoid loading flicker

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -178,7 +178,7 @@
   "src/domains/endpoint/hooks/use-endpoint-log-sources.ts": "db5f58fbfdf90e73192f68cd4c29b7da",
   "src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts": "c295d5f0c580d5bbb327b3fc6daa3505",
   "src/domains/endpoint/hooks/use-endpoint-resources.ts": "c1b719ca155f472655bf0644f278e041",
-  "src/domains/endpoint/hooks/use-streaming-logs.ts": "1d8b9797310db32450bc6817f5313797",
+  "src/domains/endpoint/hooks/use-streaming-logs.ts": "cf9cf558b44b0ff2e5b8ab0dcfb32f60",
   "src/domains/endpoint/components/ChatPlayground.tsx": "7e79b9940ee8da92f243cb50d0ccd61d",
   "src/domains/endpoint/components/ChatSidebar.tsx": "19de5399e7ae83d6d220bc7803ef93b9",
   "src/domains/endpoint/components/DeploymentConfigCard.tsx": "b7dfb1faec09a87be1e888d34c7fc338",

--- a/src/domains/endpoint/hooks/use-streaming-logs.ts
+++ b/src/domains/endpoint/hooks/use-streaming-logs.ts
@@ -1,6 +1,6 @@
-import { REST_URL, clientPostgrest } from "@/foundation/lib/api";
-import { auth } from "@/foundation/providers/auth-provider";
 import { useEffect, useRef, useState } from "react";
+import { clientPostgrest, REST_URL } from "@/foundation/lib/api";
+import { auth } from "@/foundation/providers/auth-provider";
 
 const AUTO_REFRESH_INTERVAL = 10000;
 
@@ -35,6 +35,10 @@ export const useStreamingLogs = (url: string | null, enabled = true) => {
   const [refetchTrigger, setRefetchTrigger] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isFetchingRef = useRef(false);
+  // Tracks the URL we've already completed a visible (non-silent) load for.
+  // Persists across effect re-runs (manual refetch, auto-refresh) so only a
+  // URL change (switching tabs) shows the loading state again.
+  const loadedUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
     // Skip if not enabled or no URL
@@ -45,7 +49,14 @@ export const useStreamingLogs = (url: string | null, enabled = true) => {
     async function fetchLogs() {
       if (isFetchingRef.current) return;
       isFetchingRef.current = true;
-      setIsLoading(true);
+      // The first fetch for a given URL shows the loading state and streams
+      // content in incrementally. Subsequent refreshes (auto or manual) are
+      // silent: we keep the current logs visible and swap them atomically once
+      // the new content is ready, so the viewer never flashes a loading state.
+      const silent = loadedUrlRef.current === url;
+      if (!silent) {
+        setIsLoading(true);
+      }
       setError(null);
 
       // Create new abort controller for this request
@@ -93,6 +104,14 @@ export const useStreamingLogs = (url: string | null, enabled = true) => {
 
           const chunk = decoder.decode(value, { stream: true });
           accumulatedLogs += chunk;
+          // On a silent refresh keep the old logs on screen until the stream
+          // completes, then swap once below — avoids partial-content flicker.
+          if (!silent) {
+            setLogs(accumulatedLogs);
+          }
+        }
+
+        if (silent) {
           setLogs(accumulatedLogs);
         }
       } catch (err) {
@@ -107,7 +126,15 @@ export const useStreamingLogs = (url: string | null, enabled = true) => {
         }
       } finally {
         isFetchingRef.current = false;
-        setIsLoading(false);
+        // Mark this URL as loaded so future fetches refresh silently. Only set
+        // on a visible load that reached this point without aborting, so an
+        // aborted/failed first load still shows the loading state on retry.
+        if (!silent && !abortControllerRef.current?.signal.aborted) {
+          loadedUrlRef.current = url;
+        }
+        if (!silent) {
+          setIsLoading(false);
+        }
       }
     }
 


### PR DESCRIPTION
## What

Make the endpoint Logs tab refresh silently, eliminating the loading flicker that occurred on every 10s poll.

## Why

`useStreamingLogs` called `setIsLoading(true)` on every fetch, and `EndpointLogTabs` then swapped the log content for a "loading" placeholder. This flashed in three cases:

- Initial load (expected)
- **10s auto-refresh** (flashed every time)
- Manual refresh button

## How

- Added `loadedUrlRef` to track the log-source URL that has completed its first visible load. It persists across effect re-runs (manual refetch / auto-refresh).
- Only the **first load of a given URL** (switching tab / replica changes the log source) sets `setIsLoading(true)` and streams content in incrementally.
- All later refreshes take the `silent` path: `isLoading` is untouched, the current logs stay on screen, and the new content is swapped atomically via a single `setLogs` once the stream completes — no loading placeholder flash, and no "clear then re-appear chunk by chunk" jitter.
- If the first load is aborted / fails, the URL is not marked as loaded, so a retry still shows the loading state.

The manual refresh button's `refetchLogSources()` uses react-query, whose `isLoading` is only true on the initial (uncached) load and does not flip on refetch, so the full-screen loading state does not flash either — no change needed there.

## Test

- `tsc --noEmit` passes
- Behavior-only change, no new user-facing strings (i18n lock synced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)