### PR TITLE
fix: keep cluster node GPU info visible in simplified recipe deploy

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -239,7 +239,7 @@
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "1d23880bb99098fadec0cc37dbc0e947",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "e3530b7060ad2537736662e81b4927fe",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "cfd9f29b837cedce5c4c52a906027b03",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "b2466d871f8436202bb1e6011ec61ecd",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -1359,7 +1359,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
             data-testid="endpoint-resource-layout-grid"
             className={cn(
               "grid gap-3",
-              showFull && currentCluster
+              currentCluster
                 ? "xl:grid-cols-[minmax(360px,420px)_minmax(620px,1fr)]"
                 : "xl:grid-cols-[minmax(360px,420px)]",
             )}
@@ -1752,7 +1752,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                 </div>
               </section>
             </div>
-            {showFull && clusterGpuResourcesPanel && (
+            {clusterGpuResourcesPanel && (
               <div
                 data-testid="endpoint-resource-context"
                 className="min-w-0 overflow-hidden rounded-xl border bg-background shadow-sm"


### PR DESCRIPTION
## What

In the simplified recipe-deploy form (create endpoint from a Recipe model catalog), the per-node cluster GPU resources panel (`EndpointClusterGpuResourcesPanel` — each node's GPU total/used/free) was collapsed behind the "Show all options" disclosure. This surfaces it whenever a cluster is selected.

## Why

Node GPU capacity is exactly what a user needs to choose an accelerator, so it shouldn't be hidden in the simplified flow.

## How

Two lines in `use-endpoint-form.tsx`:

- Panel render gate: `showFull && clusterGpuResourcesPanel` → `clusterGpuResourcesPanel`. The panel is already `null` when no cluster is selected, so it still only appears once a cluster is chosen.
- Resource layout grid: the second column opens on `currentCluster` instead of `showFull && currentCluster`, so the panel has a column to render into in simplified mode.

Edit mode and trivial (non-recipe) MC deploys are unaffected — `showFull` is already `true` there.

## Test

- `use-endpoint-form.test.tsx`: 42/42 pass (no test asserted hiding this panel in simplified mode)
- `tsc --noEmit`, i18n-tracker, check-i18n-keys: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)