### PR TITLE
feat(ai-traces): merge expand-all/collapse-all into a single toggle

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -291,7 +291,7 @@
   "src/domains/external-endpoint/hooks/use-test-connectivity.ts": "71fed924f6125ed6cfbbc8891b96c282",
   "src/domains/external-endpoint/hooks/use-model-mapping-rows.ts": "8acf1e3078e104a09eaa7ce60bb41b56",
   "src/pages/ai-traces/list.tsx": "7b992eb94deae481da5bab68c5cd0aa7",
-  "src/pages/ai-traces/components/TraceDetailDrawer.tsx": "f0e3bfa1160a5f7137d8c4c40ad132c8",
+  "src/pages/ai-traces/components/TraceDetailDrawer.tsx": "c1b0f27279fabc6712be1106a499a501",
   "src/pages/ai-traces/components/TraceStatsChart.tsx": "72d803582532b53b21c0bce895d0142f",
   "src/foundation/lib/api/ai-traces.ts": "cc7341072da09afbecf02835bd0a572a",
   "src/foundation/components/DateRangePicker.tsx": "7db897cba5bece0433e75fcd91d305b1",

--- a/src/pages/ai-traces/components/TraceDetailDrawer.tsx
+++ b/src/pages/ai-traces/components/TraceDetailDrawer.tsx
@@ -249,6 +249,12 @@ const BodySection = ({
       version: current.version + 1,
     }));
   };
+  // Reflects the last bulk action (defaults to expanded at version 0), so the
+  // single toggle knows which direction to fire and how to label itself.
+  const allExpanded = isOpenForExpansionSignal(
+    expansionSignal.action,
+    expansionSignal.version,
+  );
 
   return (
     <Collapsible
@@ -277,30 +283,25 @@ const BodySection = ({
           {hasFormatted && (
             <>
               {effectiveView === "formatted" && (
-                <>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2"
-                    onClick={() => setAllFormattedOpen("collapse")}
-                    aria-label={t("ai_traces.detail.collapseAll")}
-                  >
-                    <ChevronRight />
-                    {t("ai_traces.detail.collapseAll")}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 px-2"
-                    onClick={() => setAllFormattedOpen("expand")}
-                    aria-label={t("ai_traces.detail.expandAll")}
-                  >
-                    <ChevronDown />
-                    {t("ai_traces.detail.expandAll")}
-                  </Button>
-                </>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2"
+                  onClick={() =>
+                    setAllFormattedOpen(allExpanded ? "collapse" : "expand")
+                  }
+                  aria-label={
+                    allExpanded
+                      ? t("ai_traces.detail.collapseAll")
+                      : t("ai_traces.detail.expandAll")
+                  }
+                >
+                  {allExpanded ? <ChevronRight /> : <ChevronDown />}
+                  {allExpanded
+                    ? t("ai_traces.detail.collapseAll")
+                    : t("ai_traces.detail.expandAll")}
+                </Button>
               )}
               <div className="flex rounded-md border p-0.5">
                 <ToggleChip


### PR DESCRIPTION
## What

In the AI trace detail drawer, each body section (request/response, formatted view) had **two** buttons — "Expand all" and "Collapse all". This merges them into a **single toggle** button.

## Why

The two actions are mutually exclusive states of the same control; one toggle is less cluttered and clearer.

## How

`TraceDetailDrawer.tsx`:

- Derive `allExpanded` from the existing `expansionSignal` via the current `isOpenForExpansionSignal` helper (defaults to expanded at version 0).
- Render one `Button` that fires `setAllFormattedOpen(allExpanded ? "collapse" : "expand")` and swaps its icon (`ChevronRight` ⇄ `ChevronDown`) and label (`collapseAll` ⇄ `expandAll`) accordingly.

No state model or i18n keys changed — both `expandAll` / `collapseAll` strings are still used by the toggle. Behaviour is per-section, matching the previous buttons.

## Test

- `tsc --noEmit` clean; pre-commit (typecheck / dep-check / knip / i18n) green
- No tests referenced these buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)