### PR TITLE
fix: keep vGPU split options visible in simplified recipe deploy

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -239,7 +239,7 @@
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "279cf7c51f5d936b539f2e1704986f73",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "5e79ed92c585c5a1211b7bce24feb16b",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "1bb1948fc27283b8f118bed0b340ced8",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "b2466d871f8436202bb1e6011ec61ecd",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -140,6 +140,26 @@ const catalogB = {
   },
 };
 
+// Recipe-shaped MC (has variants) — selecting it activates simplified mode.
+const recipeCatalog = {
+  id: 3,
+  metadata: { name: "recipe-mc" },
+  spec: {
+    engine: { engine: "vllm", version: "0.8.5" },
+    variants: {
+      default: {
+        model: {
+          name: "org/recipe-model",
+          version: "",
+          registry: "hf",
+          file: "",
+          task: "text-generation",
+        },
+      },
+    },
+  },
+};
+
 // --- Mocks setup ---
 
 const plainKubernetesCluster = {
@@ -459,7 +479,11 @@ const defaultSelectResult = {
 };
 
 function setupMocks(
-  catalogs = [catalogA, catalogB],
+  catalogs: Array<{
+    id: number;
+    metadata: { name: string };
+    spec: Record<string, unknown>;
+  }> = [catalogA, catalogB],
   clusters: EndpointClusterRef[] = [],
 ) {
   vi.mocked(useSelect).mockImplementation(((opts: { resource: string }) => {
@@ -2694,6 +2718,54 @@ describe("useEndpointForm", () => {
 
       expect(
         screen.queryByText("common.validation.workspaceRequired"),
+      ).toBeNull();
+    });
+  });
+
+  // Simplified recipe deploy hides advanced controls, but on a vGPU-enabled
+  // cluster the virtual-card split (and its capacity feedback) is a deploy
+  // essential — a partially used card can make full-card allocation
+  // impossible, so these must not sit behind "Show all options".
+  describe("simplified recipe deploy on vGPU clusters", () => {
+    it("keeps the vGPU split group and current-request panel visible without expanding all options", async () => {
+      setupMocks(
+        [catalogA, recipeCatalog],
+        [virtualizedKubernetesClusterWithDevices],
+      );
+      render(<CreateForm />);
+
+      selectCatalog("recipe-mc");
+      await act(async () => {
+        formInstance?.setValue("spec.cluster", "virtualized-k8s-devices");
+        formInstance?.setValue("spec.resources.accelerator", {
+          type: "nvidia_gpu",
+          product: "Tesla-T4",
+        });
+      });
+
+      // Simplified mode is active: advanced model fields stay hidden...
+      expect(screen.queryByTestId("field-spec.model.version")).toBeNull();
+      // ...but the vGPU split controls and capacity feedback are visible.
+      expect(
+        screen.getByTestId("endpoint-virtual-card-split-group"),
+      ).toBeTruthy();
+      expect(screen.getByTestId("endpoint-current-request-panel")).toBeTruthy();
+    });
+
+    it("keeps the vGPU split group hidden in simplified mode on non-vGPU clusters", async () => {
+      setupMocks(
+        [catalogA, recipeCatalog],
+        [plainKubernetesClusterWithNodeResources],
+      );
+      render(<CreateForm />);
+
+      selectCatalog("recipe-mc");
+      await act(async () => {
+        formInstance?.setValue("spec.cluster", "plain-k8s-node-resources");
+      });
+
+      expect(
+        screen.queryByTestId("endpoint-virtual-card-split-group"),
       ).toBeNull();
     });
   });

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -1640,7 +1640,11 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                       />
                     </FormFieldGroup>
 
-                    {showFull && (
+                    {/* vGPU split is a deploy essential on virtualization-
+                        enabled clusters (a partially-used card can make full
+                        card allocation impossible), so simplified recipe mode
+                        must not hide it behind "Show all options". */}
+                    {(showFull || isSelectedClusterVgpuEnabled) && (
                       <div
                         data-testid="endpoint-virtual-card-split-group"
                         className="col-span-1 grid gap-3 rounded-lg border bg-muted/20 p-3 sm:col-span-2 sm:grid-cols-2"
@@ -1719,7 +1723,10 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                     )}
                   </div>
 
-                  {showFull &&
+                  {/* Same rule as the split group above: on vGPU clusters the
+                      capacity feedback must stay visible in simplified mode,
+                      or users configure the split blind. */}
+                  {(showFull || isSelectedClusterVgpuEnabled) &&
                     selectedAccelerator?.type &&
                     selectedAccelerator?.product && (
                       <div


### PR DESCRIPTION
## Problem

Slack feedback ([thread](https://smartx1.slack.com/archives/C09LB8TV90S/p1783256833913459)): after upgrading to v1.1.0-nightly-20260704-enterprise, deploying from a Model Catalog no longer shows the virtual-card split options — the user has to click "Show all options" first.

The simplified recipe deploy gates the virtual-card split group (per-card VRAM / core limit) and the current-request capacity panel behind `showFull`. On a virtualization-enabled cluster the split is a deploy **essential**, not an advanced tweak: in the reported environment the single Tesla-T4 is partially used (0 full cards available), so without the split controls the deploy is silently impossible.

## Fix

Show both blocks in simplified mode whenever the selected cluster has accelerator virtualization enabled (`showFull || isSelectedClusterVgpuEnabled`); non-vGPU clusters keep the minimal simplified layout unchanged.

## Tests

- Simplified recipe deploy + vGPU cluster: split group and current-request panel are visible without expanding, while advanced model fields stay hidden (proves simplified mode is active).
- Simplified recipe deploy + non-vGPU cluster: split group stays hidden.

Existing recipe e2e specs don't assert the hidden state of these blocks, so no e2e changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)