### PR TITLE
fix: show Model Usage before Access Log under Model Gateway (NEU-487)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -1,6 +1,6 @@
 {
   "vite.config.ts": "a2ebabd7035347e83eb48536602b2fe1",
-  "src/App.tsx": "63e0e21da09c3effaa8b215b8aa31374",
+  "src/App.tsx": "fde81ee0bd7da1cc39c7ed969abed825",
   "src/Root.tsx": "0bf1b5abed7cbc71c06832cc2de84f12",
   "src/index.tsx": "6eaed6f7788c9ba4ace41044c3cbc5a8",
   "src/pages/workspaces/create.tsx": "eda0d8545f33f74948967657ec231e35",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -362,19 +362,19 @@ const resources: ResourceProps[] = [
     },
   },
   {
-    name: "ai_traces",
-    list: "/:workspace/ai-traces",
+    name: "model_usage",
+    list: "/:workspace/model-usage",
     meta: {
-      icon: <Activity />,
+      icon: <BarChart3 />,
       workspaced: true,
       parent: "model_gateway",
     },
   },
   {
-    name: "model_usage",
-    list: "/:workspace/model-usage",
+    name: "ai_traces",
+    list: "/:workspace/ai-traces",
     meta: {
-      icon: <BarChart3 />,
+      icon: <Activity />,
       workspaced: true,
       parent: "model_gateway",
     },


### PR DESCRIPTION
## Summary
- Addresses a follow-up request on NEU-487 (from a reviewer after PR #289 merged) to swap the order of the "Model Usage" and "Access Log" entries in the "Model Gateway" sidebar nav group
- Nav order is driven by resource registration order in `src/App.tsx`; the `model_usage` resource block is now registered before the `ai_traces` (Access Log) block so "Model Usage" appears first

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Verified only the order of the two resource block declarations changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)