### PR TITLE
test(e2e): automate Model Usage TestRail cases

### DIFF
--- a/e2e/helpers/api-helper.ts
+++ b/e2e/helpers/api-helper.ts
@@ -9,6 +9,20 @@ export function isApiErrorMuted(): boolean {
   return _muteApiErrors;
 }
 
+/** One row returned by the `get_usage_by_dimension` RPC. */
+export interface UsageRow {
+  date: string;
+  api_key_id: string;
+  api_key_name: string;
+  endpoint_type: string | null;
+  endpoint_name: string | null;
+  model_name: string | null;
+  workspace: string;
+  usage: number;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+}
+
 /** Data returned by `createTestUserData` */
 export interface TestUserData {
   userName: string;
@@ -81,6 +95,141 @@ export class ApiHelper {
     );
   }
 
+  /**
+   * Like `api()` but never throws on a non-2xx response — returns the parsed
+   * status/body so callers can assert on 4xx/5xx (RPC probes, write-denial
+   * checks). `probe` mutes the page error listener for the duration.
+   */
+  async request<T = unknown>(
+    method: string,
+    path: string,
+    body?: unknown,
+    opts?: { probe?: boolean },
+  ): Promise<{ status: number; ok: boolean; body: T }> {
+    await this.ensureOnAppOrigin();
+    if (opts?.probe) _muteApiErrors = true;
+    try {
+      return (await this.page.evaluate(
+        async ({ method, path, body }) => {
+          let token = "";
+          for (const key of Object.keys(localStorage)) {
+            try {
+              const raw = localStorage.getItem(key);
+              if (!raw) continue;
+              const val = JSON.parse(raw);
+              if (val?.access_token) {
+                token = val.access_token;
+                break;
+              }
+            } catch {}
+          }
+          const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          };
+          if (token) headers.Authorization = `Bearer ${token}`;
+          const res = await fetch(`/api/v1${path}`, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : undefined,
+          });
+          const text = await res.text();
+          let parsed: unknown = text;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {}
+          return { status: res.status, ok: res.ok, body: parsed };
+        },
+        { method, path, body },
+      )) as { status: number; ok: boolean; body: T };
+    } finally {
+      if (opts?.probe) _muteApiErrors = false;
+    }
+  }
+
+  // ── Model Usage (get_usage_by_dimension RPC) ──
+
+  /**
+   * POST /rpc/get_usage_by_dimension — the read RPC behind the Model Usage
+   * page. `p_workspace`/`p_api_key_id`/`p_endpoint_name` are optional filters;
+   * omit `workspace` to aggregate across all entitled workspaces (the "All
+   * workspaces" case the UI models by sending no `p_workspace`).
+   */
+  async getUsageByDimension(params: {
+    start: string;
+    end: string;
+    workspace?: string;
+    apiKeyId?: string;
+    endpointName?: string;
+  }): Promise<{ status: number; ok: boolean; body: UsageRow[] }> {
+    const values: Record<string, unknown> = {
+      p_start_date: params.start,
+      p_end_date: params.end,
+    };
+    if (params.workspace !== undefined) values.p_workspace = params.workspace;
+    if (params.apiKeyId !== undefined) values.p_api_key_id = params.apiKeyId;
+    if (params.endpointName !== undefined)
+      values.p_endpoint_name = params.endpointName;
+    return this.request<UsageRow[]>(
+      "POST",
+      "/rpc/get_usage_by_dimension",
+      values,
+      { probe: true },
+    );
+  }
+
+  /**
+   * Force the daily-usage aggregation to run now (same call the 5-minute Go
+   * cron makes) so freshly produced usage records surface in the RPC without
+   * waiting for the scheduled job.
+   */
+  async aggregateUsage(): Promise<void> {
+    await this.request(
+      "POST",
+      "/rpc/aggregate_usage_records",
+      { p_older_than: new Date().toISOString() },
+      { probe: true },
+    );
+  }
+
+  // ── External Endpoint CRUD ──
+
+  /**
+   * POST /api/v1/external_endpoints — a model gateway proxying to an upstream
+   * OpenAI-compatible URL. Used to produce external-endpoint usage rows.
+   */
+  async createExternalEndpoint(
+    name: string,
+    upstreamUrl: string,
+    modelMapping: Record<string, string>,
+    options?: { workspace?: string },
+  ): Promise<void> {
+    await this.api("POST", "/external_endpoints", {
+      api_version: "v1",
+      kind: "ExternalEndpoint",
+      metadata: { name, workspace: options?.workspace ?? "default" },
+      spec: {
+        timeout: 60000,
+        upstreams: [
+          {
+            auth: { type: "bearer", credential: "none" },
+            upstream: { url: upstreamUrl },
+            endpoint_ref: null,
+            model_mapping: modelMapping,
+          },
+        ],
+      },
+    });
+  }
+
+  /** Soft-delete an external_endpoint by name */
+  async deleteExternalEndpoint(
+    name: string,
+    options?: { retries?: number; force?: boolean },
+  ): Promise<void> {
+    await this.softDelete("external_endpoints", name, options);
+  }
+
   // ── User CRUD ──
 
   /** POST /api/v1/auth/admin/users → poll for user_profile id */
@@ -140,6 +289,17 @@ export class ApiHelper {
     });
   }
 
+  /**
+   * PATCH /api/v1/roles — replace a role's permission set in place. Because
+   * `has_permission` reads roles live, this takes effect immediately (unlike
+   * soft-deleting a role assignment, which lingers until GC).
+   */
+  async updateRole(name: string, permissions: string[]): Promise<void> {
+    await this.api("PATCH", `/roles?metadata->>name=eq.${name}`, {
+      spec: { permissions },
+    });
+  }
+
   /** Soft-delete a role by name */
   async deleteRole(
     name: string,
@@ -150,18 +310,31 @@ export class ApiHelper {
 
   // ── Policy (RoleAssignment) CRUD ──
 
-  /** POST /api/v1/role_assignments */
+  /**
+   * POST /api/v1/role_assignments.
+   *
+   * Pass `workspace` for a workspace-scoped assignment (global defaults to
+   * false in that case unless explicitly set true). A workspace-scoped
+   * assignment only takes effect against the enterprise workspace-aware
+   * `has_permission`; on community it is inert.
+   */
   async createPolicy(
     name: string,
     userId: string,
     roleName: string,
     global = true,
+    workspace?: string,
   ): Promise<void> {
     await this.api("POST", "/role_assignments", {
       api_version: "v1",
       kind: "RoleAssignment",
       metadata: { name },
-      spec: { user_id: userId, role: roleName, global },
+      spec: {
+        user_id: userId,
+        role: roleName,
+        global,
+        ...(workspace ? { workspace } : {}),
+      },
     });
   }
 

--- a/e2e/helpers/model-usage.ts
+++ b/e2e/helpers/model-usage.ts
@@ -1,0 +1,234 @@
+import type { ApiHelper, UsageRow } from "./api-helper";
+
+/**
+ * Helpers for the Model Usage (get_usage_by_dimension) e2e tests.
+ *
+ * Real usage rows are produced by driving a controlled request through the AI
+ * gateway to a deployed programmable engine endpoint (see neutree-e2e-engine):
+ * the request is logged as an ai-trace, Vector POSTs it to `record_api_usage`
+ * (raw row), and the 5-minute aggregation cron rolls it up into
+ * `api.api_daily_usage`, which the `get_usage_by_dimension` RPC reads. Tests
+ * force the aggregation immediately (via `ApiHelper.aggregateUsage`) instead of
+ * waiting for the cron.
+ *
+ * The engine output is fully programmable via an inline `e2e:{...}` directive
+ * in the user message, so token counts and the reported `model` are
+ * deterministic — `model` in the request becomes the row's `model_name`.
+ *
+ * Gating (opt-in, shared with the ai-traces recipe):
+ *  - E2E_AITRACE_ENDPOINT  — name of a Running e2e-engine endpoint (default workspace)
+ *  - E2E_AITRACE_GATEWAY   — AI gateway base URL (default: BASE_URL host on :80)
+ */
+
+export interface UsageEnv {
+  endpoint: string;
+  gateway: string;
+  workspace: string;
+}
+
+/** Resolve gating config from env, or null when the suite should be skipped. */
+export function usageEnv(): UsageEnv | null {
+  const endpoint = process.env.E2E_AITRACE_ENDPOINT;
+  if (!endpoint) return null;
+  return {
+    endpoint,
+    gateway: gatewayBase(),
+    workspace: process.env.E2E_AITRACE_WORKSPACE ?? "default",
+  };
+}
+
+/** AI gateway base URL: explicit env, else BASE_URL host on port 80. */
+export function gatewayBase(): string {
+  if (process.env.E2E_AITRACE_GATEWAY) return process.env.E2E_AITRACE_GATEWAY;
+  const base = process.env.BASE_URL ?? "http://localhost:3000";
+  const u = new URL(base);
+  u.port = process.env.E2E_AITRACE_GATEWAY_PORT ?? "80";
+  u.pathname = "";
+  return u.toString().replace(/\/$/, "");
+}
+
+/** The engine host (gateway host without the port), for external-endpoint upstreams. */
+export function engineHost(env: UsageEnv): string {
+  return env.gateway.replace(/:\d+$/, "");
+}
+
+/** Build an inline directive string understood by the e2e engine. */
+export function directive(d: Record<string, unknown>): string {
+  return `e2e:${JSON.stringify(d)}`;
+}
+
+/** Local date (YYYY-MM-DD) offset by `days` from today. */
+export function isoDate(daysFromToday = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromToday);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export interface GatewayResult {
+  status: number;
+  body: unknown;
+}
+
+/**
+ * Fire a (non-streaming) chat completion through the AI gateway using an API
+ * key. Runs in Node — the gateway is a different origin and uses bearer
+ * API-key auth, so CORS/session don't apply. Retries while the gateway returns
+ * 401 (Kong syncs new API keys asynchronously).
+ */
+export async function chatCompletion(
+  env: UsageEnv,
+  apiKey: string,
+  d: Record<string, unknown>,
+  opts?: {
+    model?: string;
+    endpoint?: string;
+    external?: boolean;
+    workspace?: string;
+    retryOn401?: boolean;
+  },
+): Promise<GatewayResult> {
+  const endpoint = opts?.endpoint ?? env.endpoint;
+  const workspace = opts?.workspace ?? env.workspace;
+  const kind = opts?.external ? "external-endpoint" : "endpoint";
+  const url = `${env.gateway}/workspace/${workspace}/${kind}/${endpoint}/v1/chat/completions`;
+  const payload = JSON.stringify({
+    model: opts?.model ?? "any",
+    stream: false,
+    messages: [{ role: "user", content: directive(d) }],
+  });
+  const attempts = opts?.retryOn401 === false ? 1 : 25;
+  let res: Response | undefined;
+  for (let i = 0; i < attempts; i++) {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: payload,
+    });
+    if (res.status !== 401) break;
+    await new Promise((r) => setTimeout(r, 4000));
+  }
+  const r = res as Response;
+  const text = await r.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {}
+  return { status: r.status, body };
+}
+
+/**
+ * Produce a deterministic usage record: fire one gateway inference with a known
+ * `completion_tokens`/`prompt_tokens`/`model`, then poll the RPC (forcing
+ * aggregation each round) until a matching row appears. Returns the matching row.
+ */
+export async function produceUsage(
+  api: ApiHelper,
+  env: UsageEnv,
+  apiKey: string,
+  opts: {
+    model?: string;
+    promptTokens?: number;
+    completionTokens: number;
+    external?: boolean;
+    endpoint?: string;
+    /** Workspace of the endpoint/route and of the usage query (default env.workspace). */
+    workspace?: string;
+    /** Match predicate on the resulting RPC row (default: matches the token totals + model). */
+    match?: (row: UsageRow) => boolean;
+    timeoutMs?: number;
+  },
+): Promise<UsageRow> {
+  const workspace = opts.workspace ?? env.workspace;
+  const model = opts.model ?? "any";
+  const prompt = opts.promptTokens ?? 3;
+  // Retry the gateway call until it succeeds: a freshly created key needs its
+  // Kong consumer/ACL groups synced (401/403) and a freshly created external
+  // endpoint needs its route provisioned (404) — both settle asynchronously.
+  const readyDeadline = Date.now() + (opts.timeoutMs ?? 120_000);
+  let gw: GatewayResult | undefined;
+  while (Date.now() < readyDeadline) {
+    gw = await chatCompletion(
+      env,
+      apiKey,
+      {
+        mode: "fixed",
+        text: "model usage",
+        prompt_tokens: prompt,
+        completion_tokens: opts.completionTokens,
+        finish_reason: "stop",
+      },
+      {
+        model,
+        external: opts.external,
+        endpoint: opts.endpoint,
+        workspace,
+      },
+    );
+    if (gw.status === 200) break;
+    if (![401, 403, 404, 503].includes(gw.status)) break;
+    await new Promise((r) => setTimeout(r, 4000));
+  }
+  if (!gw || gw.status !== 200) {
+    throw new Error(
+      `gateway inference failed: ${gw?.status} ${JSON.stringify(gw?.body).slice(0, 300)}`,
+    );
+  }
+  const total = prompt + opts.completionTokens;
+  const match =
+    opts.match ??
+    ((row: UsageRow) =>
+      row.usage === total &&
+      (model === "any" || row.model_name === model) &&
+      (opts.external
+        ? row.endpoint_type === "external-endpoint"
+        : row.endpoint_type === "endpoint"));
+  return waitForUsage(api, match, {
+    start: isoDate(-1),
+    end: isoDate(0),
+    workspace,
+    timeoutMs: opts.timeoutMs,
+  });
+}
+
+/**
+ * Poll `get_usage_by_dimension` (forcing aggregation each round) until `match`
+ * returns true for some row, then return that row.
+ */
+export async function waitForUsage(
+  api: ApiHelper,
+  match: (row: UsageRow) => boolean,
+  opts: {
+    start: string;
+    end: string;
+    workspace?: string;
+    apiKeyId?: string;
+    timeoutMs?: number;
+    intervalMs?: number;
+  },
+): Promise<UsageRow> {
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+  const intervalMs = opts.intervalMs ?? 4_000;
+  const start = Date.now();
+  let last = 0;
+  while (Date.now() - start < timeoutMs) {
+    await api.aggregateUsage();
+    const r = await api.getUsageByDimension({
+      start: opts.start,
+      end: opts.end,
+      workspace: opts.workspace,
+      apiKeyId: opts.apiKeyId,
+    });
+    if (r.ok && Array.isArray(r.body)) {
+      last = r.body.length;
+      const hit = r.body.find(match);
+      if (hit) return hit;
+    }
+    await new Promise((res) => setTimeout(res, intervalMs));
+  }
+  throw new Error(
+    `waitForUsage: no matching usage row after ${timeoutMs}ms (last row count: ${last})`,
+  );
+}

--- a/e2e/tests/model-usage-api.spec.ts
+++ b/e2e/tests/model-usage-api.spec.ts
@@ -1,0 +1,531 @@
+import { expect, test } from "../fixtures/base";
+import { ApiHelper, type UsageRow } from "../helpers/api-helper";
+import { MULTI_USER_TIMEOUT } from "../helpers/constants";
+import { isoDate, produceUsage, usageEnv } from "../helpers/model-usage";
+import { loginAs } from "../helpers/test-user-context";
+
+// TestRail suite 2420, Model Usage section — backend read RPC
+// (get_usage_by_dimension) contract: no write surface, per-user API-key
+// ownership, per-workspace isolation, and retention of deleted endpoints.
+//
+// Usage rows are produced through the AI gateway to a Running e2e-engine
+// endpoint; opt-in via E2E_AITRACE_ENDPOINT.
+
+const env = usageEnv();
+const e = env as NonNullable<typeof env>;
+
+const START = isoDate(-30);
+const END = isoDate(0);
+
+/** Create a user with its own logged-in ApiHelper + one owned API key. */
+async function makeUserWithKey(
+  admin: ApiHelper,
+  browser: import("@playwright/test").Browser,
+  perms: string[],
+  keyWorkspaces: string[],
+) {
+  const ts = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const email = `mu-${ts}@e2e.local`;
+  const uname = `mu-${ts}`;
+  const role = `mu-r-${ts}`;
+  const policy = `mu-p-${ts}`;
+  const uid = await admin.createUser(uname, email, "Test@123456");
+  await admin.createRole(role, perms);
+  await admin.createPolicy(policy, uid, role, true);
+  const { page, context } = await loginAs(browser, admin, email, "Test@123456");
+  const api = new ApiHelper(page);
+  const keys: Array<{ name: string; sk: string; workspace: string }> = [];
+  for (const ws of keyWorkspaces) {
+    const keyName = `mu-key-${ws}-${ts}`;
+    const { sk_value } = await api.createApiKey(keyName, { workspace: ws });
+    keys.push({ name: keyName, sk: sk_value, workspace: ws });
+  }
+  return {
+    uid,
+    email,
+    api,
+    keys,
+    cleanup: async () => {
+      await context.close();
+      for (const k of keys)
+        await admin.deleteApiKey(k.name, { retries: 5 }).catch(() => {});
+      await admin.deletePolicy(policy).catch(() => {});
+      await admin.deleteRole(role, { retries: 10 }).catch(() => {});
+      await admin.deleteUser(uname, { retries: 10 }).catch(() => {});
+    },
+  };
+}
+
+test.describe("model usage — backend read RPC", () => {
+  test.skip(!env, "set E2E_AITRACE_ENDPOINT to run Model Usage RPC tests");
+
+  test("get_usage_by_dimension is read-only: no create/update/delete surface", {
+    tag: "@C2710864",
+  }, async ({ apiHelper }) => {
+    // Baseline: the RPC returns rows for the default workspace.
+    const baseline = await apiHelper.getUsageByDimension({
+      start: START,
+      end: END,
+      workspace: e.workspace,
+    });
+    expect(baseline.status).toBe(200);
+    expect(Array.isArray(baseline.body)).toBe(true);
+
+    // An admin-owned daily-usage row to probe REST writes against.
+    const owned = await apiHelper.request<Array<{ id: number }>>(
+      "GET",
+      "/api_daily_usage?select=id&order=id.asc&limit=1",
+    );
+    const probeId = owned.body?.[0]?.id;
+
+    // REST POST (insert) is denied by row-level security — no daily row is
+    // ever user-creatable.
+    const post = await apiHelper.request(
+      "POST",
+      "/api_daily_usage",
+      {
+        api_version: "v1",
+        kind: "ApiDailyUsage",
+        metadata: { name: `probe-${Date.now()}` },
+        spec: {
+          api_key_id: "00000000-0000-0000-0000-000000000000",
+          usage_date: "2020-01-01",
+          total_usage: 999999,
+          dimensional_usage: {},
+        },
+      },
+      { probe: true },
+    );
+    expect(post.status).toBeGreaterThanOrEqual(400);
+
+    // The write RPCs the case probes do not exist in the OpenAPI surface.
+    for (const rpc of ["create_usage", "update_usage"]) {
+      const r = await apiHelper.request(
+        "POST",
+        `/rpc/${rpc}`,
+        {},
+        {
+          probe: true,
+        },
+      );
+      expect([404, 405]).toContain(r.status);
+    }
+
+    // REST PATCH/DELETE must not mutate an existing (owned, visible) row.
+    if (probeId !== undefined) {
+      await apiHelper.request(
+        "PATCH",
+        `/api_daily_usage?id=eq.${probeId}`,
+        { spec: { total_usage: 424242 } },
+        { probe: true },
+      );
+      await apiHelper.request(
+        "DELETE",
+        `/api_daily_usage?id=eq.${probeId}`,
+        undefined,
+        { probe: true },
+      );
+      const after = await apiHelper.request<Array<{ id: number }>>(
+        "GET",
+        `/api_daily_usage?select=id&id=eq.${probeId}`,
+      );
+      // Row still present → DELETE had no effect.
+      expect(after.body?.[0]?.id).toBe(probeId);
+    }
+
+    // Re-query: the read surface is unchanged after all write attempts.
+    const post2 = await apiHelper.getUsageByDimension({
+      start: START,
+      end: END,
+      workspace: e.workspace,
+    });
+    expect(post2.status).toBe(200);
+    expect(post2.body.length).toBe(baseline.body.length);
+  });
+
+  test(
+    "usage query returns only the caller's own API keys and is workspace-isolated",
+    {
+      tag: "@C2710861",
+      annotation: {
+        type: "slow",
+        description: "creates multiple users, keys and workspaces",
+      },
+    },
+    async ({ apiHelper, browser }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 180_000);
+      const ts = Date.now();
+      const ws1 = `mu-ws1-${ts}`;
+      const ws2 = `mu-ws2-${ts}`;
+      const cleanups: Array<() => Promise<void>> = [];
+      try {
+        await apiHelper.createWorkspace(ws1);
+        await apiHelper.createWorkspace(ws2);
+        cleanups.push(async () => {
+          await apiHelper.deleteWorkspace(ws1, { force: true }).catch(() => {});
+          await apiHelper.deleteWorkspace(ws2, { force: true }).catch(() => {});
+        });
+
+        // User A and User B each with an own key + usage in the default ws.
+        // endpoint:read lets their key consume the internal e2e endpoint.
+        const A = await makeUserWithKey(
+          apiHelper,
+          browser,
+          ["workspace:read", "endpoint:read"],
+          [e.workspace],
+        );
+        cleanups.push(A.cleanup);
+        const B = await makeUserWithKey(
+          apiHelper,
+          browser,
+          ["workspace:read", "endpoint:read"],
+          [e.workspace],
+        );
+        cleanups.push(B.cleanup);
+
+        const rowA = await produceUsage(A.api, e, A.keys[0].sk, {
+          completionTokens: 11,
+        });
+        const rowB = await produceUsage(B.api, e, B.keys[0].sk, {
+          completionTokens: 13,
+        });
+
+        // A sees only A's key; B sees only B's key.
+        const aList = await A.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: e.workspace,
+        });
+        expect(aList.status).toBe(200);
+        expect(aList.body.every((r) => r.api_key_id === rowA.api_key_id)).toBe(
+          true,
+        );
+        expect(aList.body.some((r) => r.api_key_id === rowB.api_key_id)).toBe(
+          false,
+        );
+
+        const bList = await B.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: e.workspace,
+        });
+        expect(bList.status).toBe(200);
+        expect(bList.body.every((r) => r.api_key_id === rowB.api_key_id)).toBe(
+          true,
+        );
+
+        // A cannot escalate by passing B's key id → empty result set.
+        const escalate = await A.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: e.workspace,
+          apiKeyId: rowB.api_key_id,
+        });
+        expect(escalate.status).toBe(200);
+        expect(escalate.body.length).toBe(0);
+
+        // Workspace isolation: a user with keys in ws1 and ws2 sees each
+        // workspace's usage only under the matching p_workspace. Each key
+        // consumes a per-workspace external endpoint proxying to the shared
+        // e2e engine, so usage is attributed to the key's workspace.
+        const D = await makeUserWithKey(
+          apiHelper,
+          browser,
+          ["workspace:read", "external_endpoint:read"],
+          [ws1, ws2],
+        );
+        cleanups.push(D.cleanup);
+        const dKey1 = D.keys.find((k) => k.workspace === ws1) as {
+          sk: string;
+        };
+        const dKey2 = D.keys.find((k) => k.workspace === ws2) as {
+          sk: string;
+        };
+        const upstream = `${e.gateway.replace(/:\d+$/, "")}:8000/${e.workspace}/${e.endpoint}/v1`;
+        const ee1 = `mu-ee1-${ts}`;
+        const ee2 = `mu-ee2-${ts}`;
+        await apiHelper.createExternalEndpoint(
+          ee1,
+          upstream,
+          { any: "any" },
+          {
+            workspace: ws1,
+          },
+        );
+        await apiHelper.createExternalEndpoint(
+          ee2,
+          upstream,
+          { any: "any" },
+          {
+            workspace: ws2,
+          },
+        );
+        cleanups.push(async () => {
+          await apiHelper
+            .deleteExternalEndpoint(ee1, { force: true })
+            .catch(() => {});
+          await apiHelper
+            .deleteExternalEndpoint(ee2, { force: true })
+            .catch(() => {});
+        });
+        const matchByUsage = (u: number) => (row: UsageRow) => row.usage === u;
+        await produceUsage(D.api, e, dKey1.sk, {
+          completionTokens: 17,
+          external: true,
+          endpoint: ee1,
+          workspace: ws1,
+          match: matchByUsage(20),
+          timeoutMs: 150_000,
+        });
+        await produceUsage(D.api, e, dKey2.sk, {
+          completionTokens: 19,
+          external: true,
+          endpoint: ee2,
+          workspace: ws2,
+          match: matchByUsage(22),
+          timeoutMs: 150_000,
+        });
+
+        const d1 = await D.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws1,
+        });
+        expect(d1.status).toBe(200);
+        expect(d1.body.length).toBeGreaterThan(0);
+        expect(d1.body.every((r) => r.workspace === ws1)).toBe(true);
+
+        const d2 = await D.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws2,
+        });
+        expect(d2.status).toBe(200);
+        expect(d2.body.length).toBeGreaterThan(0);
+        expect(d2.body.every((r) => r.workspace === ws2)).toBe(true);
+        // Disjoint: no ws1 key appears under ws2.
+        const ws1Keys = new Set(d1.body.map((r) => r.api_key_id));
+        expect(d2.body.some((r) => ws1Keys.has(r.api_key_id))).toBe(false);
+      } finally {
+        for (const c of cleanups.reverse()) await c().catch(() => {});
+      }
+    },
+  );
+
+  test(
+    "deleted endpoint's historical usage is retained and still queryable",
+    {
+      tag: "@C2710862",
+      annotation: {
+        type: "slow",
+        description: "creates an external endpoint, produces usage, deletes it",
+      },
+    },
+    async ({ apiHelper, browser }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 150_000);
+      const ts = Date.now();
+      const eeName = `mu-del-${ts}`;
+      const cleanups: Array<() => Promise<void>> = [];
+      try {
+        const U = await makeUserWithKey(
+          apiHelper,
+          browser,
+          ["workspace:read", "external_endpoint:read"],
+          [e.workspace],
+        );
+        cleanups.push(U.cleanup);
+
+        // An external endpoint proxying to the e2e engine, so a call through it
+        // records usage against endpoint_name = eeName.
+        await apiHelper.createExternalEndpoint(
+          eeName,
+          `${e.gateway.replace(/:\d+$/, "")}:8000/${e.workspace}/${e.endpoint}/v1`,
+          { any: "any" },
+        );
+        cleanups.push(() =>
+          apiHelper.deleteExternalEndpoint(eeName, { force: true }),
+        );
+
+        // Wait for the gateway route to go live, then produce an external trace.
+        const row = await produceUsage(U.api, e, U.keys[0].sk, {
+          completionTokens: 23,
+          external: true,
+          endpoint: eeName,
+          match: (r) => r.endpoint_name === eeName,
+          timeoutMs: 150_000,
+        });
+        expect(row.endpoint_name).toBe(eeName);
+        expect(row.workspace).toBe(e.workspace);
+        expect(row.usage).toBeGreaterThan(0);
+
+        // Delete the endpoint.
+        await apiHelper.deleteExternalEndpoint(eeName, { force: true });
+
+        // Historical usage survives the endpoint deletion and is still returned
+        // under the original workspace.
+        const after = await U.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: e.workspace,
+        });
+        expect(after.status).toBe(200);
+        const kept = after.body.find((r) => r.endpoint_name === eeName);
+        expect(kept).toBeDefined();
+        expect(kept?.workspace).toBe(e.workspace);
+        expect((kept?.usage ?? 0) > 0).toBe(true);
+      } finally {
+        for (const c of cleanups.reverse()) await c().catch(() => {});
+      }
+    },
+  );
+
+  test(
+    "same-named keys/endpoints across workspaces: no loss, correct union",
+    {
+      tag: "@C2710863",
+      annotation: {
+        type: "slow",
+        description: "same display names in two workspaces, then union query",
+      },
+    },
+    async ({ apiHelper, browser }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 200_000);
+      const ts = Date.now();
+      const wsA = `mu-sa-${ts}`;
+      const wsB = `mu-sb-${ts}`;
+      const sameKey = `mu-key-same-${ts}`;
+      const sameEe = `mu-ee-same-${ts}`;
+      const cleanups: Array<() => Promise<void>> = [];
+      try {
+        await apiHelper.createWorkspace(wsA);
+        await apiHelper.createWorkspace(wsB);
+        cleanups.push(async () => {
+          await apiHelper.deleteWorkspace(wsA, { force: true }).catch(() => {});
+          await apiHelper.deleteWorkspace(wsB, { force: true }).catch(() => {});
+        });
+
+        // One user with same-named keys in both workspaces.
+        const ts2 = `${ts}`;
+        const email = `mu-same-${ts2}@e2e.local`;
+        const uname = `mu-same-${ts2}`;
+        const role = `mu-same-r-${ts2}`;
+        const policy = `mu-same-p-${ts2}`;
+        const uid = await apiHelper.createUser(uname, email, "Test@123456");
+        await apiHelper.createRole(role, [
+          "workspace:read",
+          "external_endpoint:read",
+        ]);
+        await apiHelper.createPolicy(policy, uid, role, true);
+        const { page, context } = await loginAs(
+          browser,
+          apiHelper,
+          email,
+          "Test@123456",
+        );
+        const userApi = new ApiHelper(page);
+        cleanups.push(async () => {
+          await context.close();
+          await apiHelper.deleteApiKey(sameKey, { retries: 5 }).catch(() => {});
+          await apiHelper.deletePolicy(policy).catch(() => {});
+          await apiHelper.deleteRole(role, { retries: 10 }).catch(() => {});
+          await apiHelper.deleteUser(uname, { retries: 10 }).catch(() => {});
+        });
+
+        const keyA = await userApi.createApiKey(sameKey, { workspace: wsA });
+        const keyB = await userApi.createApiKey(sameKey, { workspace: wsB });
+
+        const upstream = `${e.gateway.replace(/:\d+$/, "")}:8000/${e.workspace}/${e.endpoint}/v1`;
+        await apiHelper.createExternalEndpoint(
+          sameEe,
+          upstream,
+          { any: "any" },
+          {
+            workspace: wsA,
+          },
+        );
+        await apiHelper.createExternalEndpoint(
+          sameEe,
+          upstream,
+          { any: "any" },
+          {
+            workspace: wsB,
+          },
+        );
+        cleanups.push(async () => {
+          await apiHelper
+            .deleteExternalEndpoint(sameEe, { force: true })
+            .catch(() => {});
+        });
+
+        // Distinct usage per workspace: U-A total 20, U-B total 25.
+        const rowA = await produceUsage(userApi, e, keyA.sk_value, {
+          completionTokens: 17,
+          external: true,
+          endpoint: sameEe,
+          workspace: wsA,
+          match: (r) => r.usage === 20,
+          timeoutMs: 180_000,
+        });
+        const rowB = await produceUsage(userApi, e, keyB.sk_value, {
+          completionTokens: 22,
+          external: true,
+          endpoint: sameEe,
+          workspace: wsB,
+          match: (r) => r.usage === 25,
+          timeoutMs: 180_000,
+        });
+        expect(rowA.api_key_id).not.toBe(rowB.api_key_id);
+
+        // Single-workspace queries return only that workspace's rows, with the
+        // shared display names intact.
+        const qa = await userApi.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: wsA,
+        });
+        expect(qa.body.every((r) => r.workspace === wsA)).toBe(true);
+        expect(
+          qa.body.some(
+            (r) =>
+              r.api_key_name === sameKey &&
+              r.endpoint_name === sameEe &&
+              r.api_key_id === rowA.api_key_id,
+          ),
+        ).toBe(true);
+        expect(qa.body.some((r) => r.api_key_id === rowB.api_key_id)).toBe(
+          false,
+        );
+
+        const qb = await userApi.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: wsB,
+        });
+        expect(qb.body.every((r) => r.workspace === wsB)).toBe(true);
+        expect(qb.body.some((r) => r.api_key_id === rowB.api_key_id)).toBe(
+          true,
+        );
+
+        // Union (no p_workspace): both keys present, no loss, no duplication.
+        const union = await userApi.getUsageByDimension({
+          start: START,
+          end: END,
+        });
+        const idsA = union.body.filter(
+          (r) => r.api_key_id === rowA.api_key_id && r.workspace === wsA,
+        );
+        const idsB = union.body.filter(
+          (r) => r.api_key_id === rowB.api_key_id && r.workspace === wsB,
+        );
+        expect(idsA.length).toBeGreaterThan(0);
+        expect(idsB.length).toBeGreaterThan(0);
+        const sumA = idsA.reduce((s, r) => s + r.usage, 0);
+        const sumB = idsB.reduce((s, r) => s + r.usage, 0);
+        expect(sumA).toBe(20);
+        expect(sumB).toBe(25);
+      } finally {
+        for (const c of cleanups.reverse()) await c().catch(() => {});
+      }
+    },
+  );
+});

--- a/e2e/tests/model-usage-rbac.spec.ts
+++ b/e2e/tests/model-usage-rbac.spec.ts
@@ -1,0 +1,416 @@
+import type { Browser } from "@playwright/test";
+import { expect, test } from "../fixtures/base";
+import { ApiHelper } from "../helpers/api-helper";
+import { MULTI_USER_TIMEOUT } from "../helpers/constants";
+import { isoDate, produceUsage, usageEnv } from "../helpers/model-usage";
+import { loginAs } from "../helpers/test-user-context";
+
+// TestRail suite 2420, Model Usage section — permission (RBAC) behavior of the
+// get_usage_by_dimension RPC and the Model Usage page.
+//
+// Per-workspace `workspace:usage-read` scoping requires the enterprise
+// workspace-aware `has_permission` (community treats non-global assignments as
+// inert and usage-read as a global check). Opt-in via E2E_AITRACE_ENDPOINT and
+// run against an enterprise-scoped control plane.
+
+const env = usageEnv();
+const e = env as NonNullable<typeof env>;
+const START = isoDate(-30);
+const END = isoDate(0);
+
+let seq = 0;
+const uid8 = () => `${Date.now()}${seq++}`;
+
+/**
+ * Seed usage in `workspace` owned by a fresh producer user: creates the user
+ * (workspace:read + external_endpoint:read, workspace-scoped), an owned key, a
+ * per-workspace external endpoint proxying to the e2e engine, and produces one
+ * usage record. Returns the producer's key identity + a cleanup.
+ */
+async function seedUsage(
+  admin: ApiHelper,
+  browser: Browser,
+  workspace: string,
+  completionTokens: number,
+) {
+  const id = uid8();
+  const email = `mu-prod-${id}@e2e.local`;
+  const uname = `mu-prod-${id}`;
+  const role = `mu-prod-r-${id}`;
+  const policy = `mu-prod-p-${id}`;
+  const keyName = `mu-prod-key-${id}`;
+  const eeName = `mu-prod-ee-${id}`;
+  const uidVal = await admin.createUser(uname, email, "Test@123456");
+  await admin.createRole(role, ["workspace:read", "external_endpoint:read"]);
+  await admin.createPolicy(policy, uidVal, role, false, workspace);
+  const { page, context } = await loginAs(browser, admin, email, "Test@123456");
+  const api = new ApiHelper(page);
+  const { sk_value } = await api.createApiKey(keyName, { workspace });
+  const upstream = `${e.gateway.replace(/:\d+$/, "")}:8000/${e.workspace}/${e.endpoint}/v1`;
+  await admin.createExternalEndpoint(
+    eeName,
+    upstream,
+    { any: "any" },
+    {
+      workspace,
+    },
+  );
+  const row = await produceUsage(api, e, sk_value, {
+    completionTokens,
+    external: true,
+    endpoint: eeName,
+    workspace,
+    match: (r) => r.endpoint_name === eeName && r.usage > 0,
+    timeoutMs: 180_000,
+  });
+  return {
+    api,
+    uid: uidVal,
+    role,
+    keyId: row.api_key_id,
+    keyName,
+    eeName,
+    row,
+    cleanup: async () => {
+      await context.close();
+      await admin
+        .deleteExternalEndpoint(eeName, { force: true })
+        .catch(() => {});
+      await admin.deleteApiKey(keyName, { retries: 5 }).catch(() => {});
+      await admin.deletePolicy(policy).catch(() => {});
+      await admin.deleteRole(role, { retries: 10 }).catch(() => {});
+      await admin.deleteUser(uname, { retries: 10 }).catch(() => {});
+    },
+  };
+}
+
+/**
+ * A reader user (no own key) with a workspace-scoped role. Returns its logged-in
+ * ApiHelper plus `setPermissions()` (edits the role in place — takes effect
+ * immediately, unlike soft-deleting the assignment which lingers until GC) and
+ * cleanup.
+ */
+async function makeReader(
+  admin: ApiHelper,
+  browser: Browser,
+  permissions: string[],
+  workspace: string,
+) {
+  const id = uid8();
+  const email = `mu-read-${id}@e2e.local`;
+  const uname = `mu-read-${id}`;
+  const role = `mu-read-r-${id}`;
+  const policy = `mu-read-p-${id}`;
+  const uidVal = await admin.createUser(uname, email, "Test@123456");
+  await admin.createRole(role, permissions);
+  await admin.createPolicy(policy, uidVal, role, false, workspace);
+  const { page, context } = await loginAs(browser, admin, email, "Test@123456");
+  return {
+    api: new ApiHelper(page),
+    uid: uidVal,
+    email,
+    role,
+    setPermissions: (perms: string[]) => admin.updateRole(role, perms),
+    cleanup: async () => {
+      await context.close();
+      await admin.deletePolicy(policy).catch(() => {});
+      await admin.deleteRole(role, { retries: 10 }).catch(() => {});
+      await admin.deleteUser(uname, { retries: 10 }).catch(() => {});
+    },
+  };
+}
+
+test.describe("model usage — RBAC", () => {
+  test.skip(!env, "set E2E_AITRACE_ENDPOINT to run Model Usage RBAC tests");
+
+  test(
+    "workspace:read alone enters the page and sees own usage; no read → no visibility",
+    {
+      tag: "@C2710866",
+      annotation: { type: "slow", description: "workspace + producer + usage" },
+    },
+    async ({ apiHelper, browser }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 200_000);
+      const ws = `mu-perm-${uid8()}`;
+      const cleanups: Array<() => Promise<void>> = [];
+      try {
+        await apiHelper.createWorkspace(ws);
+        cleanups.push(() =>
+          apiHelper.deleteWorkspace(ws, { force: true }).then(
+            () => {},
+            () => {},
+          ),
+        );
+        // The reader owns usage in ws (produced with its own key).
+        const reader = await seedUsage(apiHelper, browser, ws, 7);
+        cleanups.push(reader.cleanup);
+
+        // workspace:read (workspace-scoped) is enough to read own usage.
+        const list = await reader.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws,
+        });
+        expect(list.status).toBe(200);
+        expect(list.body.some((r) => r.api_key_id === reader.keyId)).toBe(true);
+
+        // The Model Usage page loads for this user.
+        await reader.api.page.goto(`/#/${ws}/model-usage`);
+        await expect(
+          reader.api.page.getByText("No usage in the selected window."),
+        ).toHaveCount(0, { timeout: 15_000 });
+
+        // A user with no read on ws sees no usage there (no leak).
+        const outsider = await makeReader(
+          apiHelper,
+          browser,
+          ["workspace:read"],
+          `mu-other-${uid8()}`,
+        );
+        cleanups.push(outsider.cleanup);
+        const denied = await outsider.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws,
+        });
+        expect(denied.status).toBe(200);
+        expect(denied.body.length).toBe(0);
+      } finally {
+        for (const c of cleanups.reverse()) await c().catch(() => {});
+      }
+    },
+  );
+
+  test(
+    "without usage-read, different users in the same workspace see only their own keys",
+    {
+      tag: "@C2710867",
+      annotation: { type: "slow", description: "two producers in one ws" },
+    },
+    async ({ apiHelper, browser }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 260_000);
+      const ws = `mu-coexist-${uid8()}`;
+      const cleanups: Array<() => Promise<void>> = [];
+      try {
+        await apiHelper.createWorkspace(ws);
+        cleanups.push(() =>
+          apiHelper.deleteWorkspace(ws, { force: true }).then(
+            () => {},
+            () => {},
+          ),
+        );
+        const A = await seedUsage(apiHelper, browser, ws, 9);
+        cleanups.push(A.cleanup);
+        const B = await seedUsage(apiHelper, browser, ws, 11);
+        cleanups.push(B.cleanup);
+
+        // A sees only A's key; B sees only B's key (default isolation).
+        const aList = await A.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws,
+        });
+        expect(aList.body.every((r) => r.api_key_id === A.keyId)).toBe(true);
+        expect(aList.body.some((r) => r.api_key_id === B.keyId)).toBe(false);
+
+        const bList = await B.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws,
+        });
+        expect(bList.body.every((r) => r.api_key_id === B.keyId)).toBe(true);
+        expect(bList.body.some((r) => r.api_key_id === A.keyId)).toBe(false);
+      } finally {
+        for (const c of cleanups.reverse()) await c().catch(() => {});
+      }
+    },
+  );
+
+  test(
+    "workspace:usage-read reveals all keys; revoking it returns to own-key-only",
+    {
+      tag: ["@C2710870", "@C2710871"],
+      annotation: { type: "slow", description: "operator over two producers" },
+    },
+    async ({ apiHelper, browser }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 300_000);
+      const ws = `mu-usage-${uid8()}`;
+      const cleanups: Array<() => Promise<void>> = [];
+      try {
+        await apiHelper.createWorkspace(ws);
+        cleanups.push(() =>
+          apiHelper.deleteWorkspace(ws, { force: true }).then(
+            () => {},
+            () => {},
+          ),
+        );
+        const A = await seedUsage(apiHelper, browser, ws, 9);
+        cleanups.push(A.cleanup);
+        const B = await seedUsage(apiHelper, browser, ws, 11);
+        cleanups.push(B.cleanup);
+
+        // Operator with usage-read (workspace-scoped) sees BOTH keys.
+        const operator = await makeReader(
+          apiHelper,
+          browser,
+          ["workspace:read", "workspace:usage-read"],
+          ws,
+        );
+        cleanups.push(operator.cleanup);
+        const full = await operator.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws,
+        });
+        expect(full.status).toBe(200);
+        expect(full.body.some((r) => r.api_key_id === A.keyId)).toBe(true);
+        expect(full.body.some((r) => r.api_key_id === B.keyId)).toBe(true);
+
+        // Filtering to one key returns only that key (C2710870 filter step).
+        const onlyA = await operator.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws,
+          apiKeyId: A.keyId,
+        });
+        expect(onlyA.body.every((r) => r.api_key_id === A.keyId)).toBe(true);
+        expect(onlyA.body.length).toBeGreaterThan(0);
+
+        // Revoke usage-read → operator (no own key) now sees nothing (C2710871).
+        await operator.setPermissions(["workspace:read"]);
+        const afterRevoke = await operator.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws,
+        });
+        expect(afterRevoke.status).toBe(200);
+        expect(afterRevoke.body.some((r) => r.api_key_id === A.keyId)).toBe(
+          false,
+        );
+        expect(afterRevoke.body.some((r) => r.api_key_id === B.keyId)).toBe(
+          false,
+        );
+
+        // A, as a plain member, still only ever saw its own key.
+        const aList = await A.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: ws,
+        });
+        expect(aList.body.some((r) => r.api_key_id === B.keyId)).toBe(false);
+      } finally {
+        for (const c of cleanups.reverse()) await c().catch(() => {});
+      }
+    },
+  );
+
+  test(
+    "a workspace without read cannot be mixed in via selector, URL, or query",
+    {
+      tag: "@C2710868",
+      annotation: { type: "slow", description: "denied workspace isolation" },
+    },
+    async ({ apiHelper, browser }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 240_000);
+      const allowed = `mu-allow-${uid8()}`;
+      const denied = `mu-deny-${uid8()}`;
+      const cleanups: Array<() => Promise<void>> = [];
+      try {
+        await apiHelper.createWorkspace(allowed);
+        await apiHelper.createWorkspace(denied);
+        cleanups.push(async () => {
+          await apiHelper
+            .deleteWorkspace(allowed, { force: true })
+            .catch(() => {});
+          await apiHelper
+            .deleteWorkspace(denied, { force: true })
+            .catch(() => {});
+        });
+        // Someone else's usage lives in the denied workspace.
+        const other = await seedUsage(apiHelper, browser, denied, 13);
+        cleanups.push(other.cleanup);
+        // Our user can read `allowed` but has no grant on `denied`.
+        const user = await makeReader(
+          apiHelper,
+          browser,
+          ["workspace:read"],
+          allowed,
+        );
+        cleanups.push(user.cleanup);
+
+        // Explicit p_workspace = denied must not leak the other user's usage.
+        const probe = await user.api.getUsageByDimension({
+          start: START,
+          end: END,
+          workspace: denied,
+        });
+        expect(probe.status).toBe(200);
+        expect(probe.body.some((r) => r.api_key_id === other.keyId)).toBe(
+          false,
+        );
+
+        // The "All workspaces" union (no p_workspace) also excludes denied.
+        const union = await user.api.getUsageByDimension({
+          start: START,
+          end: END,
+        });
+        expect(union.body.some((r) => r.workspace === denied)).toBe(false);
+        expect(union.body.some((r) => r.api_key_id === other.keyId)).toBe(
+          false,
+        );
+      } finally {
+        for (const c of cleanups.reverse()) await c().catch(() => {});
+      }
+    },
+  );
+
+  test(
+    "revoking workspace:read removes usage visibility with no residual data",
+    {
+      tag: "@C2710869",
+      annotation: { type: "slow", description: "revoke read mid-session" },
+    },
+    async ({ apiHelper, browser }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 200_000);
+      const ws = `mu-revoke-${uid8()}`;
+      const cleanups: Array<() => Promise<void>> = [];
+      try {
+        await apiHelper.createWorkspace(ws);
+        cleanups.push(() =>
+          apiHelper.deleteWorkspace(ws, { force: true }).then(
+            () => {},
+            () => {},
+          ),
+        );
+        // The user owns usage in ws.
+        const user = await seedUsage(apiHelper, browser, ws, 15);
+        cleanups.push(user.cleanup);
+
+        // Before revoke: the workspace is accessible and the page loads its usage.
+        const wsBefore = await user.api.request<Array<{ metadata: unknown }>>(
+          "GET",
+          `/workspaces?select=metadata&metadata->>name=eq.${ws}`,
+        );
+        expect(wsBefore.body.length).toBe(1);
+        await user.api.page.goto(`/#/${ws}/model-usage`);
+        await expect(user.api.page).toHaveURL(new RegExp(`/${ws}/model-usage`));
+
+        // Revoke workspace:read by editing the producer's role in place (the
+        // workspaces RLS read policy is has_permission('workspace:read', ws), so
+        // this takes effect immediately). Keep external_endpoint:read so only
+        // read is revoked.
+        await apiHelper.updateRole(user.role, ["external_endpoint:read"]);
+
+        // After revoke: the workspace is no longer accessible to the user, so it
+        // cannot be selected/opened and no prior data can be re-fetched.
+        const wsAfter = await user.api.request<Array<{ metadata: unknown }>>(
+          "GET",
+          `/workspaces?select=metadata&metadata->>name=eq.${ws}`,
+        );
+        expect(wsAfter.body.length).toBe(0);
+      } finally {
+        for (const c of cleanups.reverse()) await c().catch(() => {});
+      }
+    },
+  );
+});

--- a/e2e/tests/model-usage-ui.spec.ts
+++ b/e2e/tests/model-usage-ui.spec.ts
@@ -1,0 +1,345 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "../fixtures/base";
+import { MULTI_USER_TIMEOUT } from "../helpers/constants";
+import { produceUsage, usageEnv } from "../helpers/model-usage";
+
+// TestRail suite 2420, Model Usage section — the Model Usage page UI: chart
+// toggle, filter bar, summary cards, detail table, error handling, and the
+// tie-back from produced usage to what the page renders.
+//
+// Opt-in via E2E_AITRACE_ENDPOINT (uses the default-workspace usage produced
+// through the e2e engine).
+
+const env = usageEnv();
+const e = env as NonNullable<typeof env>;
+
+const RPC = "**/rpc/get_usage_by_dimension";
+const EMPTY = "No usage in the selected window.";
+
+/** Navigate to the Model Usage page for `workspace` and wait for first load. */
+async function openModelUsage(page: Page, workspace: string): Promise<void> {
+  await page.goto(`/#/${workspace}/model-usage`);
+  await expect(page.getByText("Daily detail")).toBeVisible({ timeout: 20_000 });
+  // Refresh is disabled while loading; wait for the first fetch to settle.
+  await expect(page.getByRole("button", { name: "Refresh" })).toBeEnabled({
+    timeout: 20_000,
+  });
+}
+
+test.describe("model usage — page UI", () => {
+  test.skip(!env, "set E2E_AITRACE_ENDPOINT to run Model Usage UI tests");
+
+  test("trend chart defaults to line and toggles between line and bar", {
+    tag: "@C2710853",
+  }, async ({ page }) => {
+    await openModelUsage(page, e.workspace);
+
+    const line = page.getByRole("button", { name: "Line chart" });
+    const bar = page.getByRole("button", { name: "Bar chart" });
+
+    // The token total display is always present.
+    await expect(page.getByText("total tokens")).toBeVisible();
+
+    // Default: line selected (secondary variant), bar not.
+    await expect(line).toHaveClass(/bg-secondary/);
+    await expect(bar).not.toHaveClass(/bg-secondary/);
+
+    // Toggle to bar, then back to line — the selection follows each click.
+    await bar.click();
+    await expect(bar).toHaveClass(/bg-secondary/);
+    await expect(line).not.toHaveClass(/bg-secondary/);
+
+    await line.click();
+    await expect(line).toHaveClass(/bg-secondary/);
+    await expect(page.getByText("total tokens")).toBeVisible();
+  });
+
+  test("detail table shows the 8 expected columns and typed rows", {
+    tag: "@C2710855",
+  }, async ({ page }) => {
+    await openModelUsage(page, e.workspace);
+
+    const detail = page
+      .locator("div.border.rounded-md")
+      .filter({ hasText: "Daily detail" });
+    const headers = detail.locator("thead th");
+    const expected = [
+      "Date",
+      "API key",
+      "Type",
+      "Endpoint",
+      "Model",
+      "Prompt",
+      "Completion",
+      "Total",
+    ];
+    await expect(headers).toHaveCount(expected.length);
+    for (let i = 0; i < expected.length; i++) {
+      await expect(headers.nth(i)).toHaveText(expected[i]);
+    }
+
+    // With default-workspace usage present, the body has typed rows: the Type
+    // column is Internal/External/- and Prompt/Completion/Total are numbers.
+    const rows = detail.locator("tbody tr");
+    await expect(rows.first()).toBeVisible();
+    const firstRow = rows.first();
+    await expect(firstRow.locator("td")).toHaveCount(8);
+    // Date cell is a compact M/D value.
+    await expect(firstRow.locator("td").first()).toHaveText(/^\d+\/\d+$/);
+  });
+
+  test("summary cards expose By API key and By model with the right columns", {
+    tag: "@C2710854",
+  }, async ({ page }) => {
+    await openModelUsage(page, e.workspace);
+
+    for (const [title, nameHeader] of [
+      ["By API key", "API key"],
+      ["By model", "Model"],
+    ] as const) {
+      // Scope by the card's exact header text; a plain substring would also
+      // match the trend card's "Daily tokens by API key".
+      const card = page
+        .locator("div.border.rounded-md")
+        .filter({ has: page.getByText(title, { exact: true }) });
+      await expect(card.first()).toBeVisible();
+      const headers = card.first().locator("thead th");
+      await expect(headers).toHaveCount(4);
+      await expect(headers.nth(0)).toHaveText(nameHeader);
+      await expect(headers.nth(1)).toHaveText("Prompt");
+      await expect(headers.nth(2)).toHaveText("Completion");
+      await expect(headers.nth(3)).toHaveText("Total");
+    }
+  });
+
+  test(
+    "produced usage surfaces in the trend total, summary card and detail table",
+    {
+      tag: "@C2710851",
+      annotation: { type: "slow", description: "produces a fresh usage row" },
+    },
+    async ({ page, apiHelper }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 150_000);
+      const ts = Date.now();
+      const keyName = `mu-spine-${ts}`;
+      try {
+        const { sk_value } = await apiHelper.createApiKey(keyName, {
+          workspace: e.workspace,
+        });
+        // Admin can consume the internal e2e endpoint; produce a known row.
+        const row = await produceUsage(apiHelper, e, sk_value, {
+          completionTokens: 29,
+          promptTokens: 3,
+        });
+        expect(row.usage).toBe(32);
+
+        await openModelUsage(page, e.workspace);
+
+        // The fresh key + endpoint appear in the detail table.
+        const detail = page
+          .locator("div.border.rounded-md")
+          .filter({ hasText: "Daily detail" });
+        await expect(detail.getByText(keyName).first()).toBeVisible({
+          timeout: 15_000,
+        });
+        await expect(detail.getByText(e.endpoint).first()).toBeVisible();
+
+        // The By API key summary card lists the fresh key.
+        const byKey = page
+          .locator("div.border.rounded-md")
+          .filter({ has: page.getByText("By API key", { exact: true }) })
+          .first();
+        await expect(byKey.getByText(keyName).first()).toBeVisible();
+      } finally {
+        await apiHelper.deleteApiKey(keyName, { retries: 5 }).catch(() => {});
+      }
+    },
+  );
+
+  test("selecting a single API key auto-switches the chart to bar; clearing restores line", {
+    tag: "@C2710857",
+  }, async ({ page }) => {
+    await openModelUsage(page, e.workspace);
+
+    const line = page.getByRole("button", { name: "Line chart" });
+    const bar = page.getByRole("button", { name: "Bar chart" });
+    await expect(line).toHaveClass(/bg-secondary/);
+
+    // The API key select is the first combobox in the filter bar (scoped so we
+    // don't grab the top-bar workspace selector).
+    const filterBar = page.locator(
+      "div.flex.flex-wrap.items-center.gap-2.mb-4",
+    );
+    const apiKeySelect = filterBar.getByRole("combobox").first();
+
+    // Open the dropdown and pick the first concrete key.
+    await apiKeySelect.click();
+    const concrete = page
+      .getByRole("option")
+      .filter({ hasNotText: "All API keys" })
+      .first();
+    await expect(concrete).toBeVisible();
+    await concrete.click();
+
+    // A single key auto-selects the bar chart.
+    await expect(bar).toHaveClass(/bg-secondary/);
+    await expect(line).not.toHaveClass(/bg-secondary/);
+
+    // Clearing back to "All API keys" auto-restores the line chart.
+    await apiKeySelect.click();
+    await page.getByRole("option", { name: "All API keys" }).click();
+    await expect(line).toHaveClass(/bg-secondary/);
+  });
+
+  test("a failed usage RPC shows an inline error and does not present stale data", {
+    tag: "@C2710865",
+  }, async ({ page }) => {
+    // First load succeeds so there is data that must NOT survive a failure.
+    await openModelUsage(page, e.workspace);
+
+    // Force every subsequent usage RPC to fail.
+    await page.route(RPC, (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "injected failure" }),
+      }),
+    );
+    await page.getByRole("button", { name: "Refresh" }).click();
+
+    // An inline error is shown (not stale rows): the detail table falls back
+    // to its empty state and the destructive error line appears.
+    const detail = page
+      .locator("div.border.rounded-md")
+      .filter({ hasText: "Daily detail" });
+    await expect(detail.getByText(EMPTY)).toBeVisible({ timeout: 15_000 });
+    await expect(page.locator("div.text-destructive")).toBeVisible();
+
+    // Recovery: once the RPC succeeds again, the error clears.
+    await page.unroute(RPC);
+    await page.getByRole("button", { name: "Refresh" }).click();
+    await expect(page.locator("div.text-destructive")).toHaveCount(0, {
+      timeout: 15_000,
+    });
+  });
+
+  test(
+    "the Type filter narrows the detail table to internal or external rows",
+    {
+      tag: "@C2710858",
+      annotation: { type: "slow", description: "produces internal + external" },
+    },
+    async ({ page, apiHelper }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 200_000);
+      const ts = Date.now();
+      const intKey = `mu-int-${ts}`;
+      const extKey = `mu-ext-${ts}`;
+      const eeName = `mu-type-ee-${ts}`;
+      try {
+        const { sk_value: intSk } = await apiHelper.createApiKey(intKey, {
+          workspace: e.workspace,
+        });
+        await produceUsage(apiHelper, e, intSk, { completionTokens: 5 });
+        await apiHelper.createExternalEndpoint(
+          eeName,
+          `${e.gateway.replace(/:\d+$/, "")}:8000/${e.workspace}/${e.endpoint}/v1`,
+          { any: "any" },
+        );
+        const { sk_value: extSk } = await apiHelper.createApiKey(extKey, {
+          workspace: e.workspace,
+        });
+        await produceUsage(apiHelper, e, extSk, {
+          completionTokens: 5,
+          external: true,
+          endpoint: eeName,
+          match: (r) => r.endpoint_name === eeName,
+          timeoutMs: 150_000,
+        });
+
+        await openModelUsage(page, e.workspace);
+        const filterBar = page.locator(
+          "div.flex.flex-wrap.items-center.gap-2.mb-4",
+        );
+        const typeSelect = filterBar.getByRole("combobox").nth(1);
+        const detail = page
+          .locator("div.border.rounded-md")
+          .filter({ hasText: "Daily detail" });
+
+        // Internal: the external endpoint row is hidden.
+        await typeSelect.click();
+        await page.getByRole("option", { name: "Internal" }).click();
+        await expect(detail.getByText(eeName)).toHaveCount(0);
+        await expect(detail.getByText("External", { exact: true })).toHaveCount(
+          0,
+        );
+
+        // External: only the external endpoint row remains.
+        await typeSelect.click();
+        await page.getByRole("option", { name: "External" }).click();
+        await expect(detail.getByText(eeName).first()).toBeVisible();
+        await expect(detail.getByText("Internal", { exact: true })).toHaveCount(
+          0,
+        );
+      } finally {
+        await apiHelper
+          .deleteExternalEndpoint(eeName, { force: true })
+          .catch(() => {});
+        await apiHelper.deleteApiKey(intKey, { retries: 5 }).catch(() => {});
+        await apiHelper.deleteApiKey(extKey, { retries: 5 }).catch(() => {});
+      }
+    },
+  );
+
+  test(
+    "the Model filter narrows rows by a case-insensitive substring",
+    {
+      tag: "@C2710859",
+      annotation: { type: "slow", description: "produces qwen + llama usage" },
+    },
+    async ({ page, apiHelper }, testInfo) => {
+      testInfo.setTimeout(MULTI_USER_TIMEOUT + 200_000);
+      const ts = Date.now();
+      const keyName = `mu-model-${ts}`;
+      const qwen = `Qwen-mu-${ts}`;
+      const llama = `llama-mu-${ts}`;
+      try {
+        const { sk_value } = await apiHelper.createApiKey(keyName, {
+          workspace: e.workspace,
+        });
+        await produceUsage(apiHelper, e, sk_value, {
+          completionTokens: 5,
+          model: qwen,
+        });
+        await produceUsage(apiHelper, e, sk_value, {
+          completionTokens: 7,
+          model: llama,
+        });
+
+        await openModelUsage(page, e.workspace);
+        const filterBar = page.locator(
+          "div.flex.flex-wrap.items-center.gap-2.mb-4",
+        );
+        const modelInput = filterBar.getByPlaceholder("Model");
+        const detail = page
+          .locator("div.border.rounded-md")
+          .filter({ hasText: "Daily detail" });
+
+        // "qwen" substring keeps the Qwen row, drops llama.
+        await modelInput.fill("qwen");
+        await expect(detail.getByText(qwen).first()).toBeVisible();
+        await expect(detail.getByText(llama)).toHaveCount(0);
+
+        // Case-insensitive: "LLAMA" keeps llama, drops Qwen.
+        await modelInput.fill("LLAMA");
+        await expect(detail.getByText(llama).first()).toBeVisible();
+        await expect(detail.getByText(qwen)).toHaveCount(0);
+
+        // No match → empty state.
+        await modelInput.fill(`zzz-none-${ts}`);
+        await expect(detail.getByText(EMPTY)).toBeVisible();
+      } finally {
+        await apiHelper.deleteApiKey(keyName, { retries: 5 }).catch(() => {});
+      }
+    },
+  );
+});

--- a/e2e/tests/model-usage.spec.ts
+++ b/e2e/tests/model-usage.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "../fixtures/base";
+import type { ResourcePage } from "../helpers/resource-page";
+
+// TestRail suite 2420, Model Usage section — Roles create page permission wiring.
+//
+// `workspace:usage-read` one-directionally depends on `workspace:read`:
+// selecting Usage Read auto-selects AND locks Read, but selecting Read alone
+// does not pull in Usage Read. The Workspaces group has 5 actions
+// (read, usage-read, create, update, delete) so the group badge is "x/5".
+
+const GROUP = "Workspaces";
+const READ = "Workspaces:Read";
+const USAGE_READ = "Workspaces:Usage Read";
+const N = 5;
+
+test.describe("model usage — roles usage-read dependency", () => {
+  test("workspace:usage-read one-directionally depends on and locks workspace:read", {
+    tag: "@C2710873",
+  }, async ({ roles }: { roles: ResourcePage }) => {
+    await roles.goToCreate();
+    await roles.form.fillInput("metadata.name", `usage-read-dep-${Date.now()}`);
+
+    const permField = roles.form.field("spec.permissions");
+    const header = permField
+      .locator('[data-testid="permission-group-header"]')
+      .filter({ hasText: GROUP });
+
+    // Step 1 — baseline: nothing selected in the Workspaces group.
+    await expect(
+      header.getByText(`0/${N} Permissions`, { exact: true }),
+    ).toBeVisible();
+    await expect(permField.getByText(READ, { exact: true })).toBeVisible();
+    await expect(
+      permField.getByText(USAGE_READ, { exact: true }),
+    ).toBeVisible();
+
+    // Step 2 — selecting Read alone must NOT auto-select anything else.
+    await permField.getByText(READ, { exact: true }).click();
+    await expect(
+      header.getByText(`1/${N} Permissions`, { exact: true }),
+    ).toBeVisible();
+
+    // Step 3 — deselect Read → back to baseline.
+    await permField.getByText(READ, { exact: true }).click();
+    await expect(
+      header.getByText(`0/${N} Permissions`, { exact: true }),
+    ).toBeVisible();
+
+    // Step 4 — selecting Usage Read auto-selects Read → 2/5.
+    await permField.getByText(USAGE_READ, { exact: true }).click();
+    await expect(
+      header.getByText(`2/${N} Permissions`, { exact: true }),
+    ).toBeVisible();
+
+    // Step 5 — the Read card is now locked (cursor-not-allowed + Lock icon).
+    const lockedRead = permField
+      .locator("div.cursor-not-allowed")
+      .filter({ hasText: READ });
+    await expect(lockedRead).toBeVisible();
+
+    // Step 6 — clicking the locked Read card cannot deselect it: both stay
+    // selected (badge remains 2/5).
+    await lockedRead.click({ force: true });
+    await expect(
+      header.getByText(`2/${N} Permissions`, { exact: true }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds end-to-end coverage for the **Model Usage** feature — the `get_usage_by_dimension` RPC and the Model Usage page. Real usage is produced by driving controlled requests through the AI gateway to a programmable e2e engine endpoint, then forcing the daily-usage aggregation, so token counts, models, and endpoint types are deterministic.

**19 TestRail cases** (suite 2420, Model Usage section):

| Spec | Cases |
|---|---|
| `model-usage.spec.ts` | `workspace:usage-read` → `workspace:read` one-directional lock (C2710873) |
| `model-usage-api.spec.ts` | read-only surface (C2710864), per-key + per-workspace isolation & no-escalation (C2710861), deleted-endpoint retention (C2710862), cross-workspace same-name union (C2710863) |
| `model-usage-rbac.spec.ts` | read entry + isolation (C2710866/867), usage-read reveal + revoke (C2710870/871), denied-workspace isolation (C2710868), revoke read removes access (C2710869) |
| `model-usage-ui.spec.ts` | chart line/bar toggle (C2710853), detail columns (C2710855), summary cards (C2710854), produced-usage spine (C2710851), single-key auto-bar (C2710857), RPC-failure error state (C2710865), Type filter (C2710858), Model substring filter (C2710859) |

## Helpers

- `e2e/helpers/model-usage.ts` — gateway inference, force-aggregate, and usage-row polling.
- `ApiHelper` additions: non-throwing `request()`, `getUsageByDimension()`, `aggregateUsage()`, `updateRole()`, `createExternalEndpoint()`/`deleteExternalEndpoint()`, and a workspace-scoped `createPolicy()`.

## Gating

Usage-producing tests are opt-in via `E2E_AITRACE_ENDPOINT` (a Running e2e engine endpoint); they skip otherwise. The roles-page test (C2710873) needs no special data.

## Not covered

Upgrade (C2710850, infra-only) and a few data/interaction-heavy cases (auto-poll, custom time-window, top-bar workspace switch, cross-feature trace alignment) are left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)