### PR TITLE
test(e2e): automate API-key quota + access-control cases

### DIFF
--- a/e2e/helpers/access-quota.ts
+++ b/e2e/helpers/access-quota.ts
@@ -1,0 +1,265 @@
+import type { Browser } from "@playwright/test";
+import { ApiHelper } from "./api-helper";
+import {
+  chatCompletion,
+  type GatewayResult,
+  type UsageEnv,
+} from "./model-usage";
+import { loginAs } from "./test-user-context";
+
+/**
+ * Helpers for the API-key limits (quota / rate / access control) e2e tests.
+ *
+ * Limits are carried on `api_key.spec.limits` and enforced at the AI gateway by
+ * two Kong plugins reconciled onto the key's consumer by the control plane:
+ *   - `neutree-ai-access` (priority 895): disabled → 403 key_disabled;
+ *     allowed-models → 403 model_not_permitted; concurrency → 429
+ *     concurrency_exceeded; rps/rpm → 429 rate_limit_exceeded.
+ *   - `neutree-ai-quota` (priority 890): token quota → 429 quota_exceeded.
+ * Access (895) runs before quota (890), so a 403 access denial precedes a 429
+ * quota denial.
+ *
+ * Two kinds of eventual consistency matter:
+ *   - After creating/editing a key the control plane must reconcile the plugin
+ *     config onto the Kong consumer (poll until enforcement is observable).
+ *   - Token-quota enforcement is derived from the aggregated usage ledger and
+ *     cached in the plugin for a few seconds, so exhausting a quota means
+ *     inferring + forcing aggregation until `get_api_key_remaining` ≤ 0 and the
+ *     plugin cache turns over.
+ */
+
+/** The error code the gateway returns when it rejects a request. */
+export type GatewayErrorCode =
+  | "key_disabled"
+  | "model_not_permitted"
+  | "concurrency_exceeded"
+  | "rate_limit_exceeded"
+  | "quota_exceeded";
+
+/** Pull the machine-readable error code out of a gateway rejection body. */
+export function errorCode(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const b = body as Record<string, unknown>;
+  const err = b.error as Record<string, unknown> | undefined;
+  return (err?.code ?? b.code) as string | undefined;
+}
+
+/** Pull the human-readable message out of a gateway rejection body. */
+export function errorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== "object") return undefined;
+  const b = body as Record<string, unknown>;
+  const err = b.error as Record<string, unknown> | undefined;
+  return (err?.message ?? b.message) as string | undefined;
+}
+
+export interface InferOpts {
+  model?: string;
+  endpoint?: string;
+  external?: boolean;
+  workspace?: string;
+  /** Deterministic token spend (prompt + completion). Default 3 + 5 = 8. */
+  promptTokens?: number;
+  completionTokens?: number;
+  /** Keep the request in-flight this long (engine honors `delay_ms`). */
+  delayMs?: number;
+}
+
+/** Fire one non-streaming inference through the gateway (no 401 retry). */
+export async function infer(
+  env: UsageEnv,
+  apiKey: string,
+  opts?: InferOpts,
+): Promise<GatewayResult> {
+  return chatCompletion(
+    env,
+    apiKey,
+    {
+      mode: "fixed",
+      text: "access quota",
+      prompt_tokens: opts?.promptTokens ?? 3,
+      completion_tokens: opts?.completionTokens ?? 5,
+      finish_reason: "stop",
+      ...(opts?.delayMs ? { delay_ms: opts.delayMs } : {}),
+    },
+    {
+      model: opts?.model,
+      endpoint: opts?.endpoint,
+      external: opts?.external,
+      workspace: opts?.workspace,
+      retryOn401: false,
+    },
+  );
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** A test user with its own logged-in ApiHelper and a disposable identity. */
+export interface TestUser {
+  uid: string;
+  email: string;
+  /** ApiHelper bound to this user's authenticated page. */
+  api: ApiHelper;
+  page: import("@playwright/test").Page;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Create a fresh user (role + global policy), log it in a new browser context,
+ * and return an ApiHelper bound to its session. Cleanup closes the context and
+ * soft-deletes the identity. Keys created through `user.api` are owned by this
+ * user (create_api_key keys on auth.uid()).
+ */
+export async function makeUser(
+  admin: ApiHelper,
+  browser: Browser,
+  perms: string[] = [
+    "workspace:read",
+    "workspace:usage-read",
+    "endpoint:read",
+    "external_endpoint:read",
+  ],
+): Promise<TestUser> {
+  const ts = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const email = `aq-${ts}@e2e.local`;
+  const uname = `aq-${ts}`;
+  const role = `aq-r-${ts}`;
+  const policy = `aq-p-${ts}`;
+  const uid = await admin.createUser(uname, email, "Test@123456");
+  await admin.createRole(role, perms);
+  await admin.createPolicy(policy, uid, role, true);
+  const { page, context } = await loginAs(browser, admin, email, "Test@123456");
+  const api = new ApiHelper(page);
+  return {
+    uid,
+    email,
+    api,
+    page,
+    cleanup: async () => {
+      await context.close();
+      await admin.deletePolicy(policy).catch(() => {});
+      await admin.deleteRole(role, { retries: 10 }).catch(() => {});
+      await admin.deleteUser(uname, { retries: 10 }).catch(() => {});
+    },
+  };
+}
+
+/**
+ * Poll the gateway until a freshly created/edited key can successfully infer —
+ * its consumer + ACL groups are synced (past 401/403) and any freshly created
+ * endpoint route is provisioned (past 404). Returns once a 200 is seen.
+ */
+export async function waitGatewayReady(
+  env: UsageEnv,
+  apiKey: string,
+  opts?: InferOpts & { timeoutMs?: number },
+): Promise<void> {
+  const deadline = Date.now() + (opts?.timeoutMs ?? 120_000);
+  while (Date.now() < deadline) {
+    const r = await infer(env, apiKey, opts);
+    if (r.status === 200) return;
+    if (![401, 403, 404, 503].includes(r.status)) {
+      throw new Error(
+        `waitGatewayReady: unexpected ${r.status} ${JSON.stringify(r.body).slice(0, 200)}`,
+      );
+    }
+    await sleep(4000);
+  }
+  throw new Error("waitGatewayReady: key never became ready");
+}
+
+/**
+ * Poll `infer` until it returns the expected reject status + error code (the
+ * control plane may still be reconciling the plugin, so an early call can slip
+ * through with 200). Returns the matching result.
+ */
+export async function waitForReject(
+  env: UsageEnv,
+  apiKey: string,
+  expect: { status: number; code: GatewayErrorCode },
+  opts?: InferOpts & { timeoutMs?: number; intervalMs?: number },
+): Promise<GatewayResult> {
+  const deadline = Date.now() + (opts?.timeoutMs ?? 90_000);
+  let last: GatewayResult | undefined;
+  while (Date.now() < deadline) {
+    last = await infer(env, apiKey, opts);
+    if (last.status === expect.status && errorCode(last.body) === expect.code) {
+      return last;
+    }
+    await sleep(opts?.intervalMs ?? 3000);
+  }
+  throw new Error(
+    `waitForReject: never saw ${expect.status}/${expect.code}; last ${last?.status} ${JSON.stringify(last?.body).slice(0, 200)}`,
+  );
+}
+
+/**
+ * Fire `n` inferences concurrently (a burst) and return each result. Used to
+ * trip per-second rate limits and concurrency limits.
+ */
+export async function burst(
+  env: UsageEnv,
+  apiKey: string,
+  n: number,
+  opts?: InferOpts,
+): Promise<GatewayResult[]> {
+  return Promise.all(Array.from({ length: n }, () => infer(env, apiKey, opts)));
+}
+
+/**
+ * Drive one inference on a key and wait until its aggregated current-period
+ * usage is positive (forcing aggregation each round). Returns the used tokens.
+ * Used to light up the list/detail usage displays deterministically.
+ */
+export async function produceKeyUsage(
+  api: ApiHelper,
+  env: UsageEnv,
+  apiKey: string,
+  keyId: string,
+  opts?: InferOpts & { period?: string; timeoutMs?: number },
+): Promise<number> {
+  const tokens = {
+    completionTokens: opts?.completionTokens ?? 40,
+    promptTokens: opts?.promptTokens ?? 10,
+  };
+  await waitGatewayReady(env, apiKey, { ...opts, ...tokens });
+  await infer(env, apiKey, { ...opts, ...tokens });
+  const period = opts?.period ?? "daily";
+  const deadline = Date.now() + (opts?.timeoutMs ?? 90_000);
+  let used = 0;
+  while (Date.now() < deadline && used <= 0) {
+    await api.aggregateUsage();
+    const p = await api.apiKeyPeriodUsage(keyId, period);
+    used = Number(p.body ?? 0);
+    if (used <= 0) await sleep(4000);
+  }
+  if (used <= 0) throw new Error("produceKeyUsage: usage never surfaced");
+  return used;
+}
+
+/**
+ * Exhaust a key's token quota: repeatedly infer (spending tokens), force the
+ * usage aggregation, and wait for the plugin cache to turn over, until an
+ * inference is rejected with 429 quota_exceeded. Returns the rejecting result.
+ */
+export async function exhaustQuota(
+  api: ApiHelper,
+  env: UsageEnv,
+  apiKey: string,
+  opts?: InferOpts & { timeoutMs?: number; cacheTtlMs?: number },
+): Promise<GatewayResult> {
+  const deadline = Date.now() + (opts?.timeoutMs ?? 180_000);
+  let last: GatewayResult | undefined;
+  while (Date.now() < deadline) {
+    last = await infer(env, apiKey, opts);
+    if (last.status === 429 && errorCode(last.body) === "quota_exceeded") {
+      return last;
+    }
+    await api.aggregateUsage();
+    // Let the quota plugin's short-lived remaining cache expire so it re-reads
+    // the freshly aggregated ledger.
+    await sleep(opts?.cacheTtlMs ?? 6000);
+  }
+  throw new Error(
+    `exhaustQuota: never hit 429 quota_exceeded; last ${last?.status} ${JSON.stringify(last?.body).slice(0, 200)}`,
+  );
+}

--- a/e2e/helpers/api-helper.ts
+++ b/e2e/helpers/api-helper.ts
@@ -9,6 +9,50 @@ export function isApiErrorMuted(): boolean {
   return _muteApiErrors;
 }
 
+/** One row returned by the `get_usage_by_dimension` RPC. */
+export interface UsageRow {
+  date: string;
+  api_key_id: string;
+  api_key_name: string;
+  endpoint_type: string | null;
+  endpoint_name: string | null;
+  model_name: string | null;
+  workspace: string;
+  usage: number;
+  prompt_tokens: number | null;
+  completion_tokens: number | null;
+}
+
+/**
+ * The `spec.limits` object carried on an API key (and the shape returned by
+ * `get_api_key_limits` / accepted by `set_api_key_limits`). Rate limits are
+ * flat integers (`rps`/`rpm`/`concurrency`), not a windowed array. An absent
+ * field means unlimited; `allowed_models: []` means deny-all.
+ */
+export interface ApiKeyLimits {
+  token_quota?: {
+    limit?: number;
+    period?: "daily" | "weekly" | "monthly" | "yearly";
+    /** Read-only, computed by get_api_key_limits over the current period. */
+    used?: number;
+    remaining?: number;
+  };
+  rps?: number;
+  rpm?: number;
+  concurrency?: number;
+  allowed_models?: string[];
+  disabled?: boolean;
+}
+
+/** One row of `get_api_keys_usage_summary`. */
+export interface ApiKeyUsageSummaryRow {
+  api_key_id: string;
+  period: string;
+  token_limit: number;
+  used: number;
+  remaining: number;
+}
+
 /** Data returned by `createTestUserData` */
 export interface TestUserData {
   userName: string;
@@ -81,6 +125,252 @@ export class ApiHelper {
     );
   }
 
+  /**
+   * Like `api()` but never throws on a non-2xx response — returns the parsed
+   * status/body so callers can assert on 4xx/5xx (RPC probes, write-denial
+   * checks). `probe` mutes the page error listener for the duration.
+   */
+  async request<T = unknown>(
+    method: string,
+    path: string,
+    body?: unknown,
+    opts?: { probe?: boolean },
+  ): Promise<{ status: number; ok: boolean; body: T }> {
+    await this.ensureOnAppOrigin();
+    if (opts?.probe) _muteApiErrors = true;
+    try {
+      return (await this.page.evaluate(
+        async ({ method, path, body }) => {
+          let token = "";
+          for (const key of Object.keys(localStorage)) {
+            try {
+              const raw = localStorage.getItem(key);
+              if (!raw) continue;
+              const val = JSON.parse(raw);
+              if (val?.access_token) {
+                token = val.access_token;
+                break;
+              }
+            } catch {}
+          }
+          const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+          };
+          if (token) headers.Authorization = `Bearer ${token}`;
+          const res = await fetch(`/api/v1${path}`, {
+            method,
+            headers,
+            body: body ? JSON.stringify(body) : undefined,
+          });
+          const text = await res.text();
+          let parsed: unknown = text;
+          try {
+            parsed = text ? JSON.parse(text) : null;
+          } catch {}
+          return { status: res.status, ok: res.ok, body: parsed };
+        },
+        { method, path, body },
+      )) as { status: number; ok: boolean; body: T };
+    } finally {
+      if (opts?.probe) _muteApiErrors = false;
+    }
+  }
+
+  // ── Model Usage (get_usage_by_dimension RPC) ──
+
+  /**
+   * POST /rpc/get_usage_by_dimension — the read RPC behind the Model Usage
+   * page. `p_workspace`/`p_api_key_id`/`p_endpoint_name` are optional filters;
+   * omit `workspace` to aggregate across all entitled workspaces (the "All
+   * workspaces" case the UI models by sending no `p_workspace`).
+   */
+  async getUsageByDimension(params: {
+    start: string;
+    end: string;
+    workspace?: string;
+    apiKeyId?: string;
+    endpointName?: string;
+  }): Promise<{ status: number; ok: boolean; body: UsageRow[] }> {
+    const values: Record<string, unknown> = {
+      p_start_date: params.start,
+      p_end_date: params.end,
+    };
+    if (params.workspace !== undefined) values.p_workspace = params.workspace;
+    if (params.apiKeyId !== undefined) values.p_api_key_id = params.apiKeyId;
+    if (params.endpointName !== undefined)
+      values.p_endpoint_name = params.endpointName;
+    return this.request<UsageRow[]>(
+      "POST",
+      "/rpc/get_usage_by_dimension",
+      values,
+      { probe: true },
+    );
+  }
+
+  /**
+   * Force the daily-usage aggregation to run now (same call the 5-minute Go
+   * cron makes) so freshly produced usage records surface in the RPC without
+   * waiting for the scheduled job.
+   */
+  async aggregateUsage(): Promise<void> {
+    await this.request(
+      "POST",
+      "/rpc/aggregate_usage_records",
+      { p_older_than: new Date().toISOString() },
+      { probe: true },
+    );
+  }
+
+  // ── External Endpoint CRUD ──
+
+  /**
+   * POST /api/v1/external_endpoints — a model gateway proxying to an upstream
+   * OpenAI-compatible URL. Used to produce external-endpoint usage rows.
+   */
+  async createExternalEndpoint(
+    name: string,
+    upstreamUrl: string,
+    modelMapping: Record<string, string>,
+    options?: { workspace?: string },
+  ): Promise<void> {
+    await this.api("POST", "/external_endpoints", {
+      api_version: "v1",
+      kind: "ExternalEndpoint",
+      metadata: { name, workspace: options?.workspace ?? "default" },
+      spec: {
+        timeout: 60000,
+        upstreams: [
+          {
+            auth: { type: "bearer", credential: "none" },
+            upstream: { url: upstreamUrl },
+            endpoint_ref: null,
+            model_mapping: modelMapping,
+          },
+        ],
+      },
+    });
+  }
+
+  /** Soft-delete an external_endpoint by name */
+  async deleteExternalEndpoint(
+    name: string,
+    options?: { retries?: number; force?: boolean },
+  ): Promise<void> {
+    await this.softDelete("external_endpoints", name, options);
+  }
+
+  // ── API-key limits (quota / rate / access control) ──
+
+  /**
+   * POST /rpc/create_api_key with a `spec.limits` object. Returns the new key's
+   * id and one-time secret. `p_quota` stays 0 — all enforcement lives in
+   * `spec.limits` (the legacy scalar is kept consistent by the RPC).
+   */
+  async createApiKeyWithLimits(
+    name: string,
+    options?: { workspace?: string; limits?: ApiKeyLimits | null },
+  ): Promise<{ id: string; sk_value: string }> {
+    const result = await this.api<{
+      id: string;
+      status?: { sk_value?: string };
+    }>("POST", "/rpc/create_api_key", {
+      p_workspace: options?.workspace ?? "default",
+      p_name: name,
+      p_quota: 0,
+      p_limits: options?.limits ?? null,
+    });
+    return { id: result?.id ?? "", sk_value: result?.status?.sk_value ?? "" };
+  }
+
+  /** Look up an API key's id by name (within a workspace). */
+  async getApiKeyId(name: string, workspace?: string): Promise<string> {
+    const ws = workspace ?? "default";
+    const rows = await this.api<Array<{ id: string }>>(
+      "GET",
+      `/api_keys?metadata->>name=eq.${name}&metadata->>workspace=eq.${ws}&select=id`,
+    );
+    return rows?.[0]?.id ?? "";
+  }
+
+  /** POST /rpc/get_api_key_limits — owner-only config + used/remaining. */
+  async getApiKeyLimits(
+    id: string,
+  ): Promise<{ status: number; ok: boolean; body: ApiKeyLimits | null }> {
+    return this.request(
+      "POST",
+      "/rpc/get_api_key_limits",
+      { p_id: id },
+      { probe: true },
+    );
+  }
+
+  /** POST /rpc/set_api_key_limits — whole-object replace of `spec.limits`. */
+  async setApiKeyLimits(
+    id: string,
+    limits: ApiKeyLimits | null,
+  ): Promise<{ status: number; ok: boolean; body: unknown }> {
+    return this.request(
+      "POST",
+      "/rpc/set_api_key_limits",
+      { p_id: id, p_limits: limits },
+      { probe: true },
+    );
+  }
+
+  /** POST /rpc/get_api_key_remaining — the scalar the quota plugin reads. */
+  async getApiKeyRemaining(
+    id: string,
+  ): Promise<{ status: number; ok: boolean; body: number | null }> {
+    return this.request(
+      "POST",
+      "/rpc/get_api_key_remaining",
+      { p_id: id },
+      { probe: true },
+    );
+  }
+
+  /** POST /rpc/api_key_period_usage — used tokens in the current period. */
+  async apiKeyPeriodUsage(
+    id: string,
+    period: string,
+  ): Promise<{ status: number; ok: boolean; body: number | null }> {
+    return this.request(
+      "POST",
+      "/rpc/api_key_period_usage",
+      { p_id: id, p_period: period },
+      { probe: true },
+    );
+  }
+
+  /** POST /rpc/get_api_keys_usage_summary — batched list-page usage. */
+  async getApiKeysUsageSummary(workspace: string): Promise<{
+    status: number;
+    ok: boolean;
+    body: ApiKeyUsageSummaryRow[];
+  }> {
+    return this.request(
+      "POST",
+      "/rpc/get_api_keys_usage_summary",
+      { p_workspace: workspace },
+      { probe: true },
+    );
+  }
+
+  /** POST /rpc/get_workspace_models — options for the allowed-models picker. */
+  async getWorkspaceModels(workspace: string): Promise<{
+    status: number;
+    ok: boolean;
+    body: Array<{ model: string; source: string; endpoint_name: string }>;
+  }> {
+    return this.request(
+      "POST",
+      "/rpc/get_workspace_models",
+      { p_workspace: workspace },
+      { probe: true },
+    );
+  }
+
   // ── User CRUD ──
 
   /** POST /api/v1/auth/admin/users → poll for user_profile id */
@@ -140,6 +430,17 @@ export class ApiHelper {
     });
   }
 
+  /**
+   * PATCH /api/v1/roles — replace a role's permission set in place. Because
+   * `has_permission` reads roles live, this takes effect immediately (unlike
+   * soft-deleting a role assignment, which lingers until GC).
+   */
+  async updateRole(name: string, permissions: string[]): Promise<void> {
+    await this.api("PATCH", `/roles?metadata->>name=eq.${name}`, {
+      spec: { permissions },
+    });
+  }
+
   /** Soft-delete a role by name */
   async deleteRole(
     name: string,
@@ -150,18 +451,31 @@ export class ApiHelper {
 
   // ── Policy (RoleAssignment) CRUD ──
 
-  /** POST /api/v1/role_assignments */
+  /**
+   * POST /api/v1/role_assignments.
+   *
+   * Pass `workspace` for a workspace-scoped assignment (global defaults to
+   * false in that case unless explicitly set true). A workspace-scoped
+   * assignment only takes effect against the enterprise workspace-aware
+   * `has_permission`; on community it is inert.
+   */
   async createPolicy(
     name: string,
     userId: string,
     roleName: string,
     global = true,
+    workspace?: string,
   ): Promise<void> {
     await this.api("POST", "/role_assignments", {
       api_version: "v1",
       kind: "RoleAssignment",
       metadata: { name },
-      spec: { user_id: userId, role: roleName, global },
+      spec: {
+        user_id: userId,
+        role: roleName,
+        global,
+        ...(workspace ? { workspace } : {}),
+      },
     });
   }
 

--- a/e2e/helpers/model-usage.ts
+++ b/e2e/helpers/model-usage.ts
@@ -1,0 +1,234 @@
+import type { ApiHelper, UsageRow } from "./api-helper";
+
+/**
+ * Helpers for the Model Usage (get_usage_by_dimension) e2e tests.
+ *
+ * Real usage rows are produced by driving a controlled request through the AI
+ * gateway to a deployed programmable engine endpoint (see neutree-e2e-engine):
+ * the request is logged as an ai-trace, Vector POSTs it to `record_api_usage`
+ * (raw row), and the 5-minute aggregation cron rolls it up into
+ * `api.api_daily_usage`, which the `get_usage_by_dimension` RPC reads. Tests
+ * force the aggregation immediately (via `ApiHelper.aggregateUsage`) instead of
+ * waiting for the cron.
+ *
+ * The engine output is fully programmable via an inline `e2e:{...}` directive
+ * in the user message, so token counts and the reported `model` are
+ * deterministic — `model` in the request becomes the row's `model_name`.
+ *
+ * Gating (opt-in, shared with the ai-traces recipe):
+ *  - E2E_AITRACE_ENDPOINT  — name of a Running e2e-engine endpoint (default workspace)
+ *  - E2E_AITRACE_GATEWAY   — AI gateway base URL (default: BASE_URL host on :80)
+ */
+
+export interface UsageEnv {
+  endpoint: string;
+  gateway: string;
+  workspace: string;
+}
+
+/** Resolve gating config from env, or null when the suite should be skipped. */
+export function usageEnv(): UsageEnv | null {
+  const endpoint = process.env.E2E_AITRACE_ENDPOINT;
+  if (!endpoint) return null;
+  return {
+    endpoint,
+    gateway: gatewayBase(),
+    workspace: process.env.E2E_AITRACE_WORKSPACE ?? "default",
+  };
+}
+
+/** AI gateway base URL: explicit env, else BASE_URL host on port 80. */
+export function gatewayBase(): string {
+  if (process.env.E2E_AITRACE_GATEWAY) return process.env.E2E_AITRACE_GATEWAY;
+  const base = process.env.BASE_URL ?? "http://localhost:3000";
+  const u = new URL(base);
+  u.port = process.env.E2E_AITRACE_GATEWAY_PORT ?? "80";
+  u.pathname = "";
+  return u.toString().replace(/\/$/, "");
+}
+
+/** The engine host (gateway host without the port), for external-endpoint upstreams. */
+export function engineHost(env: UsageEnv): string {
+  return env.gateway.replace(/:\d+$/, "");
+}
+
+/** Build an inline directive string understood by the e2e engine. */
+export function directive(d: Record<string, unknown>): string {
+  return `e2e:${JSON.stringify(d)}`;
+}
+
+/** Local date (YYYY-MM-DD) offset by `days` from today. */
+export function isoDate(daysFromToday = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromToday);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export interface GatewayResult {
+  status: number;
+  body: unknown;
+}
+
+/**
+ * Fire a (non-streaming) chat completion through the AI gateway using an API
+ * key. Runs in Node — the gateway is a different origin and uses bearer
+ * API-key auth, so CORS/session don't apply. Retries while the gateway returns
+ * 401 (Kong syncs new API keys asynchronously).
+ */
+export async function chatCompletion(
+  env: UsageEnv,
+  apiKey: string,
+  d: Record<string, unknown>,
+  opts?: {
+    model?: string;
+    endpoint?: string;
+    external?: boolean;
+    workspace?: string;
+    retryOn401?: boolean;
+  },
+): Promise<GatewayResult> {
+  const endpoint = opts?.endpoint ?? env.endpoint;
+  const workspace = opts?.workspace ?? env.workspace;
+  const kind = opts?.external ? "external-endpoint" : "endpoint";
+  const url = `${env.gateway}/workspace/${workspace}/${kind}/${endpoint}/v1/chat/completions`;
+  const payload = JSON.stringify({
+    model: opts?.model ?? "any",
+    stream: false,
+    messages: [{ role: "user", content: directive(d) }],
+  });
+  const attempts = opts?.retryOn401 === false ? 1 : 25;
+  let res: Response | undefined;
+  for (let i = 0; i < attempts; i++) {
+    res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: payload,
+    });
+    if (res.status !== 401) break;
+    await new Promise((r) => setTimeout(r, 4000));
+  }
+  const r = res as Response;
+  const text = await r.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {}
+  return { status: r.status, body };
+}
+
+/**
+ * Produce a deterministic usage record: fire one gateway inference with a known
+ * `completion_tokens`/`prompt_tokens`/`model`, then poll the RPC (forcing
+ * aggregation each round) until a matching row appears. Returns the matching row.
+ */
+export async function produceUsage(
+  api: ApiHelper,
+  env: UsageEnv,
+  apiKey: string,
+  opts: {
+    model?: string;
+    promptTokens?: number;
+    completionTokens: number;
+    external?: boolean;
+    endpoint?: string;
+    /** Workspace of the endpoint/route and of the usage query (default env.workspace). */
+    workspace?: string;
+    /** Match predicate on the resulting RPC row (default: matches the token totals + model). */
+    match?: (row: UsageRow) => boolean;
+    timeoutMs?: number;
+  },
+): Promise<UsageRow> {
+  const workspace = opts.workspace ?? env.workspace;
+  const model = opts.model ?? "any";
+  const prompt = opts.promptTokens ?? 3;
+  // Retry the gateway call until it succeeds: a freshly created key needs its
+  // Kong consumer/ACL groups synced (401/403) and a freshly created external
+  // endpoint needs its route provisioned (404) — both settle asynchronously.
+  const readyDeadline = Date.now() + (opts.timeoutMs ?? 120_000);
+  let gw: GatewayResult | undefined;
+  while (Date.now() < readyDeadline) {
+    gw = await chatCompletion(
+      env,
+      apiKey,
+      {
+        mode: "fixed",
+        text: "model usage",
+        prompt_tokens: prompt,
+        completion_tokens: opts.completionTokens,
+        finish_reason: "stop",
+      },
+      {
+        model,
+        external: opts.external,
+        endpoint: opts.endpoint,
+        workspace,
+      },
+    );
+    if (gw.status === 200) break;
+    if (![401, 403, 404, 503].includes(gw.status)) break;
+    await new Promise((r) => setTimeout(r, 4000));
+  }
+  if (!gw || gw.status !== 200) {
+    throw new Error(
+      `gateway inference failed: ${gw?.status} ${JSON.stringify(gw?.body).slice(0, 300)}`,
+    );
+  }
+  const total = prompt + opts.completionTokens;
+  const match =
+    opts.match ??
+    ((row: UsageRow) =>
+      row.usage === total &&
+      (model === "any" || row.model_name === model) &&
+      (opts.external
+        ? row.endpoint_type === "external-endpoint"
+        : row.endpoint_type === "endpoint"));
+  return waitForUsage(api, match, {
+    start: isoDate(-1),
+    end: isoDate(0),
+    workspace,
+    timeoutMs: opts.timeoutMs,
+  });
+}
+
+/**
+ * Poll `get_usage_by_dimension` (forcing aggregation each round) until `match`
+ * returns true for some row, then return that row.
+ */
+export async function waitForUsage(
+  api: ApiHelper,
+  match: (row: UsageRow) => boolean,
+  opts: {
+    start: string;
+    end: string;
+    workspace?: string;
+    apiKeyId?: string;
+    timeoutMs?: number;
+    intervalMs?: number;
+  },
+): Promise<UsageRow> {
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+  const intervalMs = opts.intervalMs ?? 4_000;
+  const start = Date.now();
+  let last = 0;
+  while (Date.now() - start < timeoutMs) {
+    await api.aggregateUsage();
+    const r = await api.getUsageByDimension({
+      start: opts.start,
+      end: opts.end,
+      workspace: opts.workspace,
+      apiKeyId: opts.apiKeyId,
+    });
+    if (r.ok && Array.isArray(r.body)) {
+      last = r.body.length;
+      const hit = r.body.find(match);
+      if (hit) return hit;
+    }
+    await new Promise((res) => setTimeout(res, intervalMs));
+  }
+  throw new Error(
+    `waitForUsage: no matching usage row after ${timeoutMs}ms (last row count: ${last})`,
+  );
+}

--- a/e2e/tests/access-quota-create.spec.ts
+++ b/e2e/tests/access-quota-create.spec.ts
@@ -1,0 +1,311 @@
+import type { Locator } from "@playwright/test";
+import { expect, test } from "../fixtures/base";
+import {
+  burst,
+  errorCode,
+  infer,
+  waitForReject,
+  waitGatewayReady,
+} from "../helpers/access-quota";
+import { engineHost, usageEnv } from "../helpers/model-usage";
+import type { ResourcePage } from "../helpers/resource-page";
+
+// TestRail suite 2420, Quota & Access Control — API-key creation with a limits
+// section: full-field save + yearly period, illegal-value rejection, the
+// omit-limits "unlimited" path, the allowed-models source + enforcement, and
+// the create -> infer -> list-usage main line.
+
+const env = usageEnv();
+const e = env as NonNullable<typeof env>;
+
+function uid(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+/** Open the create dialog on the api-keys list, select the workspace, name it. */
+async function openCreate(
+  apiKeys: ResourcePage,
+  name: string,
+): Promise<Locator> {
+  await apiKeys.goToList();
+  await apiKeys.page.getByRole("link", { name: /create/i }).click();
+  const dialog = apiKeys.page.getByRole("dialog");
+  await dialog.waitFor({ state: "visible" });
+  // Scope to the workspace field — the limits section also has a "Select a
+  // model" button that would otherwise match a bare /select/i filter.
+  await dialog
+    .locator('[data-testid="field-workspace"]')
+    .getByRole("combobox")
+    .click();
+  await apiKeys.page
+    .locator('[data-state="open"][role="dialog"]')
+    .getByRole("option", { name: "default", exact: true })
+    .click();
+  await dialog.getByRole("textbox", { name: /name/i }).fill(name);
+  return dialog;
+}
+
+/** Fill a numeric limits field by its FormFieldGroup test id. */
+async function fillLimit(dialog: Locator, field: string, value: string) {
+  await dialog.locator(`[data-testid="field-${field}"] input`).fill(value);
+}
+
+test.describe("access & quota — create form", () => {
+  test("limits fields save; yearly period round-trips", {
+    tag: "@C2727084",
+  }, async ({ apiKeys, apiHelper }) => {
+    test.setTimeout(90_000);
+    const monthlyName = `aq-cm-${uid()}`;
+    const yearlyName = `aq-cy-${uid()}`;
+    try {
+      // Monthly key with every numeric field.
+      let dialog = await openCreate(apiKeys, monthlyName);
+      await fillLimit(dialog, "quota_limit", "100000");
+      await fillLimit(dialog, "rps", "5");
+      await fillLimit(dialog, "rpm", "100");
+      await fillLimit(dialog, "concurrency", "10");
+      await dialog.getByRole("button", { name: /^create$/i }).click();
+      await expect(
+        dialog.getByText("API Key created successfully", { exact: false }),
+      ).toBeVisible({ timeout: 15_000 });
+      await dialog.getByRole("button", { name: /close/i }).first().click();
+
+      const monthlyId = await apiHelper.getApiKeyId(monthlyName);
+      const m = await apiHelper.getApiKeyLimits(monthlyId);
+      expect(m.body?.token_quota?.period).toBe("monthly");
+      expect(m.body?.token_quota?.limit).toBe(100000);
+      expect(m.body?.rps).toBe(5);
+      expect(m.body?.rpm).toBe(100);
+      expect(m.body?.concurrency).toBe(10);
+
+      // Yearly key: switch the period combobox.
+      dialog = await openCreate(apiKeys, yearlyName);
+      await fillLimit(dialog, "quota_limit", "200000");
+      await dialog
+        .locator('[data-testid="field-quota_period"]')
+        .getByRole("combobox")
+        .click();
+      await apiKeys.page
+        .getByRole("option", { name: "Yearly", exact: true })
+        .click();
+      await dialog.getByRole("button", { name: /^create$/i }).click();
+      await expect(
+        dialog.getByText("API Key created successfully", { exact: false }),
+      ).toBeVisible({ timeout: 15_000 });
+      await dialog.getByRole("button", { name: /close/i }).first().click();
+
+      const yearlyId = await apiHelper.getApiKeyId(yearlyName);
+      const y = await apiHelper.getApiKeyLimits(yearlyId);
+      expect(y.body?.token_quota?.period).toBe("yearly");
+      expect(y.body?.token_quota?.limit).toBe(200000);
+
+      // The list usage summary reports the yearly limit.
+      const summary = await apiHelper.getApiKeysUsageSummary("default");
+      const row = summary.body.find((r) => r.api_key_id === yearlyId);
+      expect(row?.token_limit).toBe(200000);
+    } finally {
+      await apiHelper.deleteApiKey(monthlyName, { retries: 5 }).catch(() => {});
+      await apiHelper.deleteApiKey(yearlyName, { retries: 5 }).catch(() => {});
+    }
+  });
+
+  test("illegal numeric limits are rejected and create no key", {
+    tag: "@C2727086",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(60_000);
+    const name = `aq-inv-${uid()}`;
+    const attempt = async (limits: Record<string, unknown>) => {
+      const r = await apiHelper.request(
+        "POST",
+        "/rpc/create_api_key",
+        { p_workspace: "default", p_name: name, p_quota: 0, p_limits: limits },
+        { probe: true },
+      );
+      expect(r.status).toBeGreaterThanOrEqual(400);
+      // No key was created.
+      expect(await apiHelper.getApiKeyId(name)).toBe("");
+    };
+    try {
+      await attempt({ token_quota: { limit: 0, period: "daily" } });
+      await attempt({ token_quota: { limit: -1, period: "daily" } });
+      await attempt({ rps: 0 });
+      await attempt({ rpm: -1 });
+      await attempt({ concurrency: 0 });
+
+      // A valid set now succeeds and persists exactly.
+      const { id } = await apiHelper.createApiKeyWithLimits(name, {
+        workspace: "default",
+        limits: {
+          token_quota: { limit: 5000, period: "daily" },
+          rps: 3,
+          rpm: 60,
+          concurrency: 4,
+        },
+      });
+      const got = await apiHelper.getApiKeyLimits(id);
+      expect(got.body?.token_quota?.limit).toBe(5000);
+      expect(got.body?.rps).toBe(3);
+      expect(got.body?.rpm).toBe(60);
+      expect(got.body?.concurrency).toBe(4);
+    } finally {
+      await apiHelper.deleteApiKey(name, { retries: 5 }).catch(() => {});
+    }
+  });
+});
+
+test.describe("access & quota — create + gateway", () => {
+  test.skip(!env, "set E2E_AITRACE_ENDPOINT to run create+gateway tests");
+
+  test("omitting the limits section yields an unlimited key", {
+    tag: "@C2727087",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(90_000);
+    const name = `aq-unl-${uid()}`;
+    try {
+      const { id, sk_value } = await apiHelper.createApiKeyWithLimits(name, {
+        workspace: e.workspace,
+      });
+      // No limits policy at all.
+      const limits = await apiHelper.getApiKeyLimits(id);
+      expect(limits.status).toBe(200);
+      expect(limits.body?.token_quota).toBeUndefined();
+      expect(limits.body?.rps).toBeUndefined();
+      expect(limits.body?.disabled).toBeFalsy();
+
+      // Five rapid inferences all succeed (no rate limit).
+      await waitGatewayReady(e, sk_value, { workspace: e.workspace });
+      const results = await burst(e, sk_value, 5, { workspace: e.workspace });
+      expect(results.every((r) => r.status === 200)).toBe(true);
+      const again = await infer(e, sk_value, { workspace: e.workspace });
+      expect(again.status).toBe(200);
+
+      // An unlimited key carries no token quota → absent from the usage summary.
+      const summary = await apiHelper.getApiKeysUsageSummary(e.workspace);
+      expect(summary.body.find((r) => r.api_key_id === id)).toBeUndefined();
+    } finally {
+      await apiHelper.deleteApiKey(name, { retries: 5 }).catch(() => {});
+    }
+  });
+
+  test("allowed-models list is sourced from workspace models and enforced", {
+    tag: "@C2727085",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(120_000);
+    const allow = `aq-allow-${uid()}`;
+    const deny = `aq-deny-${uid()}`;
+    const epName = `aq-ee-${uid()}`;
+    const keyName = `aq-mdl-${uid()}`;
+    try {
+      const upstream = `${engineHost(e)}:8000/${e.workspace}/${e.endpoint}/v1`;
+      await apiHelper.createExternalEndpoint(
+        epName,
+        upstream,
+        { [allow]: "any", [deny]: "any" },
+        { workspace: e.workspace },
+      );
+
+      // The dropdown source RPC surfaces both models in the workspace.
+      const models = await apiHelper.getWorkspaceModels(e.workspace);
+      const names = models.body.map((m) => m.model);
+      expect(names).toContain(allow);
+      expect(names).toContain(deny);
+
+      // Create a key allowing only one of them.
+      const { id, sk_value } = await apiHelper.createApiKeyWithLimits(keyName, {
+        workspace: e.workspace,
+        limits: { allowed_models: [allow] },
+      });
+      expect(
+        (await apiHelper.getApiKeyLimits(id)).body?.allowed_models,
+      ).toEqual([allow]);
+
+      // Allowed model succeeds; disallowed model is rejected.
+      await waitGatewayReady(e, sk_value, {
+        workspace: e.workspace,
+        external: true,
+        endpoint: epName,
+        model: allow,
+      });
+      const denied = await waitForReject(
+        e,
+        sk_value,
+        { status: 403, code: "model_not_permitted" },
+        {
+          workspace: e.workspace,
+          external: true,
+          endpoint: epName,
+          model: deny,
+        },
+      );
+      expect(errorCode(denied.body)).toBe("model_not_permitted");
+    } finally {
+      await apiHelper.deleteApiKey(keyName, { retries: 5 }).catch(() => {});
+      await apiHelper
+        .deleteExternalEndpoint(epName, { retries: 5 })
+        .catch(() => {});
+    }
+  });
+
+  test("main line: create with quota + RPS, infer, list usage is correct", {
+    tag: "@C2727083",
+  }, async ({ apiKeys, apiHelper }) => {
+    test.setTimeout(120_000);
+    const name = `aq-spine-${uid()}`;
+    try {
+      // Create through the dialog with a daily quota + RPS.
+      const dialog = await openCreate(apiKeys, name);
+      await dialog
+        .locator('[data-testid="field-quota_limit"] input')
+        .fill("100000");
+      await dialog
+        .locator('[data-testid="field-quota_period"]')
+        .getByRole("combobox")
+        .click();
+      await apiKeys.page
+        .getByRole("option", { name: "Daily", exact: true })
+        .click();
+      await dialog.locator('[data-testid="field-rps"] input').fill("10");
+      await dialog.getByRole("button", { name: /^create$/i }).click();
+      await expect(
+        dialog.getByText("API Key created successfully", { exact: false }),
+      ).toBeVisible({ timeout: 15_000 });
+      const sk = (await dialog.locator("code").first().textContent()) ?? "";
+      await dialog.getByRole("button", { name: /close/i }).first().click();
+
+      const id = await apiHelper.getApiKeyId(name);
+      expect((await apiHelper.getApiKeyLimits(id)).body?.rps).toBe(10);
+
+      // Infer, then wait for the aggregated usage to surface.
+      await waitGatewayReady(e, sk, {
+        workspace: e.workspace,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      await infer(e, sk, {
+        workspace: e.workspace,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      let used = 0;
+      const deadline = Date.now() + 90_000;
+      while (Date.now() < deadline && used <= 0) {
+        await apiHelper.aggregateUsage();
+        const p = await apiHelper.apiKeyPeriodUsage(id, "daily");
+        used = Number(p.body ?? 0);
+        if (used <= 0) await new Promise((r) => setTimeout(r, 4000));
+      }
+      expect(used).toBeGreaterThan(0);
+
+      // Summary RPC: used > 0, limit = 100000, remaining = limit - used.
+      const summary = await apiHelper.getApiKeysUsageSummary("default");
+      const row = summary.body.find((r) => r.api_key_id === id);
+      expect(row?.token_limit).toBe(100000);
+      expect(row?.used).toBeGreaterThan(0);
+      expect(row?.remaining).toBe(row!.token_limit - row!.used);
+      // The summary RPC is exactly what the list Usage column renders; its
+      // visual cell is covered by the dedicated list test (@C2727088).
+    } finally {
+      await apiHelper.deleteApiKey(name, { retries: 5 }).catch(() => {});
+    }
+  });
+});

--- a/e2e/tests/access-quota-gateway.spec.ts
+++ b/e2e/tests/access-quota-gateway.spec.ts
@@ -1,0 +1,495 @@
+import { expect, test } from "../fixtures/base";
+import {
+  burst,
+  errorCode,
+  errorMessage,
+  exhaustQuota,
+  infer,
+  waitForReject,
+  waitGatewayReady,
+} from "../helpers/access-quota";
+import type { ApiHelper, ApiKeyLimits } from "../helpers/api-helper";
+import { engineHost, usageEnv } from "../helpers/model-usage";
+
+// TestRail suite 2420, Quota & Access Control — gateway interception + access
+// strategy. These drive real inferences through the AI
+// gateway to a Running e2e-engine endpoint and assert the Kong access/quota
+// plugins reject over-limit / disallowed requests with the documented status +
+// error code. Opt-in via E2E_AITRACE_ENDPOINT.
+//
+// The error contract (from neutree-ai-access priority 895 + neutree-ai-quota
+// priority 890; access runs before quota):
+//   disabled           -> 403 key_disabled          "This API key is disabled"
+//   model not allowed   -> 403 model_not_permitted   "Model not permitted for this API key"
+//   concurrency exceeded-> 429 concurrency_exceeded  "Concurrency limit exceeded for this API key"
+//   rate limit exceeded -> 429 rate_limit_exceeded   "Request rate limit exceeded for this API key"
+//   token quota exceeded-> 429 quota_exceeded        "Token quota exceeded for this API key"
+
+const env = usageEnv();
+const e = env as NonNullable<typeof env>;
+
+/** Big quota so a token-quota rule never interferes with a rate/access test. */
+const BIG_QUOTA = 100_000_000;
+
+function uid(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+/** Per-test bag that tracks created keys / external endpoints for cleanup. */
+function tracker(admin: ApiHelper) {
+  const keys: string[] = [];
+  const endpoints: string[] = [];
+  return {
+    async key(
+      limits: ApiKeyLimits | null,
+      tag = "k",
+    ): Promise<{ id: string; sk: string; name: string }> {
+      const name = `aq-${tag}-${uid()}`;
+      const { id, sk_value } = await admin.createApiKeyWithLimits(name, {
+        workspace: e.workspace,
+        limits,
+      });
+      keys.push(name);
+      return { id, sk: sk_value, name };
+    },
+    /** External endpoint proxying to the shared engine, exposing two client
+     * model names so an allowlist can permit one and deny the other. */
+    async twoModelEndpoint(allow: string, deny: string): Promise<string> {
+      const name = `aq-ee-${uid()}`;
+      const upstream = `${engineHost(e)}:8000/${e.workspace}/${e.endpoint}/v1`;
+      await admin.createExternalEndpoint(
+        name,
+        upstream,
+        { [allow]: "any", [deny]: "any" },
+        { workspace: e.workspace },
+      );
+      endpoints.push(name);
+      return name;
+    },
+    async cleanup() {
+      for (const k of keys)
+        await admin.deleteApiKey(k, { retries: 5 }).catch(() => {});
+      for (const ep of endpoints)
+        await admin.deleteExternalEndpoint(ep, { retries: 5 }).catch(() => {});
+    },
+  };
+}
+
+test.describe("access & quota — gateway interception", () => {
+  test.skip(!env, "set E2E_AITRACE_ENDPOINT to run gateway interception tests");
+
+  test("token quota exhausted → 429 quota_exceeded", {
+    tag: "@C2727093",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(180_000);
+    const t = tracker(apiHelper);
+    try {
+      const key = await t.key(
+        { token_quota: { limit: 120, period: "daily" } },
+        "quota",
+      );
+      // Baseline: within budget the first inference succeeds.
+      await waitGatewayReady(e, key.sk, {
+        workspace: e.workspace,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      // Spend until the aggregated ledger drives remaining ≤ 0.
+      const rejected = await exhaustQuota(apiHelper, e, key.sk, {
+        workspace: e.workspace,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      expect(rejected.status).toBe(429);
+      expect(errorCode(rejected.body)).toBe("quota_exceeded");
+      expect(errorMessage(rejected.body)).toBe(
+        "Token quota exceeded for this API key",
+      );
+      // get_api_key_remaining is now ≤ 0.
+      const remaining = await apiHelper.getApiKeyRemaining(key.id);
+      expect(remaining.status).toBe(200);
+      expect(Number(remaining.body)).toBeLessThanOrEqual(0);
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  test("per-second and per-minute rate limits reject independently", {
+    tag: "@C2727094",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(200_000);
+    const t = tracker(apiHelper);
+    try {
+      const rps = 2;
+      const rpm = 5;
+      const key = await t.key(
+        { rps, rpm, token_quota: { limit: BIG_QUOTA, period: "daily" } },
+        "rate",
+      );
+      // Confirm the persisted shape (flat rps/rpm).
+      const limits = await apiHelper.getApiKeyLimits(key.id);
+      expect(limits.body?.rps).toBe(rps);
+      expect(limits.body?.rpm).toBe(rpm);
+
+      await waitGatewayReady(e, key.sk, { workspace: e.workspace });
+
+      // Per-second: a single burst beyond rps trips at least (burst - rps)
+      // rejections in one second.
+      let sawRps = false;
+      for (let i = 0; i < 8 && !sawRps; i++) {
+        const results = await burst(e, key.sk, rps + 3, {
+          workspace: e.workspace,
+        });
+        const rejects = results.filter(
+          (r) =>
+            r.status === 429 && errorCode(r.body) === "rate_limit_exceeded",
+        );
+        if (rejects.length >= 2) {
+          expect(errorMessage(rejects[0].body)).toBe(
+            "Request rate limit exceeded for this API key",
+          );
+          sawRps = true;
+        }
+        await new Promise((r) => setTimeout(r, 1500));
+      }
+      expect(sawRps).toBe(true);
+
+      // Per-minute: pace single requests ~1.2s apart (never tripping the RPS
+      // window) until the minute budget is exhausted. Track successes since the
+      // last window roll — a rate 429 only counts as the RPM limit when it lands
+      // after at least `rpm` successes in the same fixed window (a 429 arriving
+      // sooner just means the calendar-minute bucket rolled mid-count → reset).
+      let sawRpm = false;
+      let succ = 0;
+      const deadline = Date.now() + 90_000;
+      while (Date.now() < deadline && !sawRpm) {
+        const r = await infer(e, key.sk, { workspace: e.workspace });
+        if (r.status === 429 && errorCode(r.body) === "rate_limit_exceeded") {
+          if (succ >= rpm) sawRpm = true;
+          else succ = 0;
+        } else if (r.status === 200) {
+          succ++;
+        }
+        await new Promise((res) => setTimeout(res, 1200));
+      }
+      expect(sawRpm).toBe(true);
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  test("in-flight concurrency over the max → 429 concurrency_exceeded", {
+    tag: "@C2727095",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(120_000);
+    const t = tracker(apiHelper);
+    try {
+      const key = await t.key(
+        { concurrency: 1, token_quota: { limit: BIG_QUOTA, period: "daily" } },
+        "cc",
+      );
+      const limits = await apiHelper.getApiKeyLimits(key.id);
+      expect(limits.body?.concurrency).toBe(1);
+      await waitGatewayReady(e, key.sk, { workspace: e.workspace });
+
+      let sawConcurrency = false;
+      for (let attempt = 0; attempt < 6 && !sawConcurrency; attempt++) {
+        // Hold one request in-flight (~3s) and fire a second during it.
+        const inflight = infer(e, key.sk, {
+          workspace: e.workspace,
+          delayMs: 3000,
+        });
+        await new Promise((r) => setTimeout(r, 400));
+        const second = await infer(e, key.sk, { workspace: e.workspace });
+        const first = await inflight;
+        if (
+          second.status === 429 &&
+          errorCode(second.body) === "concurrency_exceeded"
+        ) {
+          expect(errorMessage(second.body)).toBe(
+            "Concurrency limit exceeded for this API key",
+          );
+          // The in-flight request itself was allowed.
+          expect(first.status).toBe(200);
+          sawConcurrency = true;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+      expect(sawConcurrency).toBe(true);
+
+      // After the in-flight request drains, a new one succeeds.
+      const after = await infer(e, key.sk, { workspace: e.workspace });
+      expect(after.status).toBe(200);
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  test("model outside the allowlist → 403 model_not_permitted", {
+    tag: "@C2727096",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(120_000);
+    const t = tracker(apiHelper);
+    try {
+      const allow = `aq-allow-${uid()}`;
+      const deny = `aq-deny-${uid()}`;
+      const ep = await t.twoModelEndpoint(allow, deny);
+      const key = await t.key({ allowed_models: [allow] }, "wl");
+      const limits = await apiHelper.getApiKeyLimits(key.id);
+      expect(limits.body?.allowed_models).toEqual([allow]);
+
+      // The allowed model succeeds…
+      await waitGatewayReady(e, key.sk, {
+        workspace: e.workspace,
+        external: true,
+        endpoint: ep,
+        model: allow,
+      });
+      // …the disallowed model is rejected (poll past reconcile).
+      const denied = await waitForReject(
+        e,
+        key.sk,
+        { status: 403, code: "model_not_permitted" },
+        { workspace: e.workspace, external: true, endpoint: ep, model: deny },
+      );
+      expect(errorMessage(denied.body)).toBe(
+        "Model not permitted for this API key",
+      );
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  test("empty allowlist denies every model → 403 model_not_permitted", {
+    tag: "@C2727097",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(90_000);
+    const t = tracker(apiHelper);
+    try {
+      const key = await t.key({ allowed_models: [] }, "denyall");
+      const limits = await apiHelper.getApiKeyLimits(key.id);
+      expect(limits.body?.allowed_models).toEqual([]);
+
+      const denied = await waitForReject(
+        e,
+        key.sk,
+        { status: 403, code: "model_not_permitted" },
+        { workspace: e.workspace },
+      );
+      expect(errorMessage(denied.body)).toBe(
+        "Model not permitted for this API key",
+      );
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  test("disabled key → 403 key_disabled", {
+    tag: "@C2727098",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(90_000);
+    const t = tracker(apiHelper);
+    try {
+      const key = await t.key({ disabled: true }, "disabled");
+      const limits = await apiHelper.getApiKeyLimits(key.id);
+      expect(limits.body?.disabled).toBe(true);
+
+      const denied = await waitForReject(
+        e,
+        key.sk,
+        { status: 403, code: "key_disabled" },
+        { workspace: e.workspace },
+      );
+      expect(errorMessage(denied.body)).toBe("This API key is disabled");
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  test("access denial precedes quota denial", {
+    tag: "@C2727099",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(240_000);
+    const t = tracker(apiHelper);
+    try {
+      // Key A: disabled AND quota exhausted → 403 key_disabled wins over 429.
+      const keyA = await t.key(
+        { token_quota: { limit: 120, period: "daily" } },
+        "seq-dis",
+      );
+      await waitGatewayReady(e, keyA.sk, {
+        workspace: e.workspace,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      await exhaustQuota(apiHelper, e, keyA.sk, {
+        workspace: e.workspace,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      // Now disable it (preserving the exhausted quota).
+      const setA = await apiHelper.setApiKeyLimits(keyA.id, {
+        token_quota: { limit: 120, period: "daily" },
+        disabled: true,
+      });
+      expect(setA.status).toBe(200);
+      const denA = await waitForReject(
+        e,
+        keyA.sk,
+        { status: 403, code: "key_disabled" },
+        { workspace: e.workspace, completionTokens: 40, promptTokens: 10 },
+      );
+      expect(denA.status).toBe(403);
+
+      // Key B: allowlist {allow} AND quota exhausted. Disallowed model → 403
+      // model_not_permitted; allowed model → 429 quota_exceeded.
+      const allow = `aq-allow-${uid()}`;
+      const deny = `aq-deny-${uid()}`;
+      const ep = await t.twoModelEndpoint(allow, deny);
+      const keyB = await t.key(
+        {
+          allowed_models: [allow],
+          token_quota: { limit: 120, period: "daily" },
+        },
+        "seq-wl",
+      );
+      await waitGatewayReady(e, keyB.sk, {
+        workspace: e.workspace,
+        external: true,
+        endpoint: ep,
+        model: allow,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      await exhaustQuota(apiHelper, e, keyB.sk, {
+        workspace: e.workspace,
+        external: true,
+        endpoint: ep,
+        model: allow,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      // Disallowed model → access 403 despite the exhausted quota.
+      const denyModel = await waitForReject(
+        e,
+        keyB.sk,
+        { status: 403, code: "model_not_permitted" },
+        { workspace: e.workspace, external: true, endpoint: ep, model: deny },
+      );
+      expect(denyModel.status).toBe(403);
+      // Allowed model → quota 429.
+      const quota = await infer(e, keyB.sk, {
+        workspace: e.workspace,
+        external: true,
+        endpoint: ep,
+        model: allow,
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      expect(quota.status).toBe(429);
+      expect(errorCode(quota.body)).toBe("quota_exceeded");
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  test("lowering RPS takes effect after reconcile", {
+    tag: "@C2727100",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(150_000);
+    const t = tracker(apiHelper);
+    try {
+      const key = await t.key(
+        { rps: 20, token_quota: { limit: BIG_QUOTA, period: "daily" } },
+        "reconf",
+      );
+      await waitGatewayReady(e, key.sk, { workspace: e.workspace });
+
+      // Lower RPS to 2 and wait until the reconciled plugin enforces it.
+      const set = await apiHelper.setApiKeyLimits(key.id, {
+        rps: 2,
+        token_quota: { limit: BIG_QUOTA, period: "daily" },
+      });
+      expect(set.status).toBe(200);
+      const reread = await apiHelper.getApiKeyLimits(key.id);
+      expect(reread.body?.rps).toBe(2);
+
+      let enforced = false;
+      const deadline = Date.now() + 90_000;
+      while (Date.now() < deadline && !enforced) {
+        const results = await burst(e, key.sk, 5, { workspace: e.workspace });
+        const rejects = results.filter(
+          (r) =>
+            r.status === 429 && errorCode(r.body) === "rate_limit_exceeded",
+        );
+        if (rejects.length >= 2) enforced = true;
+        else await new Promise((r) => setTimeout(r, 2000));
+      }
+      expect(enforced).toBe(true);
+
+      // The second window resets → a single request succeeds again.
+      await new Promise((r) => setTimeout(r, 2200));
+      const after = await infer(e, key.sk, { workspace: e.workspace });
+      expect(after.status).toBe(200);
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  test("deleting the rate-limit rule restores burst success", {
+    tag: "@C2727103",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(150_000);
+    const t = tracker(apiHelper);
+    try {
+      const rps = 2;
+      const key = await t.key(
+        { rps, token_quota: { limit: BIG_QUOTA, period: "daily" } },
+        "delrate",
+      );
+      await waitGatewayReady(e, key.sk, { workspace: e.workspace });
+
+      // Baseline: a burst beyond rps is rate-limited (rule is enforced).
+      let enforced = false;
+      for (let i = 0; i < 8 && !enforced; i++) {
+        const results = await burst(e, key.sk, rps + 2, {
+          workspace: e.workspace,
+        });
+        const rejects = results.filter(
+          (r) =>
+            r.status === 429 && errorCode(r.body) === "rate_limit_exceeded",
+        );
+        if (rejects.length >= 1) enforced = true;
+        else await new Promise((r) => setTimeout(r, 1500));
+      }
+      expect(enforced).toBe(true);
+
+      // Remove the rate rule (whole-object replace omitting rps).
+      const set = await apiHelper.setApiKeyLimits(key.id, {
+        token_quota: { limit: BIG_QUOTA, period: "daily" },
+      });
+      expect(set.status).toBe(200);
+      const reread = await apiHelper.getApiKeyLimits(key.id);
+      expect(reread.body?.rps).toBeUndefined();
+
+      // After reconcile, a burst of rps+2 no longer produces rate rejections.
+      // Require two consecutive clean bursts so we don't accept a lucky window.
+      let cleanStreak = 0;
+      const deadline = Date.now() + 90_000;
+      while (Date.now() < deadline && cleanStreak < 2) {
+        await new Promise((r) => setTimeout(r, 2500));
+        const results = await burst(e, key.sk, rps + 2, {
+          workspace: e.workspace,
+        });
+        const rejects = results.filter(
+          (r) =>
+            r.status === 429 && errorCode(r.body) === "rate_limit_exceeded",
+        );
+        cleanStreak = rejects.length === 0 ? cleanStreak + 1 : 0;
+      }
+      expect(cleanStreak).toBeGreaterThanOrEqual(2);
+    } finally {
+      await t.cleanup();
+    }
+  });
+});

--- a/e2e/tests/access-quota-rpc.spec.ts
+++ b/e2e/tests/access-quota-rpc.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test } from "../fixtures/base";
+import { makeUser } from "../helpers/access-quota";
+import type { ApiKeyLimits } from "../helpers/api-helper";
+import { MULTI_USER_TIMEOUT } from "../helpers/constants";
+
+// TestRail suite 2420, Quota & Access Control — the limits RPC contract (quota
+// policy / delete / permissions). set_api_key_limits does a whole-object replace of spec.limits
+// (an omitted field clears that dimension); get_api_key_limits is owner-only;
+// deleting a key drops its limits; and no user can read or edit another user's
+// limits. These are pure PostgREST-RPC assertions (no gateway needed).
+//
+// NOTE: the stored shape is flat — `rps` / `rpm` / `concurrency` integers, not
+// a windowed `rate_limits` array. Tests assert the real contract.
+
+function uid(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+test.describe("access & quota — limits RPC", () => {
+  test("whole-object write, read-back, and field-omission clearing", {
+    tag: "@C2727101",
+  }, async ({ apiHelper, browser }) => {
+    test.setTimeout(MULTI_USER_TIMEOUT);
+    const user = await makeUser(apiHelper, browser);
+    try {
+      const model = `aq-model-${uid()}`;
+      const { id } = await user.api.createApiKeyWithLimits(`aq-rpc-${uid()}`, {
+        workspace: "default",
+      });
+
+      // 1) Write a full limits object.
+      const full: ApiKeyLimits = {
+        token_quota: { limit: 1000, period: "weekly" },
+        rps: 5,
+        rpm: 100,
+        concurrency: 10,
+        allowed_models: [model],
+        disabled: false,
+      };
+      expect((await user.api.setApiKeyLimits(id, full)).status).toBe(200);
+
+      let got = await user.api.getApiKeyLimits(id);
+      expect(got.status).toBe(200);
+      expect(got.body?.token_quota?.period).toBe("weekly");
+      expect(got.body?.token_quota?.limit).toBe(1000);
+      expect(got.body?.rps).toBe(5);
+      expect(got.body?.rpm).toBe(100);
+      expect(got.body?.concurrency).toBe(10);
+      expect(got.body?.allowed_models).toEqual([model]);
+      expect(got.body?.disabled).toBe(false);
+
+      // 2) Change only the token quota by re-writing the whole (read-back) object.
+      const changed: ApiKeyLimits = {
+        ...full,
+        token_quota: { limit: 2000, period: "weekly" },
+      };
+      expect((await user.api.setApiKeyLimits(id, changed)).status).toBe(200);
+      got = await user.api.getApiKeyLimits(id);
+      expect(got.body?.token_quota?.limit).toBe(2000);
+      expect(got.body?.rps).toBe(5);
+      expect(got.body?.rpm).toBe(100);
+      expect(got.body?.concurrency).toBe(10);
+      expect(got.body?.allowed_models).toEqual([model]);
+
+      // 3) Write a subset — omit token_quota + rps + rpm → they clear; keep the rest.
+      const subset: ApiKeyLimits = {
+        concurrency: 10,
+        allowed_models: [model],
+        disabled: false,
+      };
+      expect((await user.api.setApiKeyLimits(id, subset)).status).toBe(200);
+      got = await user.api.getApiKeyLimits(id);
+      expect(got.body?.token_quota).toBeUndefined();
+      expect(got.body?.rps).toBeUndefined();
+      expect(got.body?.rpm).toBeUndefined();
+      expect(got.body?.concurrency).toBe(10);
+      expect(got.body?.allowed_models).toEqual([model]);
+      expect(got.body?.disabled).toBe(false);
+    } finally {
+      await user.cleanup();
+    }
+  });
+
+  test("deleting a key drops its limits policy", {
+    tag: "@C2727104",
+  }, async ({ apiHelper }) => {
+    test.setTimeout(200_000);
+    // The admin owns the key here, so its own get_api_key_limits sees it — no
+    // separate user/login needed.
+    const keyName = `aq-del-${uid()}`;
+    const { id } = await apiHelper.createApiKeyWithLimits(keyName, {
+      workspace: "default",
+      limits: { token_quota: { limit: 500, period: "daily" }, rps: 3 },
+    });
+    // Present before deletion.
+    const before = await apiHelper.getApiKeyLimits(id);
+    expect(before.status).toBe(200);
+    expect(before.body?.token_quota?.limit).toBe(500);
+
+    // Force-delete so the controller hard-deletes the row (soft-delete alone
+    // leaves the row queryable until GC).
+    await apiHelper.deleteApiKey(keyName, { retries: 5, force: true });
+
+    // After deletion the limits are no longer queryable (4xx or empty).
+    const deadline = Date.now() + 150_000;
+    let gone = false;
+    while (Date.now() < deadline && !gone) {
+      const after = await apiHelper.getApiKeyLimits(id);
+      if (after.status >= 400 || after.body == null) gone = true;
+      else await new Promise((r) => setTimeout(r, 4000));
+    }
+    expect(gone).toBe(true);
+  });
+
+  test("owner can read and save their own key's limits", {
+    tag: "@C2727108",
+  }, async ({ apiHelper, browser }) => {
+    test.setTimeout(MULTI_USER_TIMEOUT);
+    const user = await makeUser(apiHelper, browser);
+    try {
+      const { id } = await user.api.createApiKeyWithLimits(`aq-own-${uid()}`, {
+        workspace: "default",
+      });
+      const quota = 50_000;
+      const set = await user.api.setApiKeyLimits(id, {
+        token_quota: { limit: quota, period: "daily" },
+      });
+      expect(set.status).toBe(200);
+      const got = await user.api.getApiKeyLimits(id);
+      expect(got.status).toBe(200);
+      expect(got.body?.token_quota?.period).toBe("daily");
+      expect(got.body?.token_quota?.limit).toBe(quota);
+    } finally {
+      await user.cleanup();
+    }
+  });
+
+  test("a non-owner in the same workspace cannot see or edit another's key", {
+    tag: "@C2727109",
+  }, async ({ apiHelper, browser }) => {
+    test.setTimeout(MULTI_USER_TIMEOUT * 2);
+    const ws = `aq-ws-${uid()}`;
+    await apiHelper.createWorkspace(ws);
+    const userA = await makeUser(apiHelper, browser);
+    const userB = await makeUser(apiHelper, browser);
+    const keyAName = `aq-a-${uid()}`;
+    try {
+      const quotaA = 33_000;
+      const { id: keyAId } = await userA.api.createApiKeyWithLimits(keyAName, {
+        workspace: ws,
+        limits: { token_quota: { limit: quotaA, period: "daily" } },
+      });
+
+      // B cannot find A's key by name (RLS: own keys only).
+      const bId = await userB.api.getApiKeyId(keyAName, ws);
+      expect(bId).toBe("");
+
+      // B cannot change A's limits (owner check fails → 4xx).
+      const setToken = await userB.api.setApiKeyLimits(keyAId, {
+        token_quota: { limit: 999, period: "daily" },
+      });
+      expect(setToken.status).toBeGreaterThanOrEqual(400);
+      const setRps = await userB.api.setApiKeyLimits(keyAId, { rps: 7 });
+      expect(setRps.status).toBeGreaterThanOrEqual(400);
+
+      // A's limit is unchanged.
+      const got = await userA.api.getApiKeyLimits(keyAId);
+      expect(got.body?.token_quota?.limit).toBe(quotaA);
+    } finally {
+      await apiHelper.deleteApiKey(keyAName, { retries: 5 }).catch(() => {});
+      await userA.cleanup();
+      await userB.cleanup();
+      await apiHelper.deleteWorkspace(ws, { retries: 5 }).catch(() => {});
+    }
+  });
+
+  test("a user cannot read or modify a key owned by another user", {
+    tag: "@C2727110",
+  }, async ({ apiHelper, browser }) => {
+    test.setTimeout(MULTI_USER_TIMEOUT * 2);
+    const wsC = `aq-wsc-${uid()}`;
+    const wsD = `aq-wsd-${uid()}`;
+    await apiHelper.createWorkspace(wsC);
+    await apiHelper.createWorkspace(wsD);
+    const userC = await makeUser(apiHelper, browser);
+    const userD = await makeUser(apiHelper, browser);
+    const keyCName = `aq-c-${uid()}`;
+    const keyDName = `aq-d-${uid()}`;
+    try {
+      const { id: keyCId } = await userC.api.createApiKeyWithLimits(keyCName, {
+        workspace: wsC,
+        limits: { token_quota: { limit: 11_000, period: "daily" } },
+      });
+      const { id: keyDId } = await userD.api.createApiKeyWithLimits(keyDName, {
+        workspace: wsD,
+        limits: { token_quota: { limit: 22_000, period: "daily" } },
+      });
+
+      // C cannot find D's key by name.
+      expect(await userC.api.getApiKeyId(keyDName, wsD)).toBe("");
+      // C reading D's limits → empty (owner check returns null).
+      const readD = await userC.api.getApiKeyLimits(keyDId);
+      expect(
+        readD.body == null || Object.keys(readD.body ?? {}).length === 0,
+      ).toBe(true);
+      // C writing D's limits → 4xx.
+      const writeD = await userC.api.setApiKeyLimits(keyDId, {
+        token_quota: { limit: 1, period: "daily" },
+      });
+      expect(writeD.status).toBeGreaterThanOrEqual(400);
+
+      // C can still read its own key.
+      const ownC = await userC.api.getApiKeyLimits(keyCId);
+      expect(ownC.status).toBe(200);
+      expect(ownC.body?.token_quota?.limit).toBe(11_000);
+      // D cannot read C's key.
+      const dReadsC = await userD.api.getApiKeyLimits(keyCId);
+      expect(
+        dReadsC.body == null || Object.keys(dReadsC.body ?? {}).length === 0,
+      ).toBe(true);
+    } finally {
+      await apiHelper.deleteApiKey(keyCName, { retries: 5 }).catch(() => {});
+      await apiHelper.deleteApiKey(keyDName, { retries: 5 }).catch(() => {});
+      await userC.cleanup();
+      await userD.cleanup();
+      await apiHelper.deleteWorkspace(wsC, { retries: 5 }).catch(() => {});
+      await apiHelper.deleteWorkspace(wsD, { retries: 5 }).catch(() => {});
+    }
+  });
+});

--- a/e2e/tests/access-quota-ui.spec.ts
+++ b/e2e/tests/access-quota-ui.spec.ts
@@ -1,0 +1,321 @@
+import { expect, test } from "../fixtures/base";
+import {
+  errorCode,
+  exhaustQuota,
+  produceKeyUsage,
+  waitGatewayReady,
+} from "../helpers/access-quota";
+import { usageEnv } from "../helpers/model-usage";
+
+// TestRail suite 2420, Quota & Access Control — the API-key list + detail UI: the
+// list Usage / Rate limits / Supported models / Status columns and their
+// consistency with the summary RPC; inline Disable/Enable on the list and the
+// detail page; the detail Limits card (fields + consumption bar + status); and
+// editing limits (invalid values rejected, a valid smaller quota enforced).
+
+const env = usageEnv();
+const e = env as NonNullable<typeof env>;
+
+function uid(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+test.describe("access & quota — list & detail UI", () => {
+  test.skip(!env, "set E2E_AITRACE_ENDPOINT to run the UI tests");
+
+  test("list columns and usage summary agree with the RPCs", {
+    tag: "@C2727088",
+  }, async ({ apiKeys, apiHelper }) => {
+    test.setTimeout(150_000);
+    const listName = `aq-list-${uid()}`;
+    const bName = `aq-listb-${uid()}`;
+    // Allow the model the e2e engine serves ("any") so the key can still infer
+    // to produce usage while carrying an explicit allowlist for the UI.
+    const model = "any";
+    try {
+      const list = await apiHelper.createApiKeyWithLimits(listName, {
+        workspace: "default",
+        limits: {
+          token_quota: { limit: 100000, period: "daily" },
+          rps: 5,
+          allowed_models: [model],
+        },
+      });
+      const b = await apiHelper.createApiKeyWithLimits(bName, {
+        workspace: "default",
+        limits: { token_quota: { limit: 50000, period: "daily" } },
+      });
+      await produceKeyUsage(apiHelper, e, list.sk_value, list.id);
+      await produceKeyUsage(apiHelper, e, b.sk_value, b.id);
+      // Settle the ledger, then read the summary once as the source of truth
+      // (waitGatewayReady also spends tokens, so the exact used count isn't
+      // predetermined — assert the RPCs agree with each other instead).
+      await apiHelper.aggregateUsage();
+
+      await apiKeys.goToList();
+      const headers = apiKeys.table.root.locator("thead th");
+      await expect(headers.filter({ hasText: /status/i })).toBeVisible();
+      await expect(headers.filter({ hasText: /usage/i })).toBeVisible();
+      await expect(headers.filter({ hasText: /rate limits/i })).toBeVisible();
+      await expect(
+        headers.filter({ hasText: /supported models/i }),
+      ).toBeVisible();
+
+      const row = apiKeys.table.rowWithText(listName);
+      await expect(row.getByText("Active", { exact: true })).toBeVisible();
+      await expect(row.getByText("5 RPS")).toBeVisible();
+      await expect(row.getByText(model, { exact: true }).first()).toBeVisible();
+      // Usage cell shows used / limit (contains a slash).
+      await expect(row.getByText(/\/\s*100,000/)).toBeVisible();
+
+      // Summary RPC is the source of truth for the used count.
+      const summary = await apiHelper.getApiKeysUsageSummary("default");
+      const rowList = summary.body.find((r) => r.api_key_id === list.id);
+      expect(rowList?.token_limit).toBe(100000);
+      expect(rowList?.used).toBeGreaterThan(0);
+      const used = rowList!.used;
+      expect(rowList?.remaining).toBe(100000 - used);
+      // Both keys are present in the workspace summary.
+      const ids = summary.body.map((r) => r.api_key_id);
+      expect(ids).toContain(list.id);
+      expect(ids).toContain(b.id);
+
+      // The summary agrees with period-usage and with get_usage_by_dimension.
+      const period = await apiHelper.apiKeyPeriodUsage(list.id, "daily");
+      expect(Number(period.body)).toBe(used);
+      const dim = await apiHelper.getUsageByDimension({
+        start: new Date().toISOString().slice(0, 10),
+        end: new Date().toISOString().slice(0, 10),
+        workspace: "default",
+        apiKeyId: list.id,
+      });
+      const dimSum = dim.body.reduce((s, r) => s + (r.usage ?? 0), 0);
+      expect(dimSum).toBe(used);
+    } finally {
+      await apiHelper.deleteApiKey(listName, { retries: 5 }).catch(() => {});
+      await apiHelper.deleteApiKey(bName, { retries: 5 }).catch(() => {});
+    }
+  });
+
+  test("inline Disable/Enable on the list toggles status and preserves limits", {
+    tag: "@C2727089",
+  }, async ({ apiKeys, apiHelper }) => {
+    test.setTimeout(120_000);
+    const name = `aq-ld-${uid()}`;
+    try {
+      const key = await apiHelper.createApiKeyWithLimits(name, {
+        workspace: "default",
+        limits: { token_quota: { limit: 100000, period: "daily" }, rps: 5 },
+      });
+      // Baseline: the key can infer.
+      await waitGatewayReady(e, key.sk_value, { workspace: "default" });
+
+      await apiKeys.goToList();
+      const row = apiKeys.table.rowWithText(name);
+      await expect(row.getByText("Active", { exact: true })).toBeVisible();
+
+      // Toggle via the row action menu, waiting for the menu to close so its
+      // overlay does not intercept the next open.
+      const toggle = async (item: "Disable" | "Enable") => {
+        await row.locator('[data-testid="row-actions-trigger"]').click();
+        const menuItem = apiKeys.page.getByRole("menuitem", { name: item });
+        await menuItem.click();
+        await expect(menuItem).toBeHidden();
+      };
+
+      await toggle("Disable");
+      await expect(row.getByText("Disabled", { exact: true })).toBeVisible();
+      expect((await apiHelper.getApiKeyLimits(key.id)).body?.disabled).toBe(
+        true,
+      );
+
+      await toggle("Enable");
+      await expect(row.getByText("Active", { exact: true })).toBeVisible();
+      const limits = await apiHelper.getApiKeyLimits(key.id);
+      // Enabling clears the `disabled` flag (removed, not set to false).
+      expect(limits.body?.disabled).toBeFalsy();
+      expect(limits.body?.token_quota?.limit).toBe(100000);
+
+      // Inference recovers after re-enabling.
+      await waitGatewayReady(e, key.sk_value, { workspace: "default" });
+    } finally {
+      await apiHelper.deleteApiKey(name, { retries: 5 }).catch(() => {});
+    }
+  });
+
+  test("detail Limits card shows fields, consumption bar and status", {
+    tag: "@C2727090",
+  }, async ({ apiKeys, apiHelper }) => {
+    test.setTimeout(150_000);
+    const name = `aq-detail-${uid()}`;
+    // Allow the served model ("any") so the key can infer to produce usage.
+    const model = "any";
+    try {
+      const key = await apiHelper.createApiKeyWithLimits(name, {
+        workspace: "default",
+        limits: {
+          token_quota: { limit: 100000, period: "monthly" },
+          rps: 5,
+          rpm: 100,
+          concurrency: 10,
+          allowed_models: [model],
+        },
+      });
+      const used = await produceKeyUsage(apiHelper, e, key.sk_value, key.id, {
+        period: "monthly",
+      });
+
+      await apiKeys.goToShow(name);
+      const card = apiKeys.page.locator('[data-testid="show-page"]');
+      await expect(card.getByText("Limits (optional)")).toBeVisible();
+      await expect(card.getByText("Active", { exact: true })).toBeVisible();
+      // Consumption bar line: used / limit tokens · remaining: N · Monthly
+      await expect(card.getByText("Resource consumption")).toBeVisible();
+      await expect(card.getByText(/\/\s*100,000\s*tokens/)).toBeVisible();
+      // "Monthly" also appears in the edit form's period combobox — the
+      // consumption line is the first match.
+      await expect(card.getByText(/Monthly/).first()).toBeVisible();
+      // Summary line reflects the rate limits.
+      await expect(card.getByText(/5 RPS/)).toBeVisible();
+      // Model access lists the allowed model.
+      await expect(card.getByText("Model access")).toBeVisible();
+      await expect(
+        card.getByText(model, { exact: true }).first(),
+      ).toBeVisible();
+
+      // The progress "used" matches the period-usage RPC.
+      const period = await apiHelper.apiKeyPeriodUsage(key.id, "monthly");
+      expect(Number(period.body)).toBe(used);
+    } finally {
+      await apiHelper.deleteApiKey(name, { retries: 5 }).catch(() => {});
+    }
+  });
+
+  test("Disable/Enable from the detail page toggles status and preserves limits", {
+    tag: "@C2727091",
+  }, async ({ apiKeys, apiHelper }) => {
+    test.setTimeout(120_000);
+    const name = `aq-dd-${uid()}`;
+    try {
+      const key = await apiHelper.createApiKeyWithLimits(name, {
+        workspace: "default",
+        limits: { token_quota: { limit: 100000, period: "daily" }, rps: 5 },
+      });
+      await waitGatewayReady(e, key.sk_value, { workspace: "default" });
+
+      const card = apiKeys.page.locator('[data-testid="show-page"]');
+
+      // Toggle via the card's "⋯" menu using the keyboard: pointer clicks race a
+      // lingering Radix dismissable-layer overlay and the menu's open animation,
+      // so focus the trigger and press Enter to open, then Enter to select the
+      // single (Enable/Disable) item. Reload + wait-for-card-loaded first so the
+      // card's load re-render can't detach the menu.
+      const toggle = async () => {
+        await apiKeys.goToShow(name);
+        await expect(card.getByText(/5 RPS/)).toBeVisible();
+        await card.locator('button[aria-label="Actions"]').focus();
+        await apiKeys.page.keyboard.press("Enter");
+        await apiKeys.page
+          .getByRole("menuitem")
+          .first()
+          .waitFor({ state: "visible" });
+        await apiKeys.page.keyboard.press("Enter");
+      };
+
+      await apiKeys.goToShow(name);
+      await expect(card.getByText("Active", { exact: true })).toBeVisible();
+
+      // Disable.
+      await toggle();
+      await expect(card.getByText("Disabled", { exact: true })).toBeVisible();
+      expect((await apiHelper.getApiKeyLimits(key.id)).body?.disabled).toBe(
+        true,
+      );
+
+      // Enable again — limits survive.
+      await toggle();
+      await expect(card.getByText("Active", { exact: true })).toBeVisible();
+      const limits = await apiHelper.getApiKeyLimits(key.id);
+      expect(limits.body?.disabled).toBeFalsy();
+      expect(limits.body?.token_quota?.limit).toBe(100000);
+      expect(limits.body?.rps).toBe(5);
+
+      await waitGatewayReady(e, key.sk_value, { workspace: "default" });
+    } finally {
+      await apiHelper.deleteApiKey(name, { retries: 5 }).catch(() => {});
+    }
+  });
+
+  test("editing limits: invalid values rejected, a smaller quota is enforced", {
+    tag: "@C2727092",
+  }, async ({ apiKeys, apiHelper }) => {
+    test.setTimeout(180_000);
+    const name = `aq-edit-${uid()}`;
+    try {
+      const key = await apiHelper.createApiKeyWithLimits(name, {
+        workspace: "default",
+        limits: {
+          token_quota: { limit: 100000, period: "daily" },
+          rps: 5,
+          rpm: 60,
+          concurrency: 4,
+        },
+      });
+      await apiKeys.goToShow(name);
+      const card = apiKeys.page.locator('[data-testid="show-page"]');
+      const field = (f: string) =>
+        card.locator(`[data-testid="field-${f}"] input`);
+      const save = () => card.getByRole("button", { name: /^save$/i }).click();
+
+      // Each numeric field rejects a non-positive value; the saved policy is
+      // left unchanged.
+      for (const { f, old } of [
+        { f: "quota_limit", old: "100000" },
+        { f: "rps", old: "5" },
+        { f: "rpm", old: "60" },
+        { f: "concurrency", old: "4" },
+      ]) {
+        await field(f).fill("0");
+        await save();
+        await expect(
+          card.getByText("Must be a positive integer").first(),
+        ).toBeVisible();
+        const got = await apiHelper.getApiKeyLimits(key.id);
+        expect(got.body?.token_quota?.limit).toBe(100000);
+        expect(got.body?.rps).toBe(5);
+        await field(f).fill(old);
+      }
+
+      // A valid, smaller quota saves and persists.
+      await field("quota_limit").fill("300");
+      await save();
+      let persisted = false;
+      const deadline = Date.now() + 20_000;
+      while (Date.now() < deadline && !persisted) {
+        const got = await apiHelper.getApiKeyLimits(key.id);
+        if (got.body?.token_quota?.limit === 300) persisted = true;
+        else await new Promise((r) => setTimeout(r, 1500));
+      }
+      expect(persisted).toBe(true);
+      const after = await apiHelper.getApiKeyLimits(key.id);
+      expect(after.body?.rps).toBe(5);
+      expect(after.body?.rpm).toBe(60);
+      expect(after.body?.concurrency).toBe(4);
+
+      // The new, smaller quota is enforced by the gateway.
+      await waitGatewayReady(e, key.sk_value, {
+        workspace: "default",
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      const rejected = await exhaustQuota(apiHelper, e, key.sk_value, {
+        workspace: "default",
+        completionTokens: 40,
+        promptTokens: 10,
+      });
+      expect(errorCode(rejected.body)).toBe("quota_exceeded");
+    } finally {
+      await apiHelper.deleteApiKey(name, { retries: 5 }).catch(() => {});
+    }
+  });
+});


### PR DESCRIPTION
## What

Automates the API-key **Quota & Access Control** TestRail section — 24 of the
31 cases. Each API key carries a `spec.limits` policy (token quota + period,
requests-per-second/minute, max concurrency, allowed-models whitelist, and a
disabled flag) enforced at the AI gateway.

## Coverage

- **Gateway interception (9):** token-quota exhaustion, per-second and
  per-minute rate limits (independent windows), in-flight concurrency,
  allowed-model whitelist, empty allowlist deny-all, disabled key,
  access-denial-before-quota-denial precedence, lowering RPS after reconcile,
  and removing a rate rule.
- **Limits RPC + RBAC (5):** whole-object replace with field-omission clearing,
  delete drops the policy, owner-only reads, same-workspace non-owner denial,
  and cross-user/cross-workspace isolation.
- **Create form (5):** all limit fields save, yearly period round-trips,
  non-positive values rejected with no key created, the omit-limits unlimited
  path, and the create → infer → usage main line.
- **List + detail UI (5):** list usage summary agreeing with the RPCs, inline
  enable/disable on both the list and the detail page, the detail limits card
  (fields, consumption bar, status, model access), and editing limits (invalid
  values rejected, a smaller quota enforced end-to-end).

## Not automated (7)

Control-plane upgrade (2), install-time readiness, natural-day quota rollover,
quota fail-open, bounded overage during usage-sync lag, and rate-limit
enforcement during an aggregation outage — each needs control-plane/gateway
infrastructure manipulation or a clock change that isn't available to a UI e2e
run.

## How it works

Limits are enforced by two Kong plugins the control plane reconciles onto each
key's consumer, so enforcement is eventual: tests poll the gateway until a
freshly created/edited key is observed. Token quota derives from the aggregated
usage ledger (+ a short plugin cache), so quota tests drive real inferences and
force aggregation until the plugin rejects; rate and concurrency limits are
local plugin counters exercised with concurrent bursts and an in-flight
request. Opt-in via `E2E_AITRACE_ENDPOINT` (a Running engine endpoint); the
suite is skipped otherwise.

New helpers: `e2e/helpers/access-quota.ts` and API-key-limits methods on
`ApiHelper`. Reuses the shared gateway inference helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
