### PR TITLE
fix: round VRAM amounts in the recipe VRAM badge (NEU-499)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -325,11 +325,11 @@
   "src/foundation/recipe/compose.ts": "c0cfe4da9024b651f47e4773318641d9",
   "src/foundation/recipe/normalize.ts": "37973e33217df534c07c56a63d07c1ed",
   "src/foundation/recipe/types.ts": "6b11c3319d89fc7158795a4dc2bfe661",
-  "src/foundation/recipe/vram.ts": "1b51851b7627036a5b8f6893244dcf8a",
+  "src/foundation/recipe/vram.ts": "7cdf1eda25921556f7991b37ba5d8a16",
   "src/domains/model-catalog/components/ModelInfoBadges.tsx": "1608ced09a1c2236d30ee644f974dda2",
   "src/domains/endpoint/components/ComposePreview.tsx": "ab9fb6ee6b9dfed17c774cbf0f6dd823",
   "src/domains/endpoint/components/FeaturePicker.tsx": "899067c0e1879037378ebaf1fd51fb98",
-  "src/domains/endpoint/components/VRAMCheckBadge.tsx": "e40ec87d25bacbcf4bfce6be2b23abf1",
+  "src/domains/endpoint/components/VRAMCheckBadge.tsx": "8669ff213df55b49535f2134db420d66",
   "src/domains/endpoint/components/VariantPicker.tsx": "06adfa7eca1c9d1b25e97583a12574c3",
   "src/components/ui/switch.tsx": "ed96194f48772c1f9aff21df61013a69",
   "src/foundation/lib/touched-fields.ts": "8bb21e569f8f08090d42f67df8e1e702"

--- a/src/domains/endpoint/components/VRAMCheckBadge.tsx
+++ b/src/domains/endpoint/components/VRAMCheckBadge.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle, CheckCircle2, Info } from "lucide-react";
 import { useTranslation } from "@/foundation/lib/i18n";
-import { checkVRAM } from "@/foundation/recipe/vram";
+import { checkVRAM, formatGb } from "@/foundation/recipe/vram";
 
 type Props = {
   acceleratorProduct?: string | null;
@@ -45,7 +45,7 @@ export const VRAMCheckBadge = ({
         <Info className="size-4" />
         <span>
           {t("endpoints.recipe.vramRequiredOnly", "Requires ≥ {{gb}} GB VRAM", {
-            gb: requiredGb,
+            gb: formatGb(requiredGb),
           })}
         </span>
       </div>
@@ -70,12 +70,18 @@ export const VRAMCheckBadge = ({
           ? t(
               "endpoints.recipe.vramSufficient",
               "Sufficient VRAM: {{total}} GB available, {{required}} GB required",
-              { total: result.totalGb, required: result.requiredGb },
+              {
+                total: formatGb(result.totalGb),
+                required: formatGb(result.requiredGb),
+              },
             )
           : t(
               "endpoints.recipe.vramInsufficient",
               "Insufficient VRAM: {{total}} GB available, {{required}} GB required",
-              { total: result.totalGb, required: result.requiredGb },
+              {
+                total: formatGb(result.totalGb),
+                required: formatGb(result.requiredGb),
+              },
             )}
       </span>
     </div>

--- a/src/foundation/recipe/vram.test.ts
+++ b/src/foundation/recipe/vram.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { checkVRAM, matchesAcceleratorName } from "./vram";
+import { checkVRAM, formatGb, matchesAcceleratorName } from "./vram";
 
 describe("matchesAcceleratorName", () => {
   it("matches a bare name against a vendor-prefixed product string", () => {
@@ -61,5 +61,22 @@ describe("checkVRAM", () => {
   it("returns unknown without a required VRAM", () => {
     const r = checkVRAM({ acceleratorProduct: "H100", gpuCount: 1 });
     expect(r.kind).toBe("unknown");
+  });
+});
+
+describe("formatGb", () => {
+  it("rounds noisy fractional VRAM to one decimal", () => {
+    expect(formatGb(89.9765625)).toBe("90");
+    expect(formatGb(44.988)).toBe("45");
+    expect(formatGb(23.45)).toBe("23.5");
+  });
+
+  it("keeps whole numbers clean (no trailing .0)", () => {
+    expect(formatGb(140)).toBe("140");
+    expect(formatGb(16)).toBe("16");
+  });
+
+  it("preserves a meaningful single decimal", () => {
+    expect(formatGb(47.5)).toBe("47.5");
   });
 });

--- a/src/foundation/recipe/vram.ts
+++ b/src/foundation/recipe/vram.ts
@@ -120,3 +120,13 @@ export function checkVRAM(opts: {
     requiredGb: opts.requiredGb,
   };
 }
+
+// Format a VRAM amount (GB) for display. Live per-GPU memory reported by a
+// cluster is often fractional (e.g. 44.988 GiB × 2 = 89.9765625), which reads
+// as noise in the badge. Round to at most one decimal and drop a trailing
+// ".0" so whole numbers stay clean. Display-only — the sufficiency comparison
+// in checkVRAM still uses the exact value.
+export function formatGb(gb: number): string {
+  const rounded = Math.round(gb * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}


### PR DESCRIPTION
Follow-up polish noticed while verifying NEU-499 on the deployed env.

## Problem
When a cluster reports fractional live per-GPU memory (e.g. an L20 at ~44.988 GiB), the VRAM check badge rendered the raw product: `Insufficient VRAM: 89.9765625 GB available, 140 GB required`.

## Fix
Add a display-only `formatGb()` (rounds to at most one decimal, drops a trailing `.0`) and apply it to the `total`/`required` interpolations in `VRAMCheckBadge` (sufficient / insufficient / required-only states). The `checkVRAM` sufficiency comparison still uses the exact value — only the rendered text is rounded.

`89.9765625` → `90`, `140` → `140`, `47.5` → `47.5`.

## Test
- `yarn vitest run src/foundation/recipe/vram.test.ts` — 10 passing (3 new for `formatGb`).
- `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)