### PR TITLE
fix: batch delete crashes on workspaced resources

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -89,7 +89,7 @@
   "src/foundation/types/license.ts": "e7cd2bf058d508b41b5521f5cee745a3",
   "src/foundation/types/serving-types.ts": "d3ade7b3debf53702e7f730c8469e26e",
   "src/foundation/types/system-types.ts": "95251bc1ec54424d96b599dedf23ffeb",
-  "src/foundation/providers/data-provider/index.ts": "2e0faf1150c368ef33d0093f1b59c27b",
+  "src/foundation/providers/data-provider/index.ts": "0bdab9286702a0166e9ba670b856ef1d",
   "src/foundation/providers/data-provider/utils/generate-filter.ts": "5d3bce54e997574b28f34e20392290be",
   "src/foundation/providers/data-provider/utils/handle-error.ts": "bd404b9fbf8c81eae7941b4bca78623f",
   "src/foundation/providers/data-provider/utils/map-operator.ts": "4aafc8f97463e07318fabaf816f8d321",
@@ -119,7 +119,7 @@
   "src/foundation/components/AppSidebar.tsx": "2bf74a7a63eadc4382a0797120a6ee64",
   "src/foundation/components/BaseLayout.tsx": "64ddc4474cb6be136156ab722644c460",
   "src/foundation/components/BaseStatus.tsx": "4bdd1a3d50997cad867e852e5526a2c2",
-  "src/foundation/components/BatchDeleteBar.tsx": "9825a8c0178b4a6bef389c8d61e326a4",
+  "src/foundation/components/BatchDeleteBar.tsx": "3914804d690aa8e89d99299bdd821b14",
   "src/foundation/components/ConfirmDialog.tsx": "ebe2dec7a0f7bf14ffce2aba33b5e040",
   "src/foundation/components/CreateButton.tsx": "6e3741144546089ed5bad8c1d1ff35cf",
   "src/foundation/components/DefaultLayout.tsx": "1efe07e1ec0621ec845daae497764550",
@@ -332,5 +332,6 @@
   "src/domains/endpoint/components/VRAMCheckBadge.tsx": "8669ff213df55b49535f2134db420d66",
   "src/domains/endpoint/components/VariantPicker.tsx": "06adfa7eca1c9d1b25e97583a12574c3",
   "src/components/ui/switch.tsx": "ed96194f48772c1f9aff21df61013a69",
-  "src/foundation/lib/touched-fields.ts": "8bb21e569f8f08090d42f67df8e1e702"
+  "src/foundation/lib/touched-fields.ts": "8bb21e569f8f08090d42f67df8e1e702",
+  "src/foundation/lib/batch-delete.ts": "257dd2f4cbccf000afce74b379d4e80c"
 }

--- a/src/foundation/components/BatchDeleteBar.tsx
+++ b/src/foundation/components/BatchDeleteBar.tsx
@@ -1,9 +1,10 @@
-import { useDeleteMany, useResource } from "@refinedev/core";
+import { useDelete, useNotification, useResource } from "@refinedev/core";
 import type { Row } from "@tanstack/react-table";
 import { Trash2 } from "lucide-react";
 import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { DeleteConfirmDialog } from "@/foundation/components/DeleteConfirmDialog";
+import { buildBatchDeleteVariables } from "@/foundation/lib/batch-delete";
 import { useTranslation } from "@/foundation/lib/i18n";
 
 interface BatchDeleteBarProps {
@@ -18,26 +19,51 @@ export function BatchDeleteBar({
   const { t } = useTranslation();
   const { resource } = useResource();
   const [open, setOpen] = useState(false);
-  const { mutate: deleteMany, isLoading } = useDeleteMany();
+  const [submitting, setSubmitting] = useState(false);
+  const { mutateAsync: deleteOne } = useDelete();
+  const { open: openNotification } = useNotification();
 
   const handleConfirm = useCallback(
-    (forceDelete: boolean) => {
-      const ids = selectedRows.map((row) => row.original.metadata?.name);
-      deleteMany(
-        {
-          resource: resource?.name || "",
-          ids,
-          meta: forceDelete ? { forceDelete: true } : undefined,
-        },
-        {
-          onSuccess: () => {
-            setOpen(false);
-            onDeleted();
-          },
-        },
+    async (forceDelete: boolean) => {
+      const resourceName = resource?.name || "";
+      // Delete each row with ITS OWN metadata (workspace included) — a shared
+      // meta cannot represent a multi-workspace selection, and dropping the
+      // workspace makes the provider's re-read miss and crash. See
+      // buildBatchDeleteVariables for the full rationale.
+      const variables = buildBatchDeleteVariables(
+        selectedRows,
+        resourceName,
+        forceDelete,
       );
+
+      setSubmitting(true);
+      try {
+        const results = await Promise.allSettled(
+          variables.map((variable) => deleteOne(variable)),
+        );
+        const succeeded = results.filter(
+          (r) => r.status === "fulfilled",
+        ).length;
+        // Per-row success toasts are suppressed (see helper); emit one summary
+        // so a 10-row delete does not spawn 10 notifications. Per-row failures
+        // still surface via Refine's default error notification.
+        if (succeeded > 0) {
+          openNotification?.({
+            type: "success",
+            message: t("notifications.deleteSuccess", {
+              resource: resourceName,
+            }),
+          });
+          // Only clear the selection when something was actually deleted, so a
+          // fully-failed batch keeps the rows selected for a retry.
+          onDeleted();
+        }
+      } finally {
+        setSubmitting(false);
+        setOpen(false);
+      }
     },
-    [selectedRows, deleteMany, resource?.name, onDeleted],
+    [selectedRows, deleteOne, resource?.name, onDeleted, openNotification, t],
   );
 
   if (selectedRows.length === 0) return null;
@@ -50,7 +76,7 @@ export function BatchDeleteBar({
       <DeleteConfirmDialog
         open={open}
         onOpenChange={setOpen}
-        loading={isLoading}
+        loading={submitting}
         title={t("dialogs.batchDelete.title", {
           count: selectedRows.length,
         })}

--- a/src/foundation/lib/batch-delete.test.ts
+++ b/src/foundation/lib/batch-delete.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { type BatchDeleteRow, buildBatchDeleteVariables } from "./batch-delete";
+
+const row = (name: string, workspace?: string): BatchDeleteRow => ({
+  original: { metadata: { name, workspace } },
+});
+
+describe("buildBatchDeleteVariables", () => {
+  it("threads each row's OWN workspace into its delete meta", () => {
+    // The regression: workspaced rows selected from different workspaces must
+    // each carry their own workspace, not a single shared (or missing) one.
+    const vars = buildBatchDeleteVariables(
+      [row("a", "ws1"), row("b", "ws2")],
+      "clusters",
+      false,
+    );
+
+    expect(vars).toHaveLength(2);
+    expect(vars[0]).toMatchObject({
+      resource: "clusters",
+      id: "a",
+      meta: { name: "a", workspace: "ws1" },
+    });
+    expect(vars[1]).toMatchObject({
+      resource: "clusters",
+      id: "b",
+      meta: { name: "b", workspace: "ws2" },
+    });
+  });
+
+  it("uses metadata.name as the delete id", () => {
+    const [v] = buildBatchDeleteVariables([row("only")], "endpoints", false);
+    expect(v.id).toBe("only");
+  });
+
+  it("merges forceDelete only when requested", () => {
+    const [forced] = buildBatchDeleteVariables(
+      [row("a", "ws1")],
+      "clusters",
+      true,
+    );
+    expect(forced.meta).toMatchObject({
+      name: "a",
+      workspace: "ws1",
+      forceDelete: true,
+    });
+
+    const [plain] = buildBatchDeleteVariables(
+      [row("a", "ws1")],
+      "clusters",
+      false,
+    );
+    expect(plain.meta).not.toHaveProperty("forceDelete");
+  });
+
+  it("suppresses per-row success notifications (one summary toast instead of N)", () => {
+    const vars = buildBatchDeleteVariables(
+      [row("a"), row("b")],
+      "clusters",
+      false,
+    );
+    expect(vars.every((v) => v.successNotification === false)).toBe(true);
+  });
+
+  it("does not mutate the source metadata when merging forceDelete", () => {
+    const source = row("a", "ws1");
+    buildBatchDeleteVariables([source], "clusters", true);
+    expect(source.original.metadata).not.toHaveProperty("forceDelete");
+  });
+
+  it("skips rows without a name (nothing to key the delete on)", () => {
+    const vars = buildBatchDeleteVariables(
+      [
+        { original: {} },
+        { original: { metadata: { workspace: "ws1" } } },
+        row("keep", "ws1"),
+      ],
+      "clusters",
+      false,
+    );
+    expect(vars).toHaveLength(1);
+    expect(vars[0].id).toBe("keep");
+  });
+});

--- a/src/foundation/lib/batch-delete.ts
+++ b/src/foundation/lib/batch-delete.ts
@@ -1,0 +1,49 @@
+// Batch delete threads each selected row's OWN metadata into its delete call.
+//
+// Neutree resources are keyed by `metadata->name` AND (for workspaced resources)
+// `metadata->workspace`; the data provider's soft-delete first re-reads the
+// record by that composite key before stamping `deletion_timestamp`. A batch
+// delete therefore cannot share a single `meta` across rows: each row may live
+// in a different workspace. Passing only the names (and dropping the workspace)
+// makes the re-read match zero rows, and the provider then dereferences an
+// undefined record -> "Cannot read properties of undefined (reading 'metadata')".
+//
+// This builds one delete variable object per row, carrying that row's full
+// metadata (so `workspace` reaches the provider), merging the force-delete flag,
+// and suppressing the per-row success toast so the caller can emit a single
+// summary notification instead of N of them.
+
+type RowMetadata = {
+  name?: string;
+  workspace?: string;
+} & Record<string, unknown>;
+
+export type BatchDeleteRow = {
+  original: { metadata?: RowMetadata };
+};
+
+type BatchDeleteVariable = {
+  resource: string;
+  id: string;
+  meta: Record<string, unknown>;
+  successNotification: false;
+};
+
+export function buildBatchDeleteVariables(
+  rows: BatchDeleteRow[],
+  resource: string,
+  forceDelete: boolean,
+): BatchDeleteVariable[] {
+  return rows
+    .map((row) => row.original.metadata ?? {})
+    .filter(
+      (metadata): metadata is RowMetadata & { name: string } =>
+        typeof metadata.name === "string" && metadata.name.length > 0,
+    )
+    .map((metadata) => ({
+      resource,
+      id: metadata.name,
+      meta: forceDelete ? { ...metadata, forceDelete: true } : { ...metadata },
+      successNotification: false,
+    }));
+}

--- a/src/foundation/providers/data-provider/index.ts
+++ b/src/foundation/providers/data-provider/index.ts
@@ -45,6 +45,21 @@ export const dataProvider = (
   }) => {
     const current = await _getOne({ resource, id, meta });
 
+    // Re-read must find the record before we stamp deletion_timestamp. If it
+    // returns nothing (e.g. a caller omitted the workspace for a workspaced
+    // resource), fail with a clear error instead of dereferencing undefined and
+    // crashing with "Cannot read properties of undefined (reading 'metadata')".
+    if (!current.data) {
+      return handleError(
+        new PostgrestError({
+          message: `Record not found: ${resource} "${String(id)}"`,
+          code: "404",
+          details: "",
+          hint: "",
+        }),
+      );
+    }
+
     const client = meta?.schema
       ? postgrestClient.schema(meta.schema)
       : postgrestClient;


### PR DESCRIPTION
## Problem

The list-page batch **Delete** action (`enableBatchDelete`, e.g. Clusters / Endpoints) throws `Cannot read properties of undefined (reading 'metadata')` and deletes nothing. Single-row delete works fine.

## Root cause

`BatchDeleteBar` mapped the selected rows to **bare names** and called `useDeleteMany` with a single shared `meta` that **dropped the workspace**:

```ts
const ids = selectedRows.map((row) => row.original.metadata?.name);
deleteMany({ resource, ids, meta: forceDelete ? { forceDelete: true } : undefined });
```

Neutree resources are keyed by `metadata->name` **and** (for workspaced resources) `metadata->workspace`. The data provider's soft-delete re-reads the record by that composite key before stamping `deletion_timestamp` (`data-provider/index.ts` `_getOne`/`_softDelete`). With no workspace, the re-read matches **zero rows**, and `_softDelete` then dereferences the undefined record at `...current.data.metadata` → the crash.

A single shared `meta` also fundamentally can't represent a **multi-workspace** selection.

Single-row delete avoids this because it threads the full `row.metadata` (workspace included) through `useDeleteHelper`.

## Fix

- **`BatchDeleteBar`**: delete each selected row with **its own metadata** (workspace included), via `useDelete` per row — mirroring the single-row delete contract and correctly handling mixed-workspace selections. The per-row variable building is extracted into a pure, unit-tested `buildBatchDeleteVariables` helper.
- Suppress the per-row success toasts and emit **one** summary notification (a 10-row delete no longer spawns 10 toasts). Per-row failures still surface via Refine's default error notification, and the selection is kept if every row failed so it can be retried.
- **Defensive guard** in `_softDelete`: a not-found re-read now rejects with a clear `Record not found` error instead of crashing on `undefined`.

## Verification

- New unit tests: `src/foundation/lib/batch-delete.test.ts` (6 cases — per-row workspace threading, force-delete merge, toast suppression, no source mutation, skip nameless rows).
- `yarn typecheck` clean; full suite **1092/1092** passing.
- Pre-commit gates (biome, dep-check, knip, i18n) green.

Found while verifying NEU-498 (batch delete on the Clusters list crashed; had to delete from the Show page instead).