### PR TITLE
fix: standardize core labels

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -723,9 +723,9 @@
 			"vgpuMemoryMode": "VRAM Mode",
 			"vgpuMemory": "VRAM",
 			"vgpuMemoryPercent": "VRAM Percent",
-			"vgpuCoreLimit": "Core Limit",
-			"vgpuCorePercent": "Core Percent",
-			"vgpuCoreUnits": "Core Units",
+			"vgpuCoreLimit": "Core",
+			"vgpuCorePercent": "Core",
+			"vgpuCoreUnits": "Core",
 			"singleCardMemory": "VRAM",
 			"requestedVgpuMemory": "Requested VRAM",
 			"effectiveVgpuMemory": "Effective VRAM",
@@ -788,7 +788,7 @@
 		"descriptions": {
 			"clusterSchedulingTarget": "The current product supports cluster-level scheduling targets. Resource availability is summarized from the selected cluster.",
 			"basicResources": "Capacity shared with the selected cluster.",
-			"vgpuCorePercentZero": "Optional. Leave disabled or set 0 to share the remaining compute capacity on the assigned card."
+			"vgpuCorePercentZero": "Optional. Leave disabled or set 0 to share the remaining core on the assigned card."
 		},
 		"actions": {
 			"openResources": "Open Resources",
@@ -815,12 +815,12 @@
 			"vgpuMemoryMutuallyExclusive": "Use either virtual card memory amount or memory percent, not both",
 			"vgpuMemoryMiBPositive": "Virtual card memory must be greater than 0",
 			"vgpuMemoryPercentRange": "Virtual card memory percent must be between 1 and 100",
-			"vgpuCorePercentRange": "Virtual card core percent must be between 0 and 100",
+			"vgpuCorePercentRange": "Virtual card core must be between 0 and 100",
 			"cardsAvailable": "{{count}} cards available",
 			"fullGpuResourcesInsufficient": "Requested full cards exceed the currently available capacity for this cluster.",
 			"vgpuResourcesInsufficient": "Requested virtual card resources exceed the currently available capacity for this cluster.",
 			"noRunningVgpuPods": "No running virtual accelerator pods",
-			"vgpuCoreLimitUnlimitedHint": "0 means no limit; compute is shared"
+			"vgpuCoreLimitUnlimitedHint": "0 means no limit; core is shared"
 		},
 		"tabs": {
 			"playground": "Playground"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -788,7 +788,7 @@
 		"descriptions": {
 			"clusterSchedulingTarget": "The current product supports cluster-level scheduling targets. Resource availability is summarized from the selected cluster.",
 			"basicResources": "Capacity shared with the selected cluster.",
-			"vgpuCorePercentZero": "Optional. Leave disabled or set 0 to share the assigned card's remaining Core."
+			"vgpuCorePercentZero": "Optional. Leave disabled or set 0 to share the remaining compute capacity on the assigned card."
 		},
 		"actions": {
 			"openResources": "Open Resources",
@@ -815,12 +815,12 @@
 			"vgpuMemoryMutuallyExclusive": "Use either virtual card memory amount or memory percent, not both",
 			"vgpuMemoryMiBPositive": "Virtual card memory must be greater than 0",
 			"vgpuMemoryPercentRange": "Virtual card memory percent must be between 1 and 100",
-			"vgpuCorePercentRange": "Virtual card Core must be between 0 and 100",
+			"vgpuCorePercentRange": "Virtual card core percent must be between 0 and 100",
 			"cardsAvailable": "{{count}} cards available",
 			"fullGpuResourcesInsufficient": "Requested full cards exceed the currently available capacity for this cluster.",
 			"vgpuResourcesInsufficient": "Requested virtual card resources exceed the currently available capacity for this cluster.",
 			"noRunningVgpuPods": "No running virtual accelerator pods",
-			"vgpuCoreLimitUnlimitedHint": "0 means no limit; Core is shared"
+			"vgpuCoreLimitUnlimitedHint": "0 means no limit; compute is shared"
 		},
 		"tabs": {
 			"playground": "Playground"

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -788,7 +788,7 @@
 		"descriptions": {
 			"clusterSchedulingTarget": "The current product supports cluster-level scheduling targets. Resource availability is summarized from the selected cluster.",
 			"basicResources": "Capacity shared with the selected cluster.",
-			"vgpuCorePercentZero": "Optional. Leave disabled or set 0 to share the remaining core on the assigned card."
+			"vgpuCorePercentZero": "Optional. Leave disabled or set 0 to share the assigned card's remaining Core."
 		},
 		"actions": {
 			"openResources": "Open Resources",
@@ -815,12 +815,12 @@
 			"vgpuMemoryMutuallyExclusive": "Use either virtual card memory amount or memory percent, not both",
 			"vgpuMemoryMiBPositive": "Virtual card memory must be greater than 0",
 			"vgpuMemoryPercentRange": "Virtual card memory percent must be between 1 and 100",
-			"vgpuCorePercentRange": "Virtual card core must be between 0 and 100",
+			"vgpuCorePercentRange": "Virtual card Core must be between 0 and 100",
 			"cardsAvailable": "{{count}} cards available",
 			"fullGpuResourcesInsufficient": "Requested full cards exceed the currently available capacity for this cluster.",
 			"vgpuResourcesInsufficient": "Requested virtual card resources exceed the currently available capacity for this cluster.",
 			"noRunningVgpuPods": "No running virtual accelerator pods",
-			"vgpuCoreLimitUnlimitedHint": "0 means no limit; core is shared"
+			"vgpuCoreLimitUnlimitedHint": "0 means no limit; Core is shared"
 		},
 		"tabs": {
 			"playground": "Playground"


### PR DESCRIPTION
## Issues

NEU-506

## Changes

- Standardize vGPU field labels from `Core Limit`, `Core Percent`, and `Core Units` to `Core`.
- Replace the allocated-resources hardcoded `Core` badge with the shared i18n key.
- Keep descriptive and validation copy unchanged.

## Test Plan

### Unit test

- [x] `yarn test src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx` (3 tests passed)
- [x] `yarn typecheck`
- [x] `yarn dep-check`
- [x] `yarn knip`
- [x] `node tools/i18n-tracker.cjs --git 1 --limit 20`
- [x] `node tools/check-i18n-keys.cjs`
- [x] `git diff --check`
- [ ] `yarn lint` was attempted, but the local Biome binary failed to execute before linting with `spawnSync ... Unknown system error -88`; direct binary execution exited 137.

### DB test

- Not run. This change does not touch DB schema, storage, or migrations.

### E2E test

- Not run. This is a Trivial UI/i18n label-only change with no deployed behavior or workflow change.