### PR TITLE
fix(api-key): model dropdown scroll-in-dialog + compact long model lists

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -313,7 +313,7 @@
   "src/domains/api-key/components/ApiKeyPolicyFields.tsx": "d10a82b880b50ea9605beab0a0bffeae",
   "src/domains/api-key/components/ApiKeyRankingOverview.tsx": "195d9f1d66efb631da3a763c2ad8da61",
   "src/domains/api-key/components/ModelMultiSelect.tsx": "1a14e7b5de4682533b8b12e0510a8f41",
-  "src/domains/api-key/hooks/use-api-key-policy.ts": "1249078e705dda965c81832e6ef4b964",
+  "src/domains/api-key/hooks/use-api-key-policy.ts": "95615a46ee7dfdd17c2f768aaa84496a",
   "src/foundation/components/resource-form-submit-context.ts": "7c5c5b5f94416e940786f87a98b3a9f8",
   "src/pages/model-catalogs/edit.tsx": "c82acd5263236b26ffe12d82b17d807a",
   "src/pages/model-catalogs/components/FeaturesList.tsx": "e68a4369a62b564bbbdcfd3c614a4b38",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -312,7 +312,7 @@
   "src/domains/api-key/components/ApiKeyPerformanceCard.tsx": "986c799c7c0ca0993eb7c99ae3880a12",
   "src/domains/api-key/components/ApiKeyPolicyFields.tsx": "d10a82b880b50ea9605beab0a0bffeae",
   "src/domains/api-key/components/ApiKeyRankingOverview.tsx": "195d9f1d66efb631da3a763c2ad8da61",
-  "src/domains/api-key/components/ModelMultiSelect.tsx": "64b3eef5dff936a484b316381c5bb290",
+  "src/domains/api-key/components/ModelMultiSelect.tsx": "1a14e7b5de4682533b8b12e0510a8f41",
   "src/domains/api-key/hooks/use-api-key-policy.ts": "1249078e705dda965c81832e6ef4b964",
   "src/foundation/components/resource-form-submit-context.ts": "7c5c5b5f94416e940786f87a98b3a9f8",
   "src/pages/model-catalogs/edit.tsx": "c82acd5263236b26ffe12d82b17d807a",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -39,7 +39,7 @@
   "src/pages/clusters/edit.tsx": "ecb3a6e4f04286c161d3872d9e91bfa9",
   "src/pages/clusters/list.tsx": "71b3323f97b02b4391464719cc3aa521",
   "src/pages/clusters/show.tsx": "3f22cf0a49750a7f1b739b4960cc6b0f",
-  "src/pages/api-keys/list.tsx": "02b8571c0bcc934150368d17920afef5",
+  "src/pages/api-keys/list.tsx": "c48386dc0c9ab827a12a68e9994b82fb",
   "src/pages/api-keys/show.tsx": "3ecbea3750b6bc421c97fb673084dd5f",
   "src/components/ui/alert-dialog.tsx": "fd2a0854b18d61d21fe0e8effd7e4cd9",
   "src/components/ui/alert.tsx": "25ac92016d099c561981ce1456ee8741",

--- a/src/domains/api-key/components/ModelMultiSelect.tsx
+++ b/src/domains/api-key/components/ModelMultiSelect.tsx
@@ -81,7 +81,11 @@ export const ModelMultiSelect = ({
 
   return (
     <div className="space-y-2">
-      <Popover open={open} onOpenChange={setOpen}>
+      {/* modal: this Popover is also used inside the API-key create Dialog, whose
+          react-remove-scroll otherwise blocks wheel scrolling on the portaled
+          list. A modal Popover installs its own scroll management so the option
+          list scrolls. */}
+      <Popover open={open} onOpenChange={setOpen} modal>
         <PopoverTrigger asChild>
           <Button
             type="button"
@@ -101,7 +105,7 @@ export const ModelMultiSelect = ({
             <CaretSortIcon className="ml-2 h-4 w-4 shrink-0 opacity-50" />
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-[400px] max-w-full p-0">
+        <PopoverContent className="w-[--radix-popover-trigger-width] min-w-[320px] max-w-full p-0">
           <Command shouldFilter={false} className="rounded-lg border shadow-md">
             <CommandInput
               placeholder={t("api_keys.limits.selectModel")}

--- a/src/domains/api-key/hooks/use-api-key-policy.test.ts
+++ b/src/domains/api-key/hooks/use-api-key-policy.test.ts
@@ -148,6 +148,13 @@ describe("summarizeApiKeyLimits", () => {
     expect(parts).toContain("models: gpt-4o, claude");
   });
 
+  it("caps the inline model list at 3 with a +N suffix", () => {
+    const parts = summarizeApiKeyLimits({
+      allowed_models: ["a", "b", "c", "d", "e"],
+    });
+    expect(parts).toContain("models: a, b, c +2");
+  });
+
   it("is empty for no limits", () => {
     expect(summarizeApiKeyLimits(null)).toEqual([]);
     expect(summarizeApiKeyLimits({})).toEqual([]);

--- a/src/domains/api-key/hooks/use-api-key-policy.ts
+++ b/src/domains/api-key/hooks/use-api-key-policy.ts
@@ -104,6 +104,9 @@ export function limitsToForm(
   return v;
 }
 
+// Max model names inlined in summarizeApiKeyLimits before collapsing to "+N".
+const SUMMARY_MODELS_LIMIT = 3;
+
 // Compact, en-US summary of a key's limits for detail display.
 export function summarizeApiKeyLimits(
   limits: ApiKeyLimits | null | undefined,
@@ -126,7 +129,11 @@ export function summarizeApiKeyLimits(
   if (limits.rpm) out.push(`${limits.rpm} RPM`);
   if (limits.concurrency) out.push(`${limits.concurrency} concurrent`);
   if (limits.allowed_models && limits.allowed_models.length > 0) {
-    out.push(`models: ${limits.allowed_models.join(", ")}`);
+    // Cap the inline list so a key allowing many models doesn't blow up this
+    // one-line summary; the full set is shown by the Allowed-models field below.
+    const shown = limits.allowed_models.slice(0, SUMMARY_MODELS_LIMIT);
+    const extra = limits.allowed_models.length - shown.length;
+    out.push(`models: ${shown.join(", ")}${extra > 0 ? ` +${extra}` : ""}`);
   }
   return out;
 }

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1066,6 +1066,8 @@
 			"rateColumn": "Rate limits",
 			"modelsColumn": "Supported models",
 			"allModels": "All",
+			"showMore": "Show {{count}} more",
+			"showLess": "Show less",
 			"statusColumn": "Status",
 			"statusActive": "Active",
 			"statusDisabled": "Disabled",

--- a/src/pages/api-keys/list.tsx
+++ b/src/pages/api-keys/list.tsx
@@ -43,6 +43,89 @@ const endpointPhaseClass = (phase: string | null | undefined) =>
     Deleted: "border-gray-200 bg-gray-50 text-gray-700",
   })[phase ?? ""] ?? "border-muted bg-muted text-muted-foreground";
 
+// Number of allowed models rendered before the cell collapses the rest behind
+// a "show N more" toggle — keeps rows short when a key allows many models.
+const MODELS_COLLAPSED = 2;
+
+// Allowed-models table cell: renders each model (name + endpoint/type/phase) on
+// its own block, but only the first MODELS_COLLAPSED until expanded in place.
+function ModelsCell({
+  models,
+  modelMap,
+  scopedWorkspace,
+}: {
+  models: string[];
+  modelMap: ReturnType<typeof useWorkspaceModelMap>;
+  scopedWorkspace: string | undefined;
+}) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? models : models.slice(0, MODELS_COLLAPSED);
+  const hiddenCount = models.length - MODELS_COLLAPSED;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {visible.map((m) => {
+        const info = modelMap.get(m);
+        return (
+          <div key={m} className="flex min-w-0 flex-col gap-1">
+            <span className="truncate text-sm font-semibold" title={m}>
+              {m}
+            </span>
+            {scopedWorkspace && info && info.endpoints.length > 0 ? (
+              <div className="flex flex-col gap-1">
+                {info.endpoints.map((endpoint) => (
+                  <div
+                    key={`${endpoint.type}:${endpoint.name}`}
+                    className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground"
+                  >
+                    <span className="truncate max-w-[140px]">
+                      {endpoint.name}
+                    </span>
+                    <Badge variant="outline" className="h-5 font-normal">
+                      {t(`api_keys.models.${endpoint.type}`)}
+                    </Badge>
+                    <Badge
+                      variant="outline"
+                      className={cn(
+                        "h-5 font-normal",
+                        endpointPhaseClass(endpoint.phase),
+                      )}
+                    >
+                      {endpoint.phase
+                        ? t(`status.phases.endpoint.${endpoint.phase}`)
+                        : t("api_keys.models.unknown")}
+                    </Badge>
+                  </div>
+                ))}
+              </div>
+            ) : scopedWorkspace ? (
+              <span className="text-xs text-muted-foreground">
+                {t("api_keys.modelAccess.unavailable")}
+              </span>
+            ) : null}
+          </div>
+        );
+      })}
+      {models.length > MODELS_COLLAPSED && (
+        <button
+          type="button"
+          onClick={(e) => {
+            // Don't trigger row navigation when toggling the cell.
+            e.stopPropagation();
+            setExpanded((v) => !v);
+          }}
+          className="self-start text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+        >
+          {expanded
+            ? t("api_keys.limits.showLess")
+            : t("api_keys.limits.showMore", { count: hiddenCount })}
+        </button>
+      )}
+    </div>
+  );
+}
+
 export const ApiKeysList = () => {
   const { t } = useTranslation();
   const { show } = useNavigation();
@@ -168,53 +251,12 @@ export const ApiKeysList = () => {
             </span>
           );
         }
-        // Each allowed model on its own line: model name first, endpoint/type
-        // and running phase below so duplicate model names stay distinguishable.
         return (
-          <div className="flex flex-col gap-2">
-            {models.map((m) => {
-              const info = modelMap.get(m);
-              return (
-                <div key={m} className="flex min-w-0 flex-col gap-1">
-                  <span className="truncate text-sm font-semibold" title={m}>
-                    {m}
-                  </span>
-                  {scopedWorkspace && info && info.endpoints.length > 0 ? (
-                    <div className="flex flex-col gap-1">
-                      {info.endpoints.map((endpoint) => (
-                        <div
-                          key={`${endpoint.type}:${endpoint.name}`}
-                          className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground"
-                        >
-                          <span className="truncate max-w-[140px]">
-                            {endpoint.name}
-                          </span>
-                          <Badge variant="outline" className="h-5 font-normal">
-                            {t(`api_keys.models.${endpoint.type}`)}
-                          </Badge>
-                          <Badge
-                            variant="outline"
-                            className={cn(
-                              "h-5 font-normal",
-                              endpointPhaseClass(endpoint.phase),
-                            )}
-                          >
-                            {endpoint.phase
-                              ? t(`status.phases.endpoint.${endpoint.phase}`)
-                              : t("api_keys.models.unknown")}
-                          </Badge>
-                        </div>
-                      ))}
-                    </div>
-                  ) : scopedWorkspace ? (
-                    <span className="text-xs text-muted-foreground">
-                      {t("api_keys.modelAccess.unavailable")}
-                    </span>
-                  ) : null}
-                </div>
-              );
-            })}
-          </div>
+          <ModelsCell
+            models={models}
+            modelMap={modelMap}
+            scopedWorkspace={scopedWorkspace}
+          />
         );
       }}
     />


### PR DESCRIPTION
Follow-ups on the API-key model UI (from Slack review).

## Model dropdown (allowed models)
- **Scroll inside the create Dialog**: the Dialog's `react-remove-scroll` blocked wheel scrolling on the Popover list (it portals outside the dialog's allowed scroll subtree). Mark the Popover `modal` so it manages its own scroll.
- **Width**: the fixed 400px dropdown was narrower than the (now wider) trigger, exposing the content behind it on the right. Size the dropdown to the trigger width (with a 320px min).

## Long model lists take too much space
- **List "Supported models" cell**: rendered every allowed model as a multi-line block, making rows very tall. Show the first 2, with an inline **"show N more" / "show less"** toggle for the rest.
- **Detail card summary line**: the `models: …` one-liner listed every model unbounded. Cap it to the first 3 with a `+N` suffix (full set still shown in the Allowed-models field below). Unit test added.

All commits pass typecheck / biome / dep-check / knip / i18n / unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)