### PR TITLE
fix(logs): readable log viewer in system-dark mode

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -196,7 +196,7 @@
   "src/domains/endpoint/components/RerankPlayground.tsx": "a4409b6861a882c89aecb9aec8c878e3",
   "src/domains/endpoint/components/ResourcesCard.tsx": "367ce4f960a848d614f781a3b9bccf44",
   "src/domains/endpoint/components/SliderWithInput.tsx": "79e861ce4a0846107bdad89c93389131",
-  "src/domains/endpoint/components/VirtualLog.tsx": "27086754a748869249911de248b3536f",
+  "src/domains/endpoint/components/VirtualLog.tsx": "6ce5bbb904e53e6362a7cedf99da8c84",
   "src/domains/cluster/types.ts": "b194e1c40c021e3536e0d3ed6f4aae60",
   "src/domains/cluster/lib/get-ray-dashboard-proxy.ts": "a4a3c75f58c68ee9dca572ad3a70c62b",
   "src/domains/cluster/hooks/use-cluster-monitor-panels.ts": "9b1755f6538148e43f76f6f7aab08420",

--- a/src/domains/endpoint/components/VirtualLog.tsx
+++ b/src/domains/endpoint/components/VirtualLog.tsx
@@ -112,7 +112,10 @@ export const VirtualLog: FC<VirtualLogProps> = ({
   onScrollBottom,
 }) => {
   const { t } = useTranslation();
-  const { theme } = useTheme();
+  // resolvedTheme resolves "system" to the actual "light"/"dark"; using the raw
+  // `theme` would leave system users on the light syntax palette (unreadable on
+  // the dark background).
+  const { resolvedTheme } = useTheme();
   const listRef = useRef<List>(null);
 
   /**
@@ -295,9 +298,8 @@ export const VirtualLog: FC<VirtualLogProps> = ({
 
   // Determine theme class for highlight.js
   const hlThemeClass = useMemo(() => {
-    const resolvedTheme = theme === "system" ? "light" : theme; // Default to light for system
     return resolvedTheme === "dark" ? "hljs-dark" : "hljs-light";
-  }, [theme]);
+  }, [resolvedTheme]);
 
   if (!processedLines.length) {
     return (


### PR DESCRIPTION
## Problem
In dark mode (via the "system" theme setting), the endpoint/cluster log viewer rendered light-theme highlight.js colors (dark navy / gray) on the dark background, making the logs unreadable.

## Cause
`VirtualLog` derived its highlight.js palette from next-themes' raw `theme`, mapping `"system"` to `"light"`. A user whose OS is dark but whose app theme is `"system"` therefore got the light palette on a dark page.

## Fix
Use `resolvedTheme` from next-themes, which resolves `"system"` to the actual `"light"`/`"dark"`, so the syntax palette matches the real background.

Typecheck / biome / i18n / unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)