### PR TITLE
fix: drop external_endpoints from credential YAML export

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -113,7 +113,7 @@
   "src/foundation/hooks/use-on-back.tsx": "1b26d63d0f617db082c262caaccd52b5",
   "src/foundation/hooks/use-system-api.ts": "df32ab192beead6acc8b9d53bc0789f9",
   "src/foundation/hooks/use-workspace.ts": "3a84152949452a1895b1998f503c123d",
-  "src/foundation/hooks/use-yaml-export.ts": "edf7b08698c183412ea69be37f7cf54f",
+  "src/foundation/hooks/use-yaml-export.ts": "a46c26163f36ca265998397a59ae7d1c",
   "src/foundation/hooks/use-yaml-import.ts": "bf228c58ddc4332e73685fc134480a00",
   "src/foundation/components/AppBreadcrumbs.tsx": "01bacc5c5573275c18a2fdccf99ce43a",
   "src/foundation/components/AppSidebar.tsx": "2bf74a7a63eadc4382a0797120a6ee64",

--- a/src/foundation/hooks/use-yaml-export.ts
+++ b/src/foundation/hooks/use-yaml-export.ts
@@ -30,7 +30,6 @@ export const EXPORTABLE_RESOURCES = [
 // Resources that support credentials API for sensitive field export
 const CREDENTIAL_RESOURCES = [
   "clusters",
-  "external_endpoints",
   "image_registries",
   "model_registries",
 ] as const;


### PR DESCRIPTION
## Summary
- Backend (neutree PR #433) now treats External Endpoint API keys as write-only and no longer exposes `/credentials/external_endpoints`, since users attach their own third-party keys there and that read-back path was a way for anyone with export access (e.g. an admin doing a bulk "include credentials" YAML export) to pull other users' keys in plaintext.
- Removes `external_endpoints` from `CREDENTIAL_RESOURCES` in `use-yaml-export.ts` so the "Include credentials" export option falls back to the normal (masked) list fetch for this resource type instead of hitting a route that no longer exists.

## Test plan
- [x] `vitest run src/foundation/hooks/use-yaml-export.test.ts` — 30/30 passing
- [x] `biome lint` clean
- [x] pre-commit hooks (typecheck, dependency-cruiser, knip, i18n tracker) passing