### PR TITLE
fix(combobox): guard FormCombobox against null field values (NEU-520)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -125,7 +125,7 @@
   "src/foundation/components/DefaultLayout.tsx": "1efe07e1ec0621ec845daae497764550",
   "src/foundation/components/DeleteConfirmDialog.tsx": "0f6cea568f6a58bd3228ba64b694112f",
   "src/foundation/components/FormCardGrid.tsx": "4bbca825ce5823978e2873f85875f738",
-  "src/foundation/components/FormCombobox.tsx": "305512a954f1b05c79c97bb02e43d39b",
+  "src/foundation/components/FormCombobox.tsx": "ef8b6f2c71e3c5081d0c7552f2750c4d",
   "src/foundation/components/FormFieldGroup.tsx": "0060fa8474261de4450f351b55658386",
   "src/foundation/components/FormSelect.tsx": "ac1efe26cbc1a6dd715f4aa663a297cf",
   "src/foundation/components/GrafanaDashboard.tsx": "e4ecc4941d48c37b6360fabb00395828",

--- a/src/foundation/components/FormCombobox.test.tsx
+++ b/src/foundation/components/FormCombobox.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { type FieldValues, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import { Form } from "@/components/ui/form";
+import { FormCombobox } from "./FormCombobox";
+import { FormFieldGroup } from "./FormFieldGroup";
+
+const OPTIONS = [
+  { label: "Text Generation", value: "text-generation" },
+  { label: "Text Embedding", value: "text-embedding" },
+];
+
+// Render through FormFieldGroup so the combobox receives field.value the same
+// way production forms inject it (cloneElement spreads the controller field).
+// Only string props are expressible in JSX — null and BaseRecord values reach
+// the component exclusively through this injection, and the API returns
+// explicit nulls for empty composite-type fields (NEU-520).
+function Harness({ fieldValue }: { fieldValue: unknown }) {
+  const form = useForm<FieldValues>({ defaultValues: { task: fieldValue } });
+  return (
+    <Form {...form}>
+      <FormFieldGroup {...form} name="task" label="Task">
+        <FormCombobox options={OPTIONS} placeholder="Select task" />
+      </FormFieldGroup>
+    </Form>
+  );
+}
+
+const getTrigger = () => screen.getByRole("combobox");
+
+describe("FormCombobox", () => {
+  it("renders the placeholder when the field value is null", () => {
+    render(<Harness fieldValue={null} />);
+    expect(getTrigger().textContent).toContain("Select task");
+  });
+
+  it("renders the placeholder when the field value is undefined", () => {
+    render(<Harness fieldValue={undefined} />);
+    expect(getTrigger().textContent).toContain("Select task");
+  });
+
+  it("renders the matching option label for a string field value", () => {
+    render(<Harness fieldValue="text-embedding" />);
+    expect(getTrigger().textContent).toContain("Text Embedding");
+  });
+
+  it("resolves a BaseRecord field value to its id's option label", () => {
+    render(<Harness fieldValue={{ id: "text-generation" }} />);
+    expect(getTrigger().textContent).toContain("Text Generation");
+  });
+
+  it("renders no option label for an object field value without an id", () => {
+    render(<Harness fieldValue={{ name: "x" }} />);
+    const text = getTrigger().textContent ?? "";
+    expect(text).not.toContain("Text Generation");
+    expect(text).not.toContain("Text Embedding");
+  });
+});

--- a/src/foundation/components/FormCombobox.tsx
+++ b/src/foundation/components/FormCombobox.tsx
@@ -1,5 +1,15 @@
 import { CaretSortIcon, CheckIcon } from "@radix-ui/react-icons";
-
+import type {
+  BaseOption,
+  BaseRecord,
+  UseSelectReturnType,
+} from "@refinedev/core";
+import {
+  type ComponentPropsWithoutRef,
+  type ElementRef,
+  forwardRef,
+  useState,
+} from "react";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -18,24 +28,15 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useTranslation } from "@/foundation/lib/i18n";
 import { cn } from "@/foundation/lib/utils";
-import type {
-  BaseOption,
-  BaseRecord,
-  UseSelectReturnType,
-} from "@refinedev/core";
-import {
-  type ComponentPropsWithoutRef,
-  type ElementRef,
-  forwardRef,
-  useState,
-} from "react";
 
 type ComboboxProps = ComponentPropsWithoutRef<typeof Command> &
   Pick<UseSelectReturnType<BaseOption, any>, "options"> & {
     placeholder?: string;
     emptyMessage?: string;
     onChange?: (value: string | number) => void;
-    value?: string | number | BaseRecord;
+    // null is not a valid prop value, but FormFieldGroup injects field.value
+    // verbatim and the API returns explicit nulls for empty composite fields.
+    value?: string | number | BaseRecord | null;
     disabled?: boolean;
   };
 
@@ -47,7 +48,11 @@ export const FormCombobox = forwardRef<
   const [open, setOpen] = useState(false);
 
   const value = () => {
-    if (typeof props.value === "object" && "id" in props.value) {
+    if (
+      props.value != null &&
+      typeof props.value === "object" &&
+      "id" in props.value
+    ) {
       return (props.value as BaseRecord).id;
     }
 


### PR DESCRIPTION
## Summary

Editing `legacy-endpoint-0` (created during the 1.0.1 phase) white-screens after upgrading to 1.1.0 with `TypeError: Cannot use 'in' operator to search for 'id' in null` thrown from `FormCombobox`.

**Component root cause:** `FormCombobox`'s `value()` ran `typeof props.value === "object" && "id" in props.value` without excluding `null`; since `typeof null === "object"`, a null field value throws. Fixed with a `props.value != null` guard (same pattern as `isPlainRecord` in `endpoint-form-helpers.ts`), so null now renders the placeholder like undefined.

**Data root cause (verified on the QA env):** endpoint specs are stored as Postgres composite types, which convert empty strings and missing keys to SQL NULL on write, and PostgREST always returns every composite attribute — nulls included. `spec.model.task` has no required validation on either side (the DB even dropped the `model.version` check in migration 045), so records with `task: null` are the norm for catalog/YAML/API-created endpoints, not an edge case. This is not a 1.1.0 regression — the same crash exists in 1.0.1; the record just hadn't been edited before the upgrade.

## Changes

- `FormCombobox.tsx`: null-guard the `BaseRecord` branch in `value()`; widen the `value` prop type with `| null` and document why (FormFieldGroup injects `field.value` verbatim).
- `FormCombobox.test.tsx` (new): regression tests rendering through `FormFieldGroup` so `field.value` reaches the combobox via the same `cloneElement` injection as production forms — null, undefined, string, `BaseRecord`, and id-less object cases.

## Test plan

- [x] `yarn test src/foundation/components/FormCombobox.test.tsx` — 5 passed
- [x] Mutation check: with the guard reverted, the null tests fail with the exact production error
- [x] Full suite: 1099 passed; tsc clean

Jira: [NEU-520](http://jira.smartx.com/browse/NEU-520)

🤖 Generated with [Claude Code](https://claude.com/claude-code)