### PR TITLE
fix(ui): forwardRef in Badge so it works as a Radix asChild trigger

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -43,7 +43,7 @@
   "src/pages/api-keys/show.tsx": "3ecbea3750b6bc421c97fb673084dd5f",
   "src/components/ui/alert-dialog.tsx": "fd2a0854b18d61d21fe0e8effd7e4cd9",
   "src/components/ui/alert.tsx": "25ac92016d099c561981ce1456ee8741",
-  "src/components/ui/badge.tsx": "ee17cf4c4ae2e3bf161fcd6d1006eecc",
+  "src/components/ui/badge.tsx": "d90d68a1c91314812335d2d5f2a807e0",
   "src/components/ui/breadcrumb.tsx": "82df08a923d32340565cd384babe01c7",
   "src/components/ui/button.tsx": "c8948183740d3c2351034f8b5e9fe5d2",
   "src/components/ui/card.tsx": "a21745b6e55daad1af599956327a5e8f",

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,5 +1,5 @@
-import { type VariantProps, cva } from "class-variance-authority";
-import type * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
 
 import { cn } from "@/foundation/lib/utils";
 
@@ -27,10 +27,21 @@ export interface BadgeProps
   extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return (
-    <div className={cn(badgeVariants({ variant }), className)} {...props} />
-  );
-}
+// forwardRef so the Badge can be used as a Radix `asChild` trigger (Tooltip /
+// Popover / DropdownMenu). Without it, Slot can't attach the trigger ref, so
+// the tooltip has no anchor and never opens — only the cursor-help style leaks
+// through (the access-log status badge symptom).
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(badgeVariants({ variant }), className)}
+        {...props}
+      />
+    );
+  },
+);
+Badge.displayName = "Badge";
 
 export { Badge, badgeVariants };


### PR DESCRIPTION
## Problem

On the access-log (AI traces) list, hovering a status-code badge showed a `?` (help) cursor but **no tooltip content** — the status-code description never appeared.

## Root cause

`Badge` was a plain function component with no ref forwarding. `StatusBadge` wraps it in `<TooltipTrigger asChild>`, which uses Radix `Slot`. Slot merges props/classes onto the child (so `cursor-help` leaked through, giving the `?` cursor) but **can't attach the trigger ref** to a component that doesn't forward it. With a null ref the Radix Tooltip has no anchor, so it never opens.

## Fix

Wrap `Badge` in `React.forwardRef`. This is the standard shadcn pattern and fixes every current/future case of a Radix `asChild` trigger (Tooltip / Popover / DropdownMenu) wrapping a `Badge`.

Verified manually against a local dev build: the status-code tooltip now shows its description on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)