### PR TITLE
fix(cluster): restore model cache path contrast in dark mode

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -38,7 +38,7 @@
   "src/pages/clusters/create.tsx": "ee6e135f119688d2f7a72c3ecd2cd42a",
   "src/pages/clusters/edit.tsx": "ecb3a6e4f04286c161d3872d9e91bfa9",
   "src/pages/clusters/list.tsx": "71b3323f97b02b4391464719cc3aa521",
-  "src/pages/clusters/show.tsx": "8115a02a59c8da4ed7fb5562b790efd6",
+  "src/pages/clusters/show.tsx": "973c28f1c576680c9b836cb2a704da86",
   "src/pages/api-keys/list.tsx": "c48386dc0c9ab827a12a68e9994b82fb",
   "src/pages/api-keys/show.tsx": "3ecbea3750b6bc421c97fb673084dd5f",
   "src/components/ui/alert-dialog.tsx": "fd2a0854b18d61d21fe0e8effd7e4cd9",

--- a/src/pages/clusters/show.tsx
+++ b/src/pages/clusters/show.tsx
@@ -386,7 +386,7 @@ export const ClustersShow = () => {
                                     "clusters.fields.modelCache.cacheType",
                                   )}
                                 >
-                                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+                                  <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-secondary text-secondary-foreground">
                                     {cacheType === "nfs"
                                       ? t("clusters.options.nfs")
                                       : cacheType === "pvc"
@@ -402,7 +402,7 @@ export const ClustersShow = () => {
                                         "clusters.fields.modelCache.nfsServer",
                                       )}
                                     >
-                                      <code className="text-sm bg-gray-100 px-2 py-1 rounded">
+                                      <code className="text-sm bg-muted text-foreground px-2 py-1 rounded">
                                         {cache.nfs.server}
                                       </code>
                                     </ShowPage.Row>
@@ -412,7 +412,7 @@ export const ClustersShow = () => {
                                         "clusters.fields.modelCache.cachePath",
                                       )}
                                     >
-                                      <code className="text-sm bg-gray-100 px-2 py-1 rounded">
+                                      <code className="text-sm bg-muted text-foreground px-2 py-1 rounded">
                                         {cache.nfs.path}
                                       </code>
                                     </ShowPage.Row>
@@ -425,7 +425,7 @@ export const ClustersShow = () => {
                                       "clusters.fields.modelCache.cachePath",
                                     )}
                                   >
-                                    <code className="text-sm bg-gray-100 px-2 py-1 rounded">
+                                    <code className="text-sm bg-muted text-foreground px-2 py-1 rounded">
                                       {cache.host_path.path}
                                     </code>
                                   </ShowPage.Row>


### PR DESCRIPTION
## Problem

On the cluster show page, the model cache path is unreadable in dark mode — near-white text on a light gray pill.

## Root cause — regression

This was already fixed once in #288 (`a1ffcdd`), which replaced hard-coded `bg-gray-100` with theme tokens. #274 (`f59ff52`) was branched before #288 landed, and its merge resolution reverted all 4 spots in the model-cache section back to `bg-gray-100`.

The path `<code>` chips have no explicit text color, so in dark mode they inherit the near-white foreground on a light background. The "Host Path" badge survived visually only because it hard-codes `text-gray-800`.

## Fix

Re-apply #288 verbatim:
- cache-type badge: `bg-gray-100 text-gray-800` → `bg-secondary text-secondary-foreground`
- NFS server / NFS path / host path code chips: `bg-gray-100` → `bg-muted text-foreground`

Also checked the rest of #274's diff for other clobbered theme-token fixes — none found (the removed `bg-muted/30` grid line was part of #274's own GPU-section rework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)