### PR TITLE
fix: hide unconfigured endpoint core allocation

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -301,7 +301,7 @@
   "src/components/ui/calendar.tsx": "dfedaf90a75014faab50dfb32b28c5b2",
   "src/domains/endpoint/lib/vgpu.ts": "4f5a311fa5c62ec85b60aaed6db419a7",
   "src/domains/endpoint/lib/resource-status.ts": "8bf88a620b262d25091e78061584c14e",
-  "src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx": "818a6b3cbd597ccb77f14fe331d48f62",
+  "src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx": "a70bee97858c03e2fc4db89d4de7468f",
   "src/domains/cluster/lib/resource-status.ts": "9e759f014c4589740efe23ebdaf8bf74",
   "src/foundation/lib/gpu-device-resources.ts": "64f6890d0561b8a9544fa2a22ce7b12a",
   "src/foundation/components/GpuDeviceResourcesView.tsx": "bd15d01f7f41c71b7427a487a72fe429",

--- a/src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx
+++ b/src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx
@@ -147,7 +147,7 @@ describe("EndpointRuntimeResourcesCard", () => {
     expect(container.childElementCount).toBe(0);
   });
 
-  it("renders allocated replica resources for full-card resources", () => {
+  it("hides runtime core units for full-card resources without configured core percent", () => {
     const { container } = render(
       <EndpointRuntimeResourcesCard
         resources={{
@@ -189,8 +189,8 @@ describe("EndpointRuntimeResourcesCard", () => {
     expect(screen.getByText("endpoint-abc-xgpwv")).toBeTruthy();
     expect(screen.getAllByText("Tesla-T4").length).toBeGreaterThan(0);
     expect(screen.getAllByText("15.0 GiB").length).toBeGreaterThan(0);
-    expect(screen.getByText("Core 100")).toBeTruthy();
-    expect(screen.queryByText("Core -")).toBeNull();
+    expect(screen.getAllByText("Core -").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Core 100")).toBeNull();
     expect(screen.getAllByText("neutree-gpu-t4-02").length).toBeGreaterThan(0);
     expect(
       screen.queryByText("GPU-5ad72eb2-9871-1aba-55b8-ade03c41e56a"),
@@ -209,7 +209,7 @@ describe("EndpointRuntimeResourcesCard", () => {
     );
   });
 
-  it("renders allocated replica core resources when runtime core units are set", () => {
+  it("renders allocated replica core resources when configured core percent is set", () => {
     render(
       <EndpointRuntimeResourcesCard
         configuredResources={{
@@ -254,11 +254,12 @@ describe("EndpointRuntimeResourcesCard", () => {
       />,
     );
 
-    expect(screen.getAllByText("Core 100").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Core 50").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Core 100")).toBeNull();
     expect(screen.queryByText("Core -")).toBeNull();
   });
 
-  it("renders allocated core units from runtime resources as plain numbers", () => {
+  it("renders configured flat core percent as plain numbers", () => {
     render(
       <EndpointRuntimeResourcesCard
         configuredResources={{

--- a/src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx
+++ b/src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx
@@ -309,6 +309,56 @@ describe("EndpointRuntimeResourcesCard", () => {
     expect(screen.queryByText("35%")).toBeNull();
   });
 
+  it("hides configured zero core percent", () => {
+    render(
+      <EndpointRuntimeResourcesCard
+        configuredResources={{
+          cpu: 2,
+          memory: 8,
+          gpu: 1,
+          accelerator: {
+            type: "nvidia_gpu",
+            product: "Tesla-T4",
+            virtualization: {
+              memory_mib: 8192,
+              core_percent: 0,
+            },
+          },
+        }}
+        resources={{
+          summary: {
+            products: {
+              "Tesla-T4": {
+                memory_mib: 8192,
+                core_units: 100,
+              },
+            },
+          },
+          replicas: [
+            {
+              instance_id: "endpoint-vgpu-zero",
+              replica_id: "endpoint-vgpu-zero-0",
+              node_id: "neutree-gpu-t4-02",
+              devices: [
+                {
+                  uuid: "GPU-vgpu-zero-core",
+                  product: "Tesla-T4",
+                  memory_mib: 8192,
+                  core_units: 100,
+                  node_id: "neutree-gpu-t4-02",
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getAllByText("Core -").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Core 0")).toBeNull();
+    expect(screen.queryByText("Core 100")).toBeNull();
+  });
+
   it("renders replica GPU labels in physical order when order is provided", () => {
     render(
       <EndpointRuntimeResourcesCard

--- a/src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx
+++ b/src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx
@@ -18,6 +18,13 @@ type EndpointRuntimeResourcesCardProps = {
   resources: EndpointResourceStatus | null | undefined;
 };
 
+type AcceleratorWithFlatVirtualization = NonNullable<
+  ResourceSpec["accelerator"]
+> &
+  Record<string, unknown>;
+
+const FLAT_CORE_PERCENT_KEY = "virtualization.core_percent";
+
 const formatInteger = (value: number) => formatToDecimal(value, 0) ?? "-";
 
 const formatCoreLimit = (value: number) =>
@@ -38,6 +45,25 @@ const formatAllocatedCardCount = (count: number, t: (key: string) => string) =>
       ? "endpoints.fields.allocatedCard"
       : "endpoints.fields.allocatedCards",
   )}`;
+
+const parsePositiveNumber = (value: unknown) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+};
+
+const getConfiguredCorePercent = (
+  configuredResources: ResourceSpec | null | undefined,
+) => {
+  const accelerator = configuredResources?.accelerator as
+    | AcceleratorWithFlatVirtualization
+    | null
+    | undefined;
+  const value =
+    accelerator?.virtualization?.core_percent ??
+    accelerator?.[FLAT_CORE_PERCENT_KEY];
+
+  return parsePositiveNumber(value);
+};
 
 const ResourceValue = ({
   label,
@@ -62,10 +88,16 @@ const ResourceValue = ({
 );
 
 export default function EndpointRuntimeResourcesCard({
+  configuredResources,
   resources,
 }: EndpointRuntimeResourcesCardProps) {
   const { t } = useTranslation();
   const { copy } = useCopyToClipboard();
+  const configuredCorePercent = getConfiguredCorePercent(configuredResources);
+  const coreLimitText =
+    configuredCorePercent != null
+      ? formatCoreLimit(configuredCorePercent)
+      : "-";
 
   const summaryRows = getEndpointResourceSummaryRows(resources);
   const replicaGroups = getEndpointReplicaResourceGroups(resources);
@@ -125,7 +157,7 @@ export default function EndpointRuntimeResourcesCard({
               />
               <ResourceValue
                 label={t("clusters.fields.coreUsage")}
-                value={formatCoreLimit(row.coreUnits)}
+                value={coreLimitText}
               />
             </div>
           ))}
@@ -172,8 +204,7 @@ export default function EndpointRuntimeResourcesCard({
                       {t("endpoints.fields.vgpuMemory")}
                     </Badge>
                     <Badge variant="outline" className="bg-muted/40">
-                      {t("endpoints.fields.vgpuCoreCapacity")}{" "}
-                      {formatCoreLimit(group.coreUnits)}
+                      {t("endpoints.fields.vgpuCoreCapacity")} {coreLimitText}
                     </Badge>
                   </div>
                 </div>
@@ -224,7 +255,7 @@ export default function EndpointRuntimeResourcesCard({
                         <ResourceValue
                           className="border-0 bg-transparent p-0"
                           label={t("clusters.fields.coreUsage")}
-                          value={formatCoreLimit(device.coreUnits)}
+                          value={coreLimitText}
                         />
                         <ResourceValue
                           className="border-0 bg-transparent p-0"


### PR DESCRIPTION
## Summary

Fix the endpoint detail runtime resources card so GPU core allocation is shown only when the endpoint has an explicit vGPU `core_percent` configuration. Full-card endpoint allocations still show GPU and VRAM runtime details, but the core field now remains `-` instead of implying a configured compute split.

## Changes

- Read configured core percent from nested `accelerator.virtualization.core_percent` or flat `accelerator[\"virtualization.core_percent\"]`.
- Render runtime core fields from that configured value instead of raw `status.resources.*.core_units`.
- Update component tests to cover full-card allocations and configured vGPU core percent behavior.
- Update the i18n tracker after reviewing the touched component; no new user-facing text was added.

## Test Plan

### Unit test

- `PATH=/Users/huangwei/.local/share/nvm/v20.20.2/bin:$PATH yarn vitest run src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx`
- `PATH=/Users/huangwei/.local/share/nvm/v20.20.2/bin:$PATH yarn typecheck`
- `../../node_modules/.bin/biome check src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx .i18n-tracker.lock`
- `PATH=/Users/huangwei/.local/share/nvm/v20.20.2/bin:$PATH node tools/i18n-tracker.cjs --git 1 --limit 10`
- Pre-commit hook passed: `tsc -b`, `depcruise src --config .dependency-cruiser.cjs`, `knip`, `lint-staged`, i18n tracker, i18n key check.

### DB test

- Not required. This change does not touch database schema, migrations, queries, RLS, or persistence behavior.

### E2E test

- Automated E2E skipped for Trivial UI component display fix. No backend/API/deployment flow changed; coverage is provided by the component regression test.
- Live environment validation passed on `10.255.1.54:3000`: opened endpoint `default/qwen25-0p5b-chat-gpu` detail page and confirmed unconfigured core allocation renders as `Core -`, not `Core 100`.
- Live environment validation passed on `172.21.128.74:32000`.

## Notes

- Change level: Trivial. Docs MR and TestRail sync are skipped because this is a narrow endpoint UI display fix with unit coverage and no API/schema/i18n contract change.
