### PR TITLE
test(e2e): refresh specs to match current UI + make ai-trace model configurable

### DIFF
--- a/e2e/helpers/ai-trace.ts
+++ b/e2e/helpers/ai-trace.ts
@@ -19,6 +19,8 @@ export interface AiTraceEnv {
   endpoint: string;
   gateway: string;
   workspace: string;
+  /** Served model name to send as the OpenAI `model` field (env-specific). */
+  model?: string;
 }
 
 /** Resolve gating config from env, or null when the suite should be skipped. */
@@ -29,6 +31,7 @@ export function aiTraceEnv(): AiTraceEnv | null {
     endpoint,
     gateway: gatewayBase(),
     workspace: process.env.E2E_AITRACE_WORKSPACE ?? "default",
+    model: process.env.E2E_AITRACE_MODEL,
   };
 }
 
@@ -77,7 +80,7 @@ export async function chatCompletion(
   const kind = opts?.external ? "external-endpoint" : "endpoint";
   const url = `${env.gateway}/workspace/${env.workspace}/${kind}/${endpoint}/v1/chat/completions`;
   const payload = JSON.stringify({
-    model: opts?.model ?? "any",
+    model: opts?.model ?? env.model ?? "any",
     stream: opts?.stream ?? false,
     messages: [{ role: "user", content: directive(d) }],
   });

--- a/e2e/helpers/yaml-export.ts
+++ b/e2e/helpers/yaml-export.ts
@@ -1,4 +1,4 @@
-import { type Page, expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { ASYNC_UI_TIMEOUT, BULK_TIMEOUT } from "./constants";
 
 export class YamlExportHelper {
@@ -38,11 +38,23 @@ export class YamlExportHelper {
     await this.dialog.getByRole("button", { name: /deselect all/i }).click();
   }
 
+  /**
+   * Locate a resource-type row by its exact title label.
+   *
+   * Uses an exact-text filter (not substring `hasText`) because some resource
+   * titles are substrings of others — e.g. "Endpoints" is contained within
+   * "External Endpoints" — which would otherwise make the locator match both
+   * rows and throw a Playwright strict-mode violation.
+   */
+  private resourceRow(label: string) {
+    return this.dialog
+      .locator(".border.rounded-lg")
+      .filter({ has: this.page.getByText(label, { exact: true }) });
+  }
+
   /** Expand a resource type by clicking the chevron button */
   async expandResource(label: string): Promise<void> {
-    const row = this.dialog.locator(".border.rounded-lg", {
-      hasText: label,
-    });
+    const row = this.resourceRow(label);
     // Click the chevron expand button (ghost button with w-8)
     await row.locator("button.h-8.w-8").click();
     // Wait for content to load (either entities or "No entities found")
@@ -55,9 +67,7 @@ export class YamlExportHelper {
 
   /** Toggle a resource type checkbox (select/deselect) */
   async toggleResource(label: string): Promise<void> {
-    const row = this.dialog.locator(".border.rounded-lg", {
-      hasText: label,
-    });
+    const row = this.resourceRow(label);
     await row.locator('button[role="checkbox"]').click();
     // Wait for entities to load if selecting
     await this.page.waitForTimeout(500);
@@ -141,9 +151,7 @@ export class YamlExportHelper {
 
   /** Check if a resource row has entities listed (expanded state) */
   async getEntityNames(label: string): Promise<string[]> {
-    const row = this.dialog.locator(".border.rounded-lg", {
-      hasText: label,
-    });
+    const row = this.resourceRow(label);
     const labels = row.locator(".pl-4 label.text-sm");
     const count = await labels.count();
     const names: string[] = [];
@@ -156,9 +164,7 @@ export class YamlExportHelper {
 
   /** Check if a resource type shows "No entities found" */
   async hasNoEntities(label: string): Promise<boolean> {
-    const row = this.dialog.locator(".border.rounded-lg", {
-      hasText: label,
-    });
+    const row = this.resourceRow(label);
     return (await row.getByText(/no entities found/i).count()) > 0;
   }
 }

--- a/e2e/tests/api-keys.spec.ts
+++ b/e2e/tests/api-keys.spec.ts
@@ -40,82 +40,61 @@ test.describe("api keys", () => {
   // List tests
   // ────────────────────────────────────────────────────────────
   test.describe("list", () => {
-    test(
-      "list page shows expected columns",
-      {
-        tag: "@C2611860",
-      },
-      async ({ apiKeys }) => {
-        await apiKeys.goToList();
+    test("list page shows expected columns", {
+      tag: "@C2611860",
+    }, async ({ apiKeys }) => {
+      await apiKeys.goToList();
 
-        const headers = apiKeys.table.root.locator("thead th");
-        await expect(headers.filter({ hasText: /name/i })).toBeVisible();
-        await expect(headers.filter({ hasText: /workspace/i })).toBeVisible();
-        await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
-        await expect(headers.filter({ hasText: /created/i })).toBeVisible();
+      const headers = apiKeys.table.root.locator("thead th");
+      await expect(headers.filter({ hasText: /name/i })).toBeVisible();
+      await expect(headers.filter({ hasText: /workspace/i })).toBeVisible();
+      await expect(headers.filter({ hasText: /created/i })).toBeVisible();
 
-        await apiKeys.table.expectRowWithText(keyNames.a);
-      },
-    );
+      await apiKeys.table.expectRowWithText(keyNames.a);
+    });
 
-    test(
-      "can sort by name",
-      {
-        tag: "@C2611865",
-      },
-      async ({ apiKeys }) => {
-        await apiKeys.goToList();
-        await apiKeys.table.sort(/name/i);
-      },
-    );
+    test("can sort by name", {
+      tag: "@C2611865",
+    }, async ({ apiKeys }) => {
+      await apiKeys.goToList();
+      await apiKeys.table.sort(/name/i);
+    });
 
-    test(
-      "workspace column links to workspace detail",
-      {
-        tag: "@C2611866",
-      },
-      async ({ apiKeys }) => {
-        await apiKeys.goToList();
+    test("workspace column links to workspace detail", {
+      tag: "@C2611866",
+    }, async ({ apiKeys }) => {
+      await apiKeys.goToList();
 
-        const row = apiKeys.table.rowWithText(keyNames.a);
-        await row.getByRole("link", { name: "default" }).click();
+      const row = apiKeys.table.rowWithText(keyNames.a);
+      await row.getByRole("link", { name: "default" }).click();
 
-        const showPage = apiKeys.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
-        await expect(
-          showPage.getByText("default", { exact: true }),
-        ).toBeVisible();
-      },
-    );
+      const showPage = apiKeys.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
+      await expect(
+        showPage.getByText("default", { exact: true }),
+      ).toBeVisible();
+    });
 
-    test(
-      "can sort by created at",
-      {
-        tag: "@C2611867",
-      },
-      async ({ apiKeys }) => {
-        await apiKeys.goToList();
-        await apiKeys.table.sort(/created/i);
-      },
-    );
+    test("can sort by created at", {
+      tag: "@C2611867",
+    }, async ({ apiKeys }) => {
+      await apiKeys.goToList();
+      await apiKeys.table.sort(/created/i);
+    });
 
-    test(
-      "can toggle column visibility",
-      {
-        tag: "@C2611868",
-      },
-      async ({ apiKeys }) => {
-        await apiKeys.goToList();
-        // Workspace column is visible by default
-        await expect(apiKeys.table.headerCell(/workspace/i)).toBeVisible();
-        // Toggle it hidden
-        await apiKeys.table.toggleColumn(/workspace/i);
-        await expect(apiKeys.table.headerCell(/workspace/i)).toBeHidden();
-        // Toggle it visible again
-        await apiKeys.table.toggleColumn(/workspace/i);
-        await expect(apiKeys.table.headerCell(/workspace/i)).toBeVisible();
-      },
-    );
+    test("can toggle column visibility", {
+      tag: "@C2611868",
+    }, async ({ apiKeys }) => {
+      await apiKeys.goToList();
+      // Workspace column is visible by default
+      await expect(apiKeys.table.headerCell(/workspace/i)).toBeVisible();
+      // Toggle it hidden
+      await apiKeys.table.toggleColumn(/workspace/i);
+      await expect(apiKeys.table.headerCell(/workspace/i)).toBeHidden();
+      // Toggle it visible again
+      await apiKeys.table.toggleColumn(/workspace/i);
+      await expect(apiKeys.table.headerCell(/workspace/i)).toBeVisible();
+    });
 
     test(
       "only current user's keys are visible",
@@ -155,221 +134,192 @@ test.describe("api keys", () => {
   // Detail tests
   // ────────────────────────────────────────────────────────────
   test.describe("detail", () => {
-    test(
-      "show page displays name, workspace, timestamps, and usage stats table",
-      {
-        tag: "@C2611871",
-      },
-      async ({ apiKeys }) => {
-        await apiKeys.goToShow(keyNames.a);
+    test("show page displays name, workspace, timestamps, and usage/performance panels", {
+      tag: "@C2611871",
+    }, async ({ apiKeys }) => {
+      await apiKeys.goToShow(keyNames.a);
 
-        const showPage = apiKeys.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
+      const showPage = apiKeys.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
 
-        // Name
-        await expect(
-          showPage.getByText(keyNames.a, { exact: true }),
-        ).toBeVisible();
+      // Name
+      await expect(
+        showPage.getByText(keyNames.a, { exact: true }),
+      ).toBeVisible();
 
-        // Workspace
-        const workspaceDt = showPage.locator("dt", {
-          hasText: /workspace/i,
-        });
-        await expect(workspaceDt).toBeVisible();
+      // Workspace
+      const workspaceDt = showPage.locator("dt", {
+        hasText: /workspace/i,
+      });
+      await expect(workspaceDt).toBeVisible();
 
-        // Timestamps
-        await expect(
-          showPage.getByRole("term").filter({ hasText: /created at/i }),
-        ).toBeVisible();
-        await expect(
-          showPage.getByRole("term").filter({ hasText: /updated at/i }),
-        ).toBeVisible();
+      // Timestamps
+      await expect(
+        showPage.getByRole("term").filter({ hasText: /created at/i }),
+      ).toBeVisible();
+      await expect(
+        showPage.getByRole("term").filter({ hasText: /updated at/i }),
+      ).toBeVisible();
 
-        // API Usage Statistics table
-        await expect(
-          apiKeys.page.getByText(/api usage statistics/i),
-        ).toBeVisible();
+      // Last 24h request performance card: requests / avg latency / success rate
+      await expect(
+        apiKeys.page.getByText(/last 24h request performance/i),
+      ).toBeVisible();
+      await expect(apiKeys.page.getByText(/^requests$/i)).toBeVisible();
+      await expect(apiKeys.page.getByText(/avg latency/i)).toBeVisible();
+      await expect(
+        apiKeys.page.getByText("Success rate", { exact: true }),
+      ).toBeVisible();
 
-        // Table headers: Date, Endpoint, Usage
-        const usageTable = apiKeys.page.locator("table").last();
-        await expect(usageTable.getByText(/date/i)).toBeVisible();
-        await expect(usageTable.getByText(/endpoint/i)).toBeVisible();
-        await expect(usageTable.getByText(/usage/i)).toBeVisible();
-      },
-    );
+      // Limits card (token quota / rate limits)
+      await expect(
+        apiKeys.page.getByText(/limits \(optional\)/i),
+      ).toBeVisible();
+    });
   });
 
   // ────────────────────────────────────────────────────────────
   // Create tests
   // ────────────────────────────────────────────────────────────
   test.describe("create", () => {
-    test(
-      "name format accepts special characters",
-      {
-        tag: "@C2611861",
-      },
-      async ({ apiKeys, apiHelper }) => {
-        const akName = `test-ak-sp.${Date.now()}`;
+    test("name format accepts special characters", {
+      tag: "@C2611861",
+    }, async ({ apiKeys, apiHelper }) => {
+      const akName = `test-ak-sp.${Date.now()}`;
 
-        await apiKeys.goToList();
+      await apiKeys.goToList();
 
-        // Click Create button to open modal dialog
-        await apiKeys.page.getByRole("link", { name: /create/i }).click();
-        const dialog = apiKeys.page.getByRole("dialog");
-        await dialog.waitFor({ state: "visible" });
+      // Click Create button to open modal dialog
+      await apiKeys.page.getByRole("link", { name: /create/i }).click();
+      const dialog = apiKeys.page.getByRole("dialog");
+      await dialog.waitFor({ state: "visible" });
 
-        // Select workspace
-        await dialog
-          .locator("button")
-          .filter({ hasText: /select/i })
-          .click();
-        await apiKeys.page
-          .locator('[data-state="open"][role="dialog"]')
-          .getByRole("option", { name: "default", exact: true })
-          .click();
+      // Select workspace
+      await dialog.getByRole("combobox", { name: /workspace/i }).click();
+      await apiKeys.page
+        .locator('[data-state="open"][role="dialog"]')
+        .getByRole("option", { name: "default", exact: true })
+        .click();
 
-        // Fill name (target by accessible name to avoid cmdk input)
-        await dialog.getByRole("textbox", { name: /name/i }).fill(akName);
+      // Fill name (target by accessible name to avoid cmdk input)
+      await dialog.getByRole("textbox", { name: /name/i }).fill(akName);
 
-        // Submit
-        await dialog.getByRole("button", { name: /^create$/i }).click();
+      // Submit
+      await dialog.getByRole("button", { name: /^create$/i }).click();
 
-        // Should show secret key (success state)
-        await expect(
-          dialog.getByText("API Key created successfully", { exact: false }),
-        ).toBeVisible({ timeout: ASYNC_UI_TIMEOUT });
-        await expect(dialog.locator("code")).toBeVisible();
+      // Should show secret key (success state)
+      await expect(
+        dialog.getByText("API Key created successfully", { exact: false }),
+      ).toBeVisible({ timeout: ASYNC_UI_TIMEOUT });
+      await expect(dialog.locator("code")).toBeVisible();
 
-        // Close the dialog (use .first() to avoid matching the Radix X button)
-        await dialog.getByRole("button", { name: /close/i }).first().click();
-        await dialog.waitFor({ state: "hidden" });
+      // Close the dialog (use .first() to avoid matching the Radix X button)
+      await dialog.getByRole("button", { name: /close/i }).first().click();
+      await dialog.waitFor({ state: "hidden" });
 
-        // Verify in list
-        await apiKeys.table.expectRowWithText(akName);
+      // Verify in list
+      await apiKeys.table.expectRowWithText(akName);
 
-        // Cleanup
-        await apiHelper.deleteApiKey(akName).catch(() => {});
-      },
-    );
+      // Cleanup
+      await apiHelper.deleteApiKey(akName).catch(() => {});
+    });
 
-    test(
-      "save creates key and displays secret key",
-      {
-        tag: "@C2611863",
-      },
-      async ({ apiKeys, apiHelper }) => {
-        const akName = `test-ak-save-${Date.now()}`;
+    test("save creates key and displays secret key", {
+      tag: "@C2611863",
+    }, async ({ apiKeys, apiHelper }) => {
+      const akName = `test-ak-save-${Date.now()}`;
 
-        await apiKeys.goToList();
-        await apiKeys.page.getByRole("link", { name: /create/i }).click();
-        const dialog = apiKeys.page.getByRole("dialog");
-        await dialog.waitFor({ state: "visible" });
+      await apiKeys.goToList();
+      await apiKeys.page.getByRole("link", { name: /create/i }).click();
+      const dialog = apiKeys.page.getByRole("dialog");
+      await dialog.waitFor({ state: "visible" });
 
-        // Select workspace
-        await dialog
-          .locator("button")
-          .filter({ hasText: /select/i })
-          .click();
-        await apiKeys.page
-          .locator('[data-state="open"][role="dialog"]')
-          .getByRole("option", { name: "default", exact: true })
-          .click();
+      // Select workspace
+      await dialog.getByRole("combobox", { name: /workspace/i }).click();
+      await apiKeys.page
+        .locator('[data-state="open"][role="dialog"]')
+        .getByRole("option", { name: "default", exact: true })
+        .click();
 
-        // Fill name (target by accessible name to avoid cmdk input)
-        await dialog.getByRole("textbox", { name: /name/i }).fill(akName);
+      // Fill name (target by accessible name to avoid cmdk input)
+      await dialog.getByRole("textbox", { name: /name/i }).fill(akName);
 
-        // Submit
-        await dialog.getByRole("button", { name: /^create$/i }).click();
+      // Submit
+      await dialog.getByRole("button", { name: /^create$/i }).click();
 
-        // Verify success state: secret key shown
-        await expect(
-          dialog.getByText("API Key created successfully", { exact: false }),
-        ).toBeVisible({ timeout: ASYNC_UI_TIMEOUT });
-        const secretKey = await dialog.locator("code").textContent();
-        expect(secretKey).toBeTruthy();
-        expect(secretKey?.length).toBeGreaterThan(10);
+      // Verify success state: secret key shown
+      await expect(
+        dialog.getByText("API Key created successfully", { exact: false }),
+      ).toBeVisible({ timeout: ASYNC_UI_TIMEOUT });
+      const secretKey = await dialog.locator("code").textContent();
+      expect(secretKey).toBeTruthy();
+      expect(secretKey?.length).toBeGreaterThan(10);
 
-        // Close (use .first() to avoid matching the Radix X button)
-        await dialog.getByRole("button", { name: /close/i }).first().click();
-        await dialog.waitFor({ state: "hidden" });
+      // Close (use .first() to avoid matching the Radix X button)
+      await dialog.getByRole("button", { name: /close/i }).first().click();
+      await dialog.waitFor({ state: "hidden" });
 
-        // Cleanup
-        await apiHelper.deleteApiKey(akName).catch(() => {});
-      },
-    );
+      // Cleanup
+      await apiHelper.deleteApiKey(akName).catch(() => {});
+    });
 
-    test(
-      "cancel button closes dialog without creating",
-      {
-        tag: "@C2611864",
-      },
-      async ({ apiKeys }) => {
-        const akName = `test-ak-cancel-${Date.now()}`;
+    test("cancel button closes dialog without creating", {
+      tag: "@C2611864",
+    }, async ({ apiKeys }) => {
+      const akName = `test-ak-cancel-${Date.now()}`;
 
-        await apiKeys.goToList();
-        await apiKeys.page.getByRole("link", { name: /create/i }).click();
-        const dialog = apiKeys.page.getByRole("dialog");
-        await dialog.waitFor({ state: "visible" });
+      await apiKeys.goToList();
+      await apiKeys.page.getByRole("link", { name: /create/i }).click();
+      const dialog = apiKeys.page.getByRole("dialog");
+      await dialog.waitFor({ state: "visible" });
 
-        // Fill name but cancel
-        await dialog.getByRole("textbox", { name: /name/i }).fill(akName);
-        await dialog.getByRole("button", { name: /cancel/i }).click();
-        await dialog.waitFor({ state: "hidden" });
+      // Fill name but cancel
+      await dialog.getByRole("textbox", { name: /name/i }).fill(akName);
+      await dialog.getByRole("button", { name: /cancel/i }).click();
+      await dialog.waitFor({ state: "hidden" });
 
-        // Key should not appear in list
-        await apiKeys.table.expectNoRowWithText(akName);
-      },
-    );
+      // Key should not appear in list
+      await apiKeys.table.expectNoRowWithText(akName);
+    });
 
-    test(
-      "OSS only allows default workspace",
-      {
-        tag: "@C2611875",
-      },
-      async ({ apiKeys }) => {
-        await apiKeys.goToList();
-        await apiKeys.page.getByRole("link", { name: /create/i }).click();
-        const dialog = apiKeys.page.getByRole("dialog");
-        await dialog.waitFor({ state: "visible" });
+    test("OSS only allows default workspace", {
+      tag: "@C2611875",
+    }, async ({ apiKeys }) => {
+      await apiKeys.goToList();
+      await apiKeys.page.getByRole("link", { name: /create/i }).click();
+      const dialog = apiKeys.page.getByRole("dialog");
+      await dialog.waitFor({ state: "visible" });
 
-        // Open workspace combobox
-        await dialog
-          .locator("button")
-          .filter({ hasText: /select/i })
-          .click();
-        const popover = apiKeys.page.locator(
-          '[data-state="open"][role="dialog"]',
-        );
+      // Open workspace combobox
+      await dialog.getByRole("combobox", { name: /workspace/i }).click();
+      const popover = apiKeys.page.locator(
+        '[data-state="open"][role="dialog"]',
+      );
 
-        // Should show "default" workspace option
-        await expect(
-          popover.getByRole("option", { name: "default" }),
-        ).toBeVisible();
+      // Should show "default" workspace option
+      await expect(
+        popover.getByRole("option", { name: "default" }),
+      ).toBeVisible();
 
-        // Close
-        await apiKeys.page.keyboard.press("Escape");
-        await dialog.getByRole("button", { name: /cancel/i }).click();
-      },
-    );
+      // Close
+      await apiKeys.page.keyboard.press("Escape");
+      await dialog.getByRole("button", { name: /cancel/i }).click();
+    });
   });
 
   // ────────────────────────────────────────────────────────────
   // Delete tests
   // ────────────────────────────────────────────────────────────
   test.describe("delete", () => {
-    test(
-      "can delete from list action menu",
-      {
-        tag: "@C2611869",
-      },
-      async ({ apiKeys, apiHelper }) => {
-        const akName = `test-ak-del-${Date.now()}`;
-        await apiHelper.createApiKey(akName);
+    test("can delete from list action menu", {
+      tag: "@C2611869",
+    }, async ({ apiKeys, apiHelper }) => {
+      const akName = `test-ak-del-${Date.now()}`;
+      await apiHelper.createApiKey(akName);
 
-        await apiKeys.goToList();
-        await apiKeys.table.deleteRow(akName);
-        await apiKeys.table.expectNoRowWithText(akName);
-      },
-    );
+      await apiKeys.goToList();
+      await apiKeys.table.deleteRow(akName);
+      await apiKeys.table.expectNoRowWithText(akName);
+    });
   });
 });

--- a/e2e/tests/clusters-create.spec.ts
+++ b/e2e/tests/clusters-create.spec.ts
@@ -31,554 +31,824 @@ test.describe("clusters - create", () => {
   // Create tests
   // ────────────────────────────────────────────────────────────
   test.describe("create", () => {
-    test(
-      "create form shows basic fields",
-      { tag: "@C2612678" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("create form shows basic fields", { tag: "@C2612678" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-        await expect(clusters.form.field("metadata.name")).toBeVisible();
-        await expect(clusters.form.field("metadata.workspace")).toBeVisible();
-        await expect(clusters.form.field("spec.image_registry")).toBeVisible();
-        await expect(clusters.form.field("spec.type")).toBeVisible();
-      },
-    );
+      await expect(clusters.form.field("metadata.name")).toBeVisible();
+      await expect(clusters.form.field("metadata.workspace")).toBeVisible();
+      await expect(clusters.form.field("spec.image_registry")).toBeVisible();
+      await expect(clusters.form.field("spec.type")).toBeVisible();
+    });
 
-    test(
-      "type selector shows Static Nodes and Kubernetes",
-      { tag: "@C2612679" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("type selector shows Static Nodes and Kubernetes", {
+      tag: "@C2612679",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
 
-        const typeField = clusters.form.field("spec.type");
-        await typeField.locator('button[role="combobox"]').click();
+      const typeField = clusters.form.field("spec.type");
+      await typeField.locator('button[role="combobox"]').click();
 
-        await expect(
-          clusters.page.getByRole("option", { name: /static nodes/i }),
-        ).toBeVisible();
-        await expect(
-          clusters.page.getByRole("option", { name: /kubernetes/i }),
-        ).toBeVisible();
-      },
-    );
+      await expect(
+        clusters.page.getByRole("option", { name: /static nodes/i }),
+      ).toBeVisible();
+      await expect(
+        clusters.page.getByRole("option", { name: /kubernetes/i }),
+      ).toBeVisible();
+    });
 
-    test(
-      "SSH: provider fields visible",
-      { tag: "@C2612793" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("SSH: provider fields visible", { tag: "@C2612793" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-        // Default type is SSH, so provider fields should be visible
-        await expect(clusters.page.getByText("Head Node IP")).toBeVisible();
-        await expect(clusters.page.getByText("Worker Node IPs")).toBeVisible();
-      },
-    );
+      // Default type is SSH, so provider fields should be visible
+      await expect(clusters.page.getByText("Head Node IP")).toBeVisible();
+      await expect(clusters.page.getByText("Worker Node IPs")).toBeVisible();
+    });
 
-    test(
-      "SSH: head IP required validation",
-      { tag: "@C2612794" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("SSH: head IP required validation", { tag: "@C2612794" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-        // Head Node IP input uses placeholder "e.g 192.168.1.1"
-        const headIpInput = clusters.page.getByPlaceholder("e.g 192.168.1.1");
+      // Head Node IP input uses placeholder "e.g 192.168.1.1"
+      const headIpInput = clusters.page.getByPlaceholder("e.g 192.168.1.1");
 
-        // Fill then clear and blur to trigger validation
-        await headIpInput.fill("1.1.1.1");
-        await headIpInput.clear();
-        await headIpInput.blur();
+      // Fill then clear and blur to trigger validation
+      await headIpInput.fill("1.1.1.1");
+      await headIpInput.clear();
+      await headIpInput.blur();
 
-        // Check validation error
-        await expect(
-          clusters.page.getByText("IP address is required"),
-        ).toBeVisible();
-      },
-    );
+      // Check validation error
+      await expect(
+        clusters.page.getByText("IP address is required"),
+      ).toBeVisible();
+    });
 
-    test(
-      "SSH: worker IP input placeholder",
-      { tag: "@C2612795" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("SSH: worker IP input placeholder", { tag: "@C2612795" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-        await expect(
-          clusters.page.getByPlaceholder("Add New Worker Node IP"),
-        ).toBeVisible();
-      },
-    );
+      await expect(
+        clusters.page.getByPlaceholder("Add New Worker Node IP"),
+      ).toBeVisible();
+    });
 
-    test(
-      "SSH: add single worker IP",
-      { tag: "@C2612796" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("SSH: add single worker IP", { tag: "@C2612796" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-        const workerInput = clusters.page.getByPlaceholder(
-          "Add New Worker Node IP",
-        );
-        await workerInput.fill("10.0.0.1");
-        await clusters.page
-          .getByRole("button", { name: "Add", exact: true })
-          .click();
+      const workerInput = clusters.page.getByPlaceholder(
+        "Add New Worker Node IP",
+      );
+      await workerInput.fill("10.0.0.1");
+      await clusters.page
+        .getByRole("button", { name: "Add", exact: true })
+        .click();
 
-        // Verify IP shown in list
-        await expect(clusters.page.getByText("10.0.0.1")).toBeVisible();
-      },
-    );
+      // Verify IP shown in list
+      await expect(clusters.page.getByText("10.0.0.1")).toBeVisible();
+    });
 
-    test(
-      "SSH: add multiple worker IPs",
-      { tag: "@C2612797" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("SSH: add multiple worker IPs", { tag: "@C2612797" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-        const workerInput = clusters.page.getByPlaceholder(
-          "Add New Worker Node IP",
-        );
+      const workerInput = clusters.page.getByPlaceholder(
+        "Add New Worker Node IP",
+      );
 
-        // Add first IP
-        await workerInput.fill("10.0.0.1");
-        await clusters.page
-          .getByRole("button", { name: "Add", exact: true })
-          .click();
+      // Add first IP
+      await workerInput.fill("10.0.0.1");
+      await clusters.page
+        .getByRole("button", { name: "Add", exact: true })
+        .click();
 
-        // Add second IP
-        await workerInput.fill("10.0.0.2");
-        await clusters.page
-          .getByRole("button", { name: "Add", exact: true })
-          .click();
+      // Add second IP
+      await workerInput.fill("10.0.0.2");
+      await clusters.page
+        .getByRole("button", { name: "Add", exact: true })
+        .click();
 
-        // Verify both IPs shown
-        await expect(clusters.page.getByText("10.0.0.1")).toBeVisible();
-        await expect(clusters.page.getByText("10.0.0.2")).toBeVisible();
-      },
-    );
+      // Verify both IPs shown
+      await expect(clusters.page.getByText("10.0.0.1")).toBeVisible();
+      await expect(clusters.page.getByText("10.0.0.2")).toBeVisible();
+    });
 
-    test(
-      "SSH: add then remove worker IP",
-      { tag: "@C2612798" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("SSH: add then remove worker IP", { tag: "@C2612798" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-        const workerInput = clusters.page.getByPlaceholder(
-          "Add New Worker Node IP",
-        );
-        await workerInput.fill("10.0.0.1");
-        await clusters.page
-          .getByRole("button", { name: "Add", exact: true })
-          .click();
+      const workerInput = clusters.page.getByPlaceholder(
+        "Add New Worker Node IP",
+      );
+      await workerInput.fill("10.0.0.1");
+      await clusters.page
+        .getByRole("button", { name: "Add", exact: true })
+        .click();
 
-        // Verify IP is shown and badge updated (ensures React re-render is done)
-        await expect(clusters.page.getByText("10.0.0.1")).toBeVisible();
-        await expect(clusters.page.getByText("1 nodes")).toBeVisible();
+      // Verify IP is shown and badge updated (ensures React re-render is done)
+      await expect(clusters.page.getByText("10.0.0.1")).toBeVisible();
+      await expect(clusters.page.getByText("1 nodes")).toBeVisible();
 
-        // Click the trash button via evaluate to avoid React re-render detachment
+      // Click the trash button via evaluate to avoid React re-render detachment
+      await clusters.page.evaluate(() => {
+        const btn = document.querySelector('[data-testid="remove-worker-ip"]');
+        if (btn) (btn as HTMLButtonElement).click();
+      });
+
+      // Verify IP removed — empty state message should reappear
+      await expect(
+        clusters.page.getByText("No worker nodes added"),
+      ).toBeVisible();
+    });
+
+    test("SSH: worker IPs count badge", { tag: "@C2612799" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+
+      // Initially 0 nodes
+      await expect(clusters.page.getByText("0 nodes")).toBeVisible();
+
+      const workerInput = clusters.page.getByPlaceholder(
+        "Add New Worker Node IP",
+      );
+
+      // Add first IP and wait for it to appear in list
+      await workerInput.fill("10.0.0.1");
+      await clusters.page
+        .getByRole("button", { name: "Add", exact: true })
+        .click();
+      await expect(clusters.page.getByText("10.0.0.1")).toBeVisible();
+      await expect(clusters.page.getByText("1 nodes")).toBeVisible();
+
+      // Wait for the bidirectional useEffect state sync (local ↔ form) to settle
+      // before adding the next IP — without this the sync can overwrite local state
+      await expect(workerInput).toHaveValue("");
+      // eslint-disable-next-line playwright/no-wait-for-timeout
+      await clusters.page.waitForTimeout(300);
+
+      // Add second IP and wait for it to appear in list
+      await workerInput.fill("10.0.0.2");
+      await clusters.page
+        .getByRole("button", { name: "Add", exact: true })
+        .click();
+      await expect(clusters.page.getByText("10.0.0.2")).toBeVisible();
+      await expect(clusters.page.getByText("2 nodes")).toBeVisible();
+
+      // Remove first IP — retry evaluate click until badge updates
+      await expect(async () => {
         await clusters.page.evaluate(() => {
           const btn = document.querySelector(
             '[data-testid="remove-worker-ip"]',
           );
           if (btn) (btn as HTMLButtonElement).click();
         });
+        await expect(clusters.page.getByText("1 nodes")).toBeVisible({
+          timeout: 2000,
+        });
+      }).toPass({ timeout: 10000 });
+    });
 
-        // Verify IP removed — empty state message should reappear
-        await expect(
-          clusters.page.getByText("No worker nodes added"),
-        ).toBeVisible();
-      },
-    );
+    test("SSH: auth fields visible", { tag: "@C2612801" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-    test(
-      "SSH: worker IPs count badge",
-      { tag: "@C2612799" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+      await expect(
+        clusters.form.field("spec.config.ssh_config.auth.ssh_user"),
+      ).toBeVisible();
+      await expect(
+        clusters.form.field("spec.config.ssh_config.auth.ssh_private_key"),
+      ).toBeVisible();
+    });
 
-        // Initially 0 nodes
-        await expect(clusters.page.getByText("0 nodes")).toBeVisible();
+    test("SSH: model cache section visible", { tag: "@C2612804" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
 
-        const workerInput = clusters.page.getByPlaceholder(
-          "Add New Worker Node IP",
+      // Model Caches section title and Add button
+      await expect(
+        clusters.page.getByRole("button", { name: /add model cache/i }),
+      ).toBeVisible();
+    });
+
+    test("SSH: model cache only has Host Path option", {
+      tag: "@C2612805",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+
+      // Add a cache item
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
+
+      // The cache type select shows "Host Path" by default — click to open it
+      // Navigate from "Cache Type" text to its sibling combobox
+      const cacheTypeCombobox = clusters.page
+        .locator('[data-testid="cache-type-select"]')
+        .locator('button[role="combobox"]');
+      await cacheTypeCombobox.click();
+
+      // Only Host Path should be available
+      await expect(
+        clusters.page.getByRole("option", { name: /host path/i }),
+      ).toBeVisible();
+
+      // Should have exactly 1 option
+      const options = clusters.page.getByRole("option");
+      await expect(options).toHaveCount(1);
+    });
+
+    test("K8s: kubeconfig field visible", { tag: "@C2612765" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+
+      // Switch to Kubernetes type
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      await expect(
+        clusters.form.field("spec.config.kubernetes_config.kubeconfig"),
+      ).toBeVisible();
+    });
+
+    test("K8s: router fields visible", { tag: "@C2623069" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+
+      // Switch to Kubernetes type
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      await expect(
+        clusters.form.field("spec.config.kubernetes_config.router.access_mode"),
+      ).toBeVisible();
+      await expect(
+        clusters.form.field("spec.config.kubernetes_config.router.replicas"),
+      ).toBeVisible();
+      await expect(
+        clusters.form.field(
+          "spec.config.kubernetes_config.router.resources.cpu",
+        ),
+      ).toBeVisible();
+      await expect(
+        clusters.form.field(
+          "spec.config.kubernetes_config.router.resources.memory",
+        ),
+      ).toBeVisible();
+    });
+
+    test("K8s: default router replicas = 2", { tag: "@C2623070" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      const replicasInput = clusters.form
+        .field("spec.config.kubernetes_config.router.replicas")
+        .locator("input");
+      await expect(replicasInput).toHaveValue("2");
+    });
+
+    test("K8s: default router CPU = 1", { tag: "@C2623071" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      const cpuInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.cpu")
+        .locator("input");
+      await expect(cpuInput).toHaveValue("1");
+    });
+
+    test("K8s: default router memory = 1Gi", { tag: "@C2623072" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      const memoryInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.memory")
+        .locator("input");
+      await expect(memoryInput).toHaveValue("1Gi");
+    });
+
+    test("K8s: access mode default LoadBalancer, can change to NodePort", {
+      tag: "@C2623073",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      const accessModeButton = clusters.form
+        .field("spec.config.kubernetes_config.router.access_mode")
+        .locator('button[role="combobox"]');
+
+      // Default should show "LoadBalancer"
+      await expect(accessModeButton).toHaveText(/LoadBalancer/);
+
+      // Change to NodePort
+      await accessModeButton.click();
+      await clusters.page.getByRole("option", { name: "NodePort" }).click();
+
+      await expect(accessModeButton).toHaveText(/NodePort/);
+    });
+
+    test("K8s: no default model cache, add via button", {
+      tag: "@C2612777",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      // No cache items initially — empty state message shown
+      await expect(clusters.page.getByText("No model caches")).toBeVisible();
+
+      // Click "Add Model Cache" → cache form appears
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
+
+      // Cache card should appear (title starts with #1)
+      await expect(clusters.page.getByText("#1 -")).toBeVisible();
+
+      // Empty state message should be gone
+      await expect(clusters.page.getByText("No model caches")).toBeHidden();
+    });
+
+    test("K8s: model cache has Host Path, NFS, PVC options", {
+      tag: "@C2612778",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+
+      // Switch to Kubernetes type
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      // Add a cache item
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
+
+      // The cache type select shows "Host Path" by default — click to open it
+      const cacheTypeCombobox = clusters.page
+        .locator('[data-testid="cache-type-select"]')
+        .locator('button[role="combobox"]');
+      await cacheTypeCombobox.click();
+
+      await expect(
+        clusters.page.getByRole("option", { name: /host path/i }),
+      ).toBeVisible();
+      await expect(
+        clusters.page.getByRole("option", { name: /nfs/i }),
+      ).toBeVisible();
+      await expect(
+        clusters.page.getByRole("option", { name: /pvc/i }),
+      ).toBeVisible();
+    });
+
+    test("only 1 model cache allowed in UI", { tag: "@C2623045" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+
+      // Add a cache item
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
+
+      // Cache card appears
+      await expect(clusters.page.getByText("#1 -")).toBeVisible();
+
+      // "Add Model Cache" button should be hidden since limit is 1
+      await expect(
+        clusters.page.getByRole("button", { name: /add model cache/i }),
+      ).toBeHidden();
+    });
+
+    test("SSH: host path empty path blocks submit", {
+      tag: "@C2612812",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+
+      // Add a model cache (default type is Host Path)
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
+
+      // Leave cache path empty and try to submit
+      await clusters.form.submit();
+
+      // Client-side validation prevents submission — form stays visible
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+
+      // Validation error should appear for cache path
+      await expect(
+        clusters.page.getByText(/cache path is required/i),
+      ).toBeVisible();
+    });
+
+    test("K8s: NFS empty server/path blocks submit", {
+      tag: "@C2612813",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      // Add a cache item
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
+
+      // Switch cache type to NFS
+      const cacheTypeCombobox = clusters.page
+        .locator('[data-testid="cache-type-select"]')
+        .locator('button[role="combobox"]');
+      await cacheTypeCombobox.click();
+      await clusters.page.getByRole("option", { name: /^NFS$/i }).click();
+
+      // Leave NFS fields empty and try to submit
+      await clusters.form.submit();
+
+      // Form stays visible — validation prevents submission
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+
+      // Validation errors should appear
+      await expect(
+        clusters.page.getByText(/server address is required/i),
+      ).toBeVisible();
+      await expect(
+        clusters.page.getByText(/cache path is required/i),
+      ).toBeVisible();
+    });
+
+    test("K8s: PVC empty storage class still submittable", {
+      tag: "@C2623046",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      // Add a cache item
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
+
+      // Switch cache type to PVC
+      const cacheTypeCombobox = clusters.page
+        .locator('[data-testid="cache-type-select"]')
+        .locator('button[role="combobox"]');
+      await cacheTypeCombobox.click();
+      await clusters.page.getByRole("option", { name: /^PVC$/i }).click();
+
+      // Storage field has a default value (500Gi), storageClassName is optional
+      // Verify storageClassName has no required indicator — no error when empty
+      await clusters.form.submit();
+
+      // No "storageClassName is required" error should appear
+      await expect(
+        clusters.page.getByText(/storage class.*required/i),
+      ).toBeHidden();
+    });
+
+    test("K8s: PVC default AccessMode = ReadWriteMany", {
+      tag: "@C2623078",
+    }, async ({ clusters, apiHelper }) => {
+      // spec.version is a required field, auto-populated from
+      // GET /clusters/available_versions once workspace+registry+type are
+      // set. Mock it so the version resolves deterministically instead of
+      // depending on the test image registry actually having published
+      // versions (it doesn't), which would otherwise leave spec.version
+      // empty/invalid and block submission before it reaches the server.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
+
+      await clusters.goToCreate();
+
+      const name = `test-cl-pvc-am-${Date.now()}`;
+      await clusters.form.fillInput("metadata.name", name);
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
+
+      // Add a model cache and switch to PVC type
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
+
+      const cacheNameInput = clusters.form
+        .field("spec.config.model_caches.0.name")
+        .locator("input");
+      await cacheNameInput.fill("test-pvc-cache");
+
+      const cacheTypeCombobox = clusters.page
+        .locator('[data-testid="cache-type-select"]')
+        .locator('button[role="combobox"]');
+      await cacheTypeCombobox.click();
+      await clusters.page.getByRole("option", { name: /^PVC$/i }).click();
+
+      // Intercept the POST request to verify accessModes in payload
+      const requestPromise = clusters.page.waitForRequest(
+        (r) => r.url().includes("/clusters") && r.method() === "POST",
+      );
+      await clusters.form.submit();
+      const request = await requestPromise;
+      const body = JSON.parse(request.postData() || "{}");
+
+      // Verify PVC accessModes defaults to ReadWriteMany
+      const modelCaches = body.spec?.config?.model_caches;
+      expect(modelCaches).toBeDefined();
+      expect(modelCaches[0]?.pvc?.accessModes).toEqual(["ReadWriteMany"]);
+
+      // Cleanup in case the cluster was actually created
+      await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+    });
+
+    test.skip("cancel does not create resource", { tag: "@miss" }, async ({
+      clusters,
+    }) => {
+      const name = `test-cl-cancel-${Date.now()}`;
+
+      await clusters.goToCreate();
+
+      await clusters.form.fillInput("metadata.name", name);
+
+      // Accept browser dialog if warnWhenUnsavedChanges fires
+      clusters.page.on("dialog", (dialog) => dialog.accept());
+      await clusters.form.cancel();
+
+      // Navigate to list and verify no row was created
+      await clusters.goToList();
+      await clusters.table.expectNoRowWithText(name);
+    });
+
+    // ── Group 1: Create Form Validation ──
+
+    test("create: empty name → submit fails", { tag: "@C2612670" }, async ({
+      clusters,
+    }) => {
+      // spec.version is a required field, auto-populated once
+      // workspace+registry+type are set. Mock available_versions so it
+      // resolves deterministically and the only invalid field left is the
+      // empty name under test (see the PVC AccessMode test above for the
+      // same rationale).
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
+
+      await clusters.goToCreate();
+
+      // Select image registry so that's not the failure reason
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+
+      // Fill head IP to pass provider validation
+      await clusters.page
+        .getByPlaceholder("e.g 192.168.1.1")
+        .fill("192.168.1.1");
+
+      // Leave name empty → submit and wait for any API response
+      const responsePromise = clusters.page.waitForResponse((r) =>
+        r.url().includes("/clusters"),
+      );
+      await clusters.form.submit();
+      const response = await responsePromise;
+
+      // Server should reject empty name
+      expect(response.ok()).toBe(false);
+
+      // Form stays visible
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
+
+    test("create: no image registry → submit fails", {
+      tag: "@C2612674",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+
+      // Fill name but don't select image registry
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-cl-noimr-${Date.now()}`,
+      );
+
+      // Fill head IP to pass provider validation
+      await clusters.page
+        .getByPlaceholder("e.g 192.168.1.1")
+        .fill("192.168.1.1");
+
+      // Without an image registry, spec.version's available_versions query
+      // never enables (versionsQueryEnabled requires workspace + registry +
+      // type — see use-cluster-form.tsx), so spec.version stays cleared
+      // and its own required-field validation blocks the submit
+      // client-side before any request reaches the server. Assert that
+      // no POST is fired and the (now-required) version field surfaces the
+      // validation error, rather than waiting for a server response that
+      // will never come.
+      let sawRequest = false;
+      clusters.page.on("request", (r) => {
+        if (r.url().includes("/clusters") && r.method() === "POST") {
+          sawRequest = true;
+        }
+      });
+
+      await clusters.form.submit();
+
+      await expect(
+        clusters.page.getByText(/version is required/i),
+      ).toBeVisible();
+
+      // Form stays visible
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+      expect(sawRequest).toBe(false);
+    });
+
+    test("create: image registry search and select", {
+      tag: "@C2612676",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+
+      // Open the image registry combobox
+      const irField = clusters.form.field("spec.image_registry");
+      await irField.locator("button").click();
+
+      // Type partial name to search
+      const dialog = clusters.page.locator(
+        '[data-state="open"][role="dialog"]',
+      );
+      const searchInput = dialog.getByRole("combobox");
+      await searchInput.fill(irName.value.slice(0, 10));
+
+      // Verify the option appears in filtered results and select it
+      await expect(
+        dialog.getByRole("option", { name: irName.value, exact: true }),
+      ).toBeVisible();
+      await dialog
+        .getByRole("option", { name: irName.value, exact: true })
+        .click();
+
+      // Verify the trigger now shows the selected value
+      await expect(irField.locator("button")).toHaveText(
+        new RegExp(irName.value),
+      );
+    });
+
+    test("create: image registry filtered by workspace", {
+      tag: "@C2612680",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+
+      // Default workspace is "default" — open image registry combobox
+      const irField = clusters.form.field("spec.image_registry");
+      await irField.locator("button").click();
+
+      // The test image registry (created in default workspace) should appear
+      const dialog = clusters.page.locator(
+        '[data-state="open"][role="dialog"]',
+      );
+      await expect(
+        dialog.getByRole("option", { name: irName.value, exact: true }),
+      ).toBeVisible();
+
+      // Close the combobox
+      await clusters.page.keyboard.press("Escape");
+    });
+
+    test("SSH: no head IP → submit shows error", { tag: "@C2612792" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+
+      // Fill name and select image registry
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-cl-noip-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+
+      // Don't fill head IP — click submit
+      await clusters.form.submit();
+
+      // Client-side validation shows "IP address is required"
+      await expect(
+        clusters.page.getByText("IP address is required"),
+      ).toBeVisible();
+
+      // Form stays visible (submission blocked)
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
+
+    // ── Group 2: K8s Router Parameter Validation ──
+
+    test("K8s: router config always has defaults when type selected", {
+      tag: "@C2612766",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      // Router fields should exist with default values
+      await expect(
+        clusters.form.field("spec.config.kubernetes_config.router.access_mode"),
+      ).toBeVisible();
+      await expect(
+        clusters.form.field("spec.config.kubernetes_config.router.replicas"),
+      ).toBeVisible();
+      await expect(
+        clusters.form.field(
+          "spec.config.kubernetes_config.router.resources.cpu",
+        ),
+      ).toBeVisible();
+      await expect(
+        clusters.form.field(
+          "spec.config.kubernetes_config.router.resources.memory",
+        ),
+      ).toBeVisible();
+
+      // Verify defaults
+      const replicasInput = clusters.form
+        .field("spec.config.kubernetes_config.router.replicas")
+        .locator("input");
+      await expect(replicasInput).toHaveValue("2");
+
+      const cpuInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.cpu")
+        .locator("input");
+      await expect(cpuInput).toHaveValue("1");
+
+      const memoryInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.memory")
+        .locator("input");
+      await expect(memoryInput).toHaveValue("1Gi");
+    });
+
+    test("K8s: access mode default always set", { tag: "@C2612767" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+
+      // Access mode Select always has a default value
+      const accessModeButton = clusters.form
+        .field("spec.config.kubernetes_config.router.access_mode")
+        .locator('button[role="combobox"]');
+      await expect(accessModeButton).toHaveText(/LoadBalancer/);
+
+      // Open and verify options
+      await accessModeButton.click();
+      await expect(
+        clusters.page.getByRole("option", { name: "LoadBalancer" }),
+      ).toBeVisible();
+      await expect(
+        clusters.page.getByRole("option", { name: "NodePort" }),
+      ).toBeVisible();
+      await clusters.page.keyboard.press("Escape");
+    });
+
+    test("K8s: create payload does not include router version", {
+      tag: "@C2728017",
+    }, async ({ clusters, apiHelper }) => {
+      const name = `test-k8s-router-ver-${Date.now()}`;
+      try {
+        await clusters.page.route(
+          "**/api/v1/clusters/available_versions?**",
+          async (route) => {
+            await route.fulfill({
+              contentType: "application/json",
+              body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+            });
+          },
         );
-
-        // Add first IP and wait for it to appear in list
-        await workerInput.fill("10.0.0.1");
-        await clusters.page
-          .getByRole("button", { name: "Add", exact: true })
-          .click();
-        await expect(clusters.page.getByText("10.0.0.1")).toBeVisible();
-        await expect(clusters.page.getByText("1 nodes")).toBeVisible();
-
-        // Wait for the bidirectional useEffect state sync (local ↔ form) to settle
-        // before adding the next IP — without this the sync can overwrite local state
-        await expect(workerInput).toHaveValue("");
-        // eslint-disable-next-line playwright/no-wait-for-timeout
-        await clusters.page.waitForTimeout(300);
-
-        // Add second IP and wait for it to appear in list
-        await workerInput.fill("10.0.0.2");
-        await clusters.page
-          .getByRole("button", { name: "Add", exact: true })
-          .click();
-        await expect(clusters.page.getByText("10.0.0.2")).toBeVisible();
-        await expect(clusters.page.getByText("2 nodes")).toBeVisible();
-
-        // Remove first IP — retry evaluate click until badge updates
-        await expect(async () => {
-          await clusters.page.evaluate(() => {
-            const btn = document.querySelector(
-              '[data-testid="remove-worker-ip"]',
-            );
-            if (btn) (btn as HTMLButtonElement).click();
-          });
-          await expect(clusters.page.getByText("1 nodes")).toBeVisible({
-            timeout: 2000,
-          });
-        }).toPass({ timeout: 10000 });
-      },
-    );
-
-    test(
-      "SSH: auth fields visible",
-      { tag: "@C2612801" },
-      async ({ clusters }) => {
         await clusters.goToCreate();
 
-        await expect(
-          clusters.form.field("spec.config.ssh_config.auth.ssh_user"),
-        ).toBeVisible();
-        await expect(
-          clusters.form.field("spec.config.ssh_config.auth.ssh_private_key"),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "SSH: model cache section visible",
-      { tag: "@C2612804" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Model Caches section title and Add button
-        await expect(
-          clusters.page.getByRole("button", { name: /add model cache/i }),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "SSH: model cache only has Host Path option",
-      { tag: "@C2612805" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Add a cache item
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
-
-        // The cache type select shows "Host Path" by default — click to open it
-        // Navigate from "Cache Type" text to its sibling combobox
-        const cacheTypeCombobox = clusters.page
-          .locator('[data-testid="cache-type-select"]')
-          .locator('button[role="combobox"]');
-        await cacheTypeCombobox.click();
-
-        // Only Host Path should be available
-        await expect(
-          clusters.page.getByRole("option", { name: /host path/i }),
-        ).toBeVisible();
-
-        // Should have exactly 1 option
-        const options = clusters.page.getByRole("option");
-        await expect(options).toHaveCount(1);
-      },
-    );
-
-    test(
-      "K8s: kubeconfig field visible",
-      { tag: "@C2612765" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Switch to Kubernetes type
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        await expect(
-          clusters.form.field("spec.config.kubernetes_config.kubeconfig"),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "K8s: router fields visible",
-      { tag: "@C2623069" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Switch to Kubernetes type
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        await expect(
-          clusters.form.field(
-            "spec.config.kubernetes_config.router.access_mode",
-          ),
-        ).toBeVisible();
-        await expect(
-          clusters.form.field("spec.config.kubernetes_config.router.replicas"),
-        ).toBeVisible();
-        await expect(
-          clusters.form.field(
-            "spec.config.kubernetes_config.router.resources.cpu",
-          ),
-        ).toBeVisible();
-        await expect(
-          clusters.form.field(
-            "spec.config.kubernetes_config.router.resources.memory",
-          ),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "K8s: default router replicas = 2",
-      { tag: "@C2623070" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        const replicasInput = clusters.form
-          .field("spec.config.kubernetes_config.router.replicas")
-          .locator("input");
-        await expect(replicasInput).toHaveValue("2");
-      },
-    );
-
-    test(
-      "K8s: default router CPU = 1",
-      { tag: "@C2623071" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        const cpuInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.cpu")
-          .locator("input");
-        await expect(cpuInput).toHaveValue("1");
-      },
-    );
-
-    test(
-      "K8s: default router memory = 1Gi",
-      { tag: "@C2623072" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        const memoryInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.memory")
-          .locator("input");
-        await expect(memoryInput).toHaveValue("1Gi");
-      },
-    );
-
-    test(
-      "K8s: access mode default LoadBalancer, can change to NodePort",
-      { tag: "@C2623073" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        const accessModeButton = clusters.form
-          .field("spec.config.kubernetes_config.router.access_mode")
-          .locator('button[role="combobox"]');
-
-        // Default should show "LoadBalancer"
-        await expect(accessModeButton).toHaveText(/LoadBalancer/);
-
-        // Change to NodePort
-        await accessModeButton.click();
-        await clusters.page.getByRole("option", { name: "NodePort" }).click();
-
-        await expect(accessModeButton).toHaveText(/NodePort/);
-      },
-    );
-
-    test(
-      "K8s: no default model cache, add via button",
-      { tag: "@C2612777" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        // No cache items initially — empty state message shown
-        await expect(clusters.page.getByText("No model caches")).toBeVisible();
-
-        // Click "Add Model Cache" → cache form appears
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
-
-        // Cache card should appear (title starts with #1)
-        await expect(clusters.page.getByText("#1 -")).toBeVisible();
-
-        // Empty state message should be gone
-        await expect(clusters.page.getByText("No model caches")).toBeHidden();
-      },
-    );
-
-    test(
-      "K8s: model cache has Host Path, NFS, PVC options",
-      { tag: "@C2612778" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Switch to Kubernetes type
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        // Add a cache item
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
-
-        // The cache type select shows "Host Path" by default — click to open it
-        const cacheTypeCombobox = clusters.page
-          .locator('[data-testid="cache-type-select"]')
-          .locator('button[role="combobox"]');
-        await cacheTypeCombobox.click();
-
-        await expect(
-          clusters.page.getByRole("option", { name: /host path/i }),
-        ).toBeVisible();
-        await expect(
-          clusters.page.getByRole("option", { name: /nfs/i }),
-        ).toBeVisible();
-        await expect(
-          clusters.page.getByRole("option", { name: /pvc/i }),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "only 1 model cache allowed in UI",
-      { tag: "@C2623045" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Add a cache item
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
-
-        // Cache card appears
-        await expect(clusters.page.getByText("#1 -")).toBeVisible();
-
-        // "Add Model Cache" button should be hidden since limit is 1
-        await expect(
-          clusters.page.getByRole("button", { name: /add model cache/i }),
-        ).toBeHidden();
-      },
-    );
-
-    test(
-      "SSH: host path empty path blocks submit",
-      { tag: "@C2612812" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Add a model cache (default type is Host Path)
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
-
-        // Leave cache path empty and try to submit
-        await clusters.form.submit();
-
-        // Client-side validation prevents submission — form stays visible
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-
-        // Validation error should appear for cache path
-        await expect(
-          clusters.page.getByText(/cache path is required/i),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "K8s: NFS empty server/path blocks submit",
-      { tag: "@C2612813" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        // Add a cache item
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
-
-        // Switch cache type to NFS
-        const cacheTypeCombobox = clusters.page
-          .locator('[data-testid="cache-type-select"]')
-          .locator('button[role="combobox"]');
-        await cacheTypeCombobox.click();
-        await clusters.page.getByRole("option", { name: /^NFS$/i }).click();
-
-        // Leave NFS fields empty and try to submit
-        await clusters.form.submit();
-
-        // Form stays visible — validation prevents submission
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-
-        // Validation errors should appear
-        await expect(
-          clusters.page.getByText(/server address is required/i),
-        ).toBeVisible();
-        await expect(
-          clusters.page.getByText(/cache path is required/i),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "K8s: PVC empty storage class still submittable",
-      { tag: "@C2623046" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        // Add a cache item
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
-
-        // Switch cache type to PVC
-        const cacheTypeCombobox = clusters.page
-          .locator('[data-testid="cache-type-select"]')
-          .locator('button[role="combobox"]');
-        await cacheTypeCombobox.click();
-        await clusters.page.getByRole("option", { name: /^PVC$/i }).click();
-
-        // Storage field has a default value (500Gi), storageClassName is optional
-        // Verify storageClassName has no required indicator — no error when empty
-        await clusters.form.submit();
-
-        // No "storageClassName is required" error should appear
-        await expect(
-          clusters.page.getByText(/storage class.*required/i),
-        ).toBeHidden();
-      },
-    );
-
-    test(
-      "K8s: PVC default AccessMode = ReadWriteMany",
-      { tag: "@C2623078" },
-      async ({ clusters, apiHelper }) => {
-        await clusters.goToCreate();
-
-        const name = `test-cl-pvc-am-${Date.now()}`;
         await clusters.form.fillInput("metadata.name", name);
         await clusters.form.selectComboboxOption(
           "spec.image_registry",
@@ -589,24 +859,12 @@ test.describe("clusters - create", () => {
           "spec.config.kubernetes_config.kubeconfig",
           "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
         );
+        await expect(
+          clusters.form
+            .field("spec.version")
+            .locator('button[role="combobox"]'),
+        ).toHaveText("v1.0.1");
 
-        // Add a model cache and switch to PVC type
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
-
-        const cacheNameInput = clusters.form
-          .field("spec.config.model_caches.0.name")
-          .locator("input");
-        await cacheNameInput.fill("test-pvc-cache");
-
-        const cacheTypeCombobox = clusters.page
-          .locator('[data-testid="cache-type-select"]')
-          .locator('button[role="combobox"]');
-        await cacheTypeCombobox.click();
-        await clusters.page.getByRole("option", { name: /^PVC$/i }).click();
-
-        // Intercept the POST request to verify accessModes in payload
         const requestPromise = clusters.page.waitForRequest(
           (r) => r.url().includes("/clusters") && r.method() === "POST",
         );
@@ -614,843 +872,611 @@ test.describe("clusters - create", () => {
         const request = await requestPromise;
         const body = JSON.parse(request.postData() || "{}");
 
-        // Verify PVC accessModes defaults to ReadWriteMany
-        const modelCaches = body.spec?.config?.model_caches;
-        expect(modelCaches).toBeDefined();
-        expect(modelCaches[0]?.pvc?.accessModes).toEqual(["ReadWriteMany"]);
-
-        // Cleanup in case the cluster was actually created
+        expect(body.spec?.version).toBe("v1.0.1");
+        expect(body.spec?.config?.kubernetes_config?.router).not.toHaveProperty(
+          "version",
+        );
+        expect(body.spec?.config?.kubernetes_config?.router).toMatchObject({
+          access_mode: "LoadBalancer",
+          replicas: 2,
+          resources: { cpu: "1", memory: "1Gi" },
+        });
+      } finally {
         await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-      },
-    );
+      }
+    });
 
-    test.skip(
-      "cancel does not create resource",
-      { tag: "@miss" },
-      async ({ clusters }) => {
-        const name = `test-cl-cancel-${Date.now()}`;
-
-        await clusters.goToCreate();
-
-        await clusters.form.fillInput("metadata.name", name);
-
-        // Accept browser dialog if warnWhenUnsavedChanges fires
-        clusters.page.on("dialog", (dialog) => dialog.accept());
-        await clusters.form.cancel();
-
-        // Navigate to list and verify no row was created
-        await clusters.goToList();
-        await clusters.table.expectNoRowWithText(name);
-      },
-    );
-
-    // ── Group 1: Create Form Validation ──
-
-    test(
-      "create: empty name → submit fails",
-      { tag: "@C2612670" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Select image registry so that's not the failure reason
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-
-        // Fill head IP to pass provider validation
-        await clusters.page
-          .getByPlaceholder("e.g 192.168.1.1")
-          .fill("192.168.1.1");
-
-        // Leave name empty → submit and wait for any API response
-        const responsePromise = clusters.page.waitForResponse((r) =>
-          r.url().includes("/clusters"),
-        );
-        await clusters.form.submit();
-        const response = await responsePromise;
-
-        // Server should reject empty name
-        expect(response.ok()).toBe(false);
-
-        // Form stays visible
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "create: no image registry → submit fails",
-      { tag: "@C2612674" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Fill name but don't select image registry
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-cl-noimr-${Date.now()}`,
-        );
-
-        // Fill head IP to pass provider validation
-        await clusters.page
-          .getByPlaceholder("e.g 192.168.1.1")
-          .fill("192.168.1.1");
-
-        // Submit and wait for any API response
-        const responsePromise = clusters.page.waitForResponse((r) =>
-          r.url().includes("/clusters"),
-        );
-        await clusters.form.submit();
-        const response = await responsePromise;
-
-        // Server should reject missing image registry
-        expect(response.ok()).toBe(false);
-
-        // Form stays visible
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
-
-    test(
-      "create: image registry search and select",
-      { tag: "@C2612676" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Open the image registry combobox
-        const irField = clusters.form.field("spec.image_registry");
-        await irField.locator("button").click();
-
-        // Type partial name to search
-        const dialog = clusters.page.locator(
-          '[data-state="open"][role="dialog"]',
-        );
-        const searchInput = dialog.getByRole("combobox");
-        await searchInput.fill(irName.value.slice(0, 10));
-
-        // Verify the option appears in filtered results and select it
-        await expect(
-          dialog.getByRole("option", { name: irName.value, exact: true }),
-        ).toBeVisible();
-        await dialog
-          .getByRole("option", { name: irName.value, exact: true })
-          .click();
-
-        // Verify the trigger now shows the selected value
-        await expect(irField.locator("button")).toHaveText(
-          new RegExp(irName.value),
-        );
-      },
-    );
-
-    test(
-      "create: image registry filtered by workspace",
-      { tag: "@C2612680" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Default workspace is "default" — open image registry combobox
-        const irField = clusters.form.field("spec.image_registry");
-        await irField.locator("button").click();
-
-        // The test image registry (created in default workspace) should appear
-        const dialog = clusters.page.locator(
-          '[data-state="open"][role="dialog"]',
-        );
-        await expect(
-          dialog.getByRole("option", { name: irName.value, exact: true }),
-        ).toBeVisible();
-
-        // Close the combobox
-        await clusters.page.keyboard.press("Escape");
-      },
-    );
-
-    test(
-      "SSH: no head IP → submit shows error",
-      { tag: "@C2612792" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-
-        // Fill name and select image registry
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-cl-noip-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-
-        // Don't fill head IP — click submit
-        await clusters.form.submit();
-
-        // Client-side validation shows "IP address is required"
-        await expect(
-          clusters.page.getByText("IP address is required"),
-        ).toBeVisible();
-
-        // Form stays visible (submission blocked)
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
-
-    // ── Group 2: K8s Router Parameter Validation ──
-
-    test(
-      "K8s: router config always has defaults when type selected",
-      { tag: "@C2612766" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        // Router fields should exist with default values
-        await expect(
-          clusters.form.field(
-            "spec.config.kubernetes_config.router.access_mode",
-          ),
-        ).toBeVisible();
-        await expect(
-          clusters.form.field("spec.config.kubernetes_config.router.replicas"),
-        ).toBeVisible();
-        await expect(
-          clusters.form.field(
-            "spec.config.kubernetes_config.router.resources.cpu",
-          ),
-        ).toBeVisible();
-        await expect(
-          clusters.form.field(
-            "spec.config.kubernetes_config.router.resources.memory",
-          ),
-        ).toBeVisible();
-
-        // Verify defaults
-        const replicasInput = clusters.form
-          .field("spec.config.kubernetes_config.router.replicas")
-          .locator("input");
-        await expect(replicasInput).toHaveValue("2");
-
-        const cpuInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.cpu")
-          .locator("input");
-        await expect(cpuInput).toHaveValue("1");
-
-        const memoryInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.memory")
-          .locator("input");
-        await expect(memoryInput).toHaveValue("1Gi");
-      },
-    );
-
-    test(
-      "K8s: access mode default always set",
-      { tag: "@C2612767" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-
-        // Access mode Select always has a default value
-        const accessModeButton = clusters.form
-          .field("spec.config.kubernetes_config.router.access_mode")
-          .locator('button[role="combobox"]');
-        await expect(accessModeButton).toHaveText(/LoadBalancer/);
-
-        // Open and verify options
-        await accessModeButton.click();
-        await expect(
-          clusters.page.getByRole("option", { name: "LoadBalancer" }),
-        ).toBeVisible();
-        await expect(
-          clusters.page.getByRole("option", { name: "NodePort" }),
-        ).toBeVisible();
-        await clusters.page.keyboard.press("Escape");
-      },
-    );
-
-    test(
-      "K8s: create payload does not include router version",
-      { tag: "@C2728017" },
-      async ({ clusters, apiHelper }) => {
-        const name = `test-k8s-router-ver-${Date.now()}`;
-        try {
-          await clusters.page.route(
-            "**/api/v1/clusters/available_versions?**",
-            async (route) => {
-              await route.fulfill({
-                contentType: "application/json",
-                body: JSON.stringify({ available_versions: ["v1.0.1"] }),
-              });
-            },
-          );
-          await clusters.goToCreate();
-
-          await clusters.form.fillInput("metadata.name", name);
-          await clusters.form.selectComboboxOption(
-            "spec.image_registry",
-            irName.value,
-          );
-          await clusters.form.selectOption("spec.type", "Kubernetes");
-          await clusters.form.fillTextarea(
-            "spec.config.kubernetes_config.kubeconfig",
-            "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-          );
-          await expect(
-            clusters.form
-              .field("spec.version")
-              .locator('button[role="combobox"]'),
-          ).toHaveText("v1.0.1");
-
-          const requestPromise = clusters.page.waitForRequest(
-            (r) => r.url().includes("/clusters") && r.method() === "POST",
-          );
-          await clusters.form.submit();
-          const request = await requestPromise;
-          const body = JSON.parse(request.postData() || "{}");
-
-          expect(body.spec?.version).toBe("v1.0.1");
-          expect(
-            body.spec?.config?.kubernetes_config?.router,
-          ).not.toHaveProperty("version");
-          expect(body.spec?.config?.kubernetes_config?.router).toMatchObject({
-            access_mode: "LoadBalancer",
-            replicas: 2,
-            resources: { cpu: "1", memory: "1Gi" },
+    test("K8s: empty replicas → submit fails", { tag: "@C2612768" }, async ({
+      clusters,
+    }) => {
+      // spec.version is required and auto-populated; mock
+      // available_versions so it resolves and only the field under test
+      // (replicas) is what blocks submission (see PVC AccessMode test).
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
           });
-        } finally {
-          await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-        }
-      },
-    );
+        },
+      );
 
-    test(
-      "K8s: empty replicas → submit fails",
-      { tag: "@C2612768" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+      await clusters.goToCreate();
 
-        // Fill required fields
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-k8s-rep-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-        );
+      // Fill required fields
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-k8s-rep-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
 
-        // Clear replicas
-        const replicasInput = clusters.form
-          .field("spec.config.kubernetes_config.router.replicas")
-          .locator("input");
-        await replicasInput.clear();
+      // Clear replicas
+      const replicasInput = clusters.form
+        .field("spec.config.kubernetes_config.router.replicas")
+        .locator("input");
+      await replicasInput.clear();
 
-        // Submit and expect error
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      // Submit and expect error
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
 
-    test(
-      "K8s: replicas < 1 → submit fails",
-      { tag: "@C2612769" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("K8s: replicas < 1 → submit fails", { tag: "@C2612769" }, async ({
+      clusters,
+    }) => {
+      // See "K8s: empty replicas → submit fails" above.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-k8s-repl0-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-        );
+      await clusters.goToCreate();
 
-        // Set replicas to 0
-        const replicasInput = clusters.form
-          .field("spec.config.kubernetes_config.router.replicas")
-          .locator("input");
-        await replicasInput.clear();
-        await replicasInput.fill("0");
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-k8s-repl0-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      // Set replicas to 0
+      const replicasInput = clusters.form
+        .field("spec.config.kubernetes_config.router.replicas")
+        .locator("input");
+      await replicasInput.clear();
+      await replicasInput.fill("0");
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
 
-    test(
-      "K8s: replicas non-numeric → number field rejects",
-      { tag: "@C2612770" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
-        await clusters.form.selectOption("spec.type", "Kubernetes");
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
 
-        // type="number" input ignores non-numeric input — fill "abc" results in empty value
-        const replicasInput = clusters.form
-          .field("spec.config.kubernetes_config.router.replicas")
-          .locator("input");
+    test("K8s: replicas non-numeric → number field rejects", {
+      tag: "@C2612770",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
+      await clusters.form.selectOption("spec.type", "Kubernetes");
 
-        // Clear and try to type text — value should be empty or unchanged
-        await replicasInput.clear();
-        await replicasInput.pressSequentially("abc");
+      // type="number" input ignores non-numeric input — fill "abc" results in empty value
+      const replicasInput = clusters.form
+        .field("spec.config.kubernetes_config.router.replicas")
+        .locator("input");
 
-        // Number input doesn't accept non-numeric characters
-        await expect(replicasInput).toHaveValue("");
-      },
-    );
+      // Clear and try to type text — value should be empty or unchanged
+      await replicasInput.clear();
+      await replicasInput.pressSequentially("abc");
 
-    test(
-      "K8s: empty CPU and memory → submit fails",
-      { tag: "@C2612771" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+      // Number input doesn't accept non-numeric characters
+      await expect(replicasInput).toHaveValue("");
+    });
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-k8s-res-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-        );
+    test("K8s: empty CPU and memory → submit fails", {
+      tag: "@C2612771",
+    }, async ({ clusters }) => {
+      // See "K8s: empty replicas → submit fails" above.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-        // Clear both CPU and Memory
-        const cpuInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.cpu")
-          .locator("input");
-        await cpuInput.clear();
+      await clusters.goToCreate();
 
-        const memoryInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.memory")
-          .locator("input");
-        await memoryInput.clear();
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-k8s-res-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      // Clear both CPU and Memory
+      const cpuInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.cpu")
+        .locator("input");
+      await cpuInput.clear();
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      const memoryInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.memory")
+        .locator("input");
+      await memoryInput.clear();
 
-    test(
-      "K8s: empty CPU → submit fails",
-      { tag: "@C2612772" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-k8s-cpu-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-        );
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
 
-        // Clear CPU only
-        const cpuInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.cpu")
-          .locator("input");
-        await cpuInput.clear();
+    test("K8s: empty CPU → submit fails", { tag: "@C2612772" }, async ({
+      clusters,
+    }) => {
+      // See "K8s: empty replicas → submit fails" above.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      await clusters.goToCreate();
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-k8s-cpu-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
 
-    test(
-      "K8s: empty memory → submit fails",
-      { tag: "@C2612773" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+      // Clear CPU only
+      const cpuInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.cpu")
+        .locator("input");
+      await cpuInput.clear();
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-k8s-mem-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-        );
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
 
-        // Clear Memory only
-        const memoryInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.memory")
-          .locator("input");
-        await memoryInput.clear();
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+    test("K8s: empty memory → submit fails", { tag: "@C2612773" }, async ({
+      clusters,
+    }) => {
+      // See "K8s: empty replicas → submit fails" above.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      await clusters.goToCreate();
 
-    test(
-      "K8s: invalid memory format → submit fails",
-      { tag: "@C2612774" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-k8s-mem-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-k8s-memfmt-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-        );
+      // Clear Memory only
+      const memoryInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.memory")
+        .locator("input");
+      await memoryInput.clear();
 
-        // Set invalid memory format
-        const memoryInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.memory")
-          .locator("input");
-        await memoryInput.clear();
-        await memoryInput.fill("abc");
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+    test("K8s: invalid memory format → submit fails", {
+      tag: "@C2612774",
+    }, async ({ clusters }) => {
+      // See "K8s: empty replicas → submit fails" above.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-    test(
-      "K8s: invalid CPU format → submit fails",
-      { tag: "@C2612775" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+      await clusters.goToCreate();
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-k8s-cpufmt-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-        );
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-k8s-memfmt-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
 
-        // Set invalid CPU format
-        const cpuInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.cpu")
-          .locator("input");
-        await cpuInput.clear();
-        await cpuInput.fill("abc");
+      // Set invalid memory format
+      const memoryInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.memory")
+        .locator("input");
+      await memoryInput.clear();
+      await memoryInput.fill("abc");
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
+
+    test("K8s: invalid CPU format → submit fails", {
+      tag: "@C2612775",
+    }, async ({ clusters }) => {
+      // See "K8s: empty replicas → submit fails" above.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
+
+      await clusters.goToCreate();
+
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-k8s-cpufmt-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
+
+      // Set invalid CPU format
+      const cpuInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.cpu")
+        .locator("input");
+      await cpuInput.clear();
+      await cpuInput.fill("abc");
+
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
+
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
 
     // ── Group 3: Cache Name Validation ──
 
-    test(
-      "cache: empty name → submit fails",
-      { tag: "@C2612809" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("cache: empty name → submit fails", { tag: "@C2612809" }, async ({
+      clusters,
+    }) => {
+      // spec.version is a required field, auto-populated once
+      // workspace+registry+type are set (type defaults to "ssh" — see
+      // use-cluster-form.tsx's versionsQueryEnabled). Mock available_versions
+      // so it resolves deterministically and the only invalid field left is
+      // the cache name under test (see the K8s resource tests above for the
+      // same rationale).
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-cl-cn-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
+      await clusters.goToCreate();
 
-        // Fill head IP to pass provider validation
-        await clusters.page
-          .getByPlaceholder("e.g 192.168.1.1")
-          .fill("192.168.1.1");
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-cl-cn-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
 
-        // Add a model cache — leave name empty
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
+      // Fill head IP to pass provider validation
+      await clusters.page
+        .getByPlaceholder("e.g 192.168.1.1")
+        .fill("192.168.1.1");
 
-        // Fill cache path to pass path validation
-        const cachePathInput = clusters.form
-          .field("spec.config.model_caches.0.host_path.path")
-          .locator("input");
-        await cachePathInput.fill("/data/cache");
+      // Add a model cache — leave name empty
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
 
-        // Submit — server should reject empty cache name
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      // Fill cache path to pass path validation
+      const cachePathInput = clusters.form
+        .field("spec.config.model_caches.0.host_path.path")
+        .locator("input");
+      await cachePathInput.fill("/data/cache");
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      // Submit — server should reject empty cache name
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
 
-    test(
-      "cache: invalid RFC 1123 name → submit fails",
-      { tag: "@C2612810" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-cl-cn2-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
+    test("cache: invalid RFC 1123 name → submit fails", {
+      tag: "@C2612810",
+    }, async ({ clusters }) => {
+      // See "cache: empty name → submit fails" above.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-        await clusters.page
-          .getByPlaceholder("e.g 192.168.1.1")
-          .fill("192.168.1.1");
+      await clusters.goToCreate();
 
-        // Add a model cache with invalid name (uppercase, special chars)
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-cl-cn2-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
 
-        const cacheNameInput = clusters.form
-          .field("spec.config.model_caches.0.name")
-          .locator("input");
-        await cacheNameInput.fill("Invalid_Name!");
+      await clusters.page
+        .getByPlaceholder("e.g 192.168.1.1")
+        .fill("192.168.1.1");
 
-        const cachePathInput = clusters.form
-          .field("spec.config.model_caches.0.host_path.path")
-          .locator("input");
-        await cachePathInput.fill("/data/cache");
+      // Add a model cache with invalid name (uppercase, special chars)
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      const cacheNameInput = clusters.form
+        .field("spec.config.model_caches.0.name")
+        .locator("input");
+      await cacheNameInput.fill("Invalid_Name!");
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      const cachePathInput = clusters.form
+        .field("spec.config.model_caches.0.host_path.path")
+        .locator("input");
+      await cachePathInput.fill("/data/cache");
+
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
+
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
 
     // ── Group 4: Workspace & Image Registry Dropdown ──
 
-    test(
-      "workspace defaults to empty when global filter is All workspaces",
-      { tag: "@C2612671" },
-      async ({ clusters }) => {
-        // Navigate with _all_ workspace filter (simulates "All workspaces")
-        await clusters.page.goto("/#/_all_/clusters/create");
-        await clusters.page
-          .locator('[data-testid="form"]')
-          .waitFor({ state: "visible" });
+    test("workspace defaults to empty when global filter is All workspaces", {
+      tag: "@C2612671",
+    }, async ({ clusters }) => {
+      // Navigate with _all_ workspace filter (simulates "All workspaces")
+      await clusters.page.goto("/#/_all_/clusters/create");
+      await clusters.page
+        .locator('[data-testid="form"]')
+        .waitFor({ state: "visible" });
 
-        const wsButton = clusters.form
-          .field("metadata.workspace")
-          .locator('button[role="combobox"]');
+      const wsButton = clusters.form
+        .field("metadata.workspace")
+        .locator('button[role="combobox"]');
 
-        // When _all_ is set, Combobox can't find matching option → no "default"
-        await expect(wsButton).not.toHaveText(/default/);
-      },
-    );
+      // When _all_ is set, Combobox can't find matching option → no "default"
+      await expect(wsButton).not.toHaveText(/default/);
+    });
 
-    test(
-      "workspace auto-fills from global workspace filter",
-      { tag: "@C2612683" },
-      async ({ clusters }) => {
-        // goToCreate() navigates to /default/clusters/create
-        await clusters.goToCreate();
+    test("workspace auto-fills from global workspace filter", {
+      tag: "@C2612683",
+    }, async ({ clusters }) => {
+      // goToCreate() navigates to /default/clusters/create
+      await clusters.goToCreate();
 
-        const wsButton = clusters.form
-          .field("metadata.workspace")
-          .locator('button[role="combobox"]');
+      const wsButton = clusters.form
+        .field("metadata.workspace")
+        .locator('button[role="combobox"]');
 
-        await expect(wsButton).toHaveText(/default/);
-      },
-    );
+      await expect(wsButton).toHaveText(/default/);
+    });
 
-    test(
-      "workspace search with no results preserves default value",
-      { tag: "@C2612673" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("workspace search with no results preserves default value", {
+      tag: "@C2612673",
+    }, async ({ clusters }) => {
+      await clusters.goToCreate();
 
-        // Open workspace combobox
-        const wsField = clusters.form.field("metadata.workspace");
-        await wsField.locator("button").click();
+      // Open workspace combobox
+      const wsField = clusters.form.field("metadata.workspace");
+      await wsField.locator("button").click();
 
-        // Type a non-existent workspace name in the search input
-        const dialog = clusters.page.locator(
-          '[data-state="open"][role="dialog"]',
-        );
-        const searchInput = dialog.getByRole("combobox");
-        await searchInput.fill("nonexistent-ws-xyz");
+      // Type a non-existent workspace name in the search input
+      const dialog = clusters.page.locator(
+        '[data-state="open"][role="dialog"]',
+      );
+      const searchInput = dialog.getByRole("combobox");
+      await searchInput.fill("nonexistent-ws-xyz");
 
-        // No options should appear
-        await expect(dialog.getByRole("option")).toHaveCount(0);
+      // No options should appear
+      await expect(dialog.getByRole("option")).toHaveCount(0);
 
-        // Close dropdown
-        await clusters.page.keyboard.press("Escape");
+      // Close dropdown
+      await clusters.page.keyboard.press("Escape");
 
-        // Verify workspace button still shows "default"
-        const wsButton = wsField.locator('button[role="combobox"]');
-        await expect(wsButton).toHaveText(/default/);
-      },
-    );
+      // Verify workspace button still shows "default"
+      const wsButton = wsField.locator('button[role="combobox"]');
+      await expect(wsButton).toHaveText(/default/);
+    });
 
-    test(
-      "image registry dropdown is empty for workspace with no registries",
-      { tag: "@C2612675" },
-      async ({ clusters }) => {
-        // Navigate to a non-existent workspace → no image registries
-        await clusters.page.goto("/#/no-ir-ws/clusters/create");
-        await clusters.page
-          .locator('[data-testid="form"]')
-          .waitFor({ state: "visible" });
+    test("image registry dropdown is empty for workspace with no registries", {
+      tag: "@C2612675",
+    }, async ({ clusters }) => {
+      // Navigate to a non-existent workspace → no image registries
+      await clusters.page.goto("/#/no-ir-ws/clusters/create");
+      await clusters.page
+        .locator('[data-testid="form"]')
+        .waitFor({ state: "visible" });
 
-        // Open image registry combobox
-        const irField = clusters.form.field("spec.image_registry");
-        await irField.locator("button").click();
+      // Open image registry combobox
+      const irField = clusters.form.field("spec.image_registry");
+      await irField.locator("button").click();
 
-        // Wait for popover dialog
-        const dialog = clusters.page.locator(
-          '[data-state="open"][role="dialog"]',
-        );
-        await dialog.waitFor({ state: "visible" });
+      // Wait for popover dialog
+      const dialog = clusters.page.locator(
+        '[data-state="open"][role="dialog"]',
+      );
+      await dialog.waitFor({ state: "visible" });
 
-        // No options should appear
-        await expect(dialog.getByRole("option")).toHaveCount(0);
-      },
-    );
+      // No options should appear
+      await expect(dialog.getByRole("option")).toHaveCount(0);
+    });
 
-    test(
-      "cache: reserved name 'default' → submit fails",
-      { tag: "@C2612811" },
-      async ({ clusters }) => {
-        await clusters.goToCreate();
+    test("cache: reserved name 'default' → submit fails", {
+      tag: "@C2612811",
+    }, async ({ clusters }) => {
+      // See "cache: empty name → submit fails" above.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-        await clusters.form.fillInput(
-          "metadata.name",
-          `test-cl-cn3-${Date.now()}`,
-        );
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
+      await clusters.goToCreate();
 
-        await clusters.page
-          .getByPlaceholder("e.g 192.168.1.1")
-          .fill("192.168.1.1");
+      await clusters.form.fillInput(
+        "metadata.name",
+        `test-cl-cn3-${Date.now()}`,
+      );
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
 
-        // Add a model cache with reserved name "default"
-        await clusters.page
-          .getByRole("button", { name: /add model cache/i })
-          .click();
+      await clusters.page
+        .getByPlaceholder("e.g 192.168.1.1")
+        .fill("192.168.1.1");
 
-        const cacheNameInput = clusters.form
-          .field("spec.config.model_caches.0.name")
-          .locator("input");
-        await cacheNameInput.fill("default");
+      // Add a model cache with reserved name "default"
+      await clusters.page
+        .getByRole("button", { name: /add model cache/i })
+        .click();
 
-        const cachePathInput = clusters.form
-          .field("spec.config.model_caches.0.host_path.path")
-          .locator("input");
-        await cachePathInput.fill("/data/cache");
+      const cacheNameInput = clusters.form
+        .field("spec.config.model_caches.0.name")
+        .locator("input");
+      await cacheNameInput.fill("default");
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) => r.url().includes("/clusters") && !r.ok(),
-        );
-        await clusters.form.submit();
-        await responsePromise;
+      const cachePathInput = clusters.form
+        .field("spec.config.model_caches.0.host_path.path")
+        .locator("input");
+      await cachePathInput.fill("/data/cache");
 
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-      },
-    );
+      const responsePromise = clusters.page.waitForResponse(
+        (r) => r.url().includes("/clusters") && !r.ok(),
+      );
+      await clusters.form.submit();
+      await responsePromise;
+
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+    });
   });
 
   // ────────────────────────────────────────────────────────────
@@ -1465,49 +1491,47 @@ test.describe("clusters - create", () => {
       "Requires real K8s cluster (set E2E_PROFILE with k8s kubeconfig)",
     );
 
-    test(
-      "K8s: fill config correctly, save and return to list",
-      { tag: ["@C2612776", "@real-k8s"] },
-      async ({ clusters, apiHelper }) => {
-        const name = `test-cl-k8s-new-${Date.now()}`;
-        await clusters.goToCreate();
+    test("K8s: fill config correctly, save and return to list", {
+      tag: ["@C2612776", "@real-k8s"],
+    }, async ({ clusters, apiHelper }) => {
+      const name = `test-cl-k8s-new-${Date.now()}`;
+      await clusters.goToCreate();
 
-        // Fill name and image registry
-        await clusters.form.fillInput("metadata.name", name);
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
+      // Fill name and image registry
+      await clusters.form.fillInput("metadata.name", name);
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
 
-        // Switch to Kubernetes type
-        await clusters.form.selectOption("spec.type", "Kubernetes");
+      // Switch to Kubernetes type
+      await clusters.form.selectOption("spec.type", "Kubernetes");
 
-        // Fill kubeconfig from profile
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          config.k8sCluster.kubeconfig,
-        );
+      // Fill kubeconfig from profile
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        config.k8sCluster.kubeconfig,
+      );
 
-        // Set access mode from profile
-        const accessModeButton = clusters.form
-          .field("spec.config.kubernetes_config.router.access_mode")
-          .locator('button[role="combobox"]');
-        await accessModeButton.click();
-        await clusters.page
-          .getByRole("option", { name: config.k8sCluster.routerAccessMode })
-          .click();
+      // Set access mode from profile
+      const accessModeButton = clusters.form
+        .field("spec.config.kubernetes_config.router.access_mode")
+        .locator('button[role="combobox"]');
+      await accessModeButton.click();
+      await clusters.page
+        .getByRole("option", { name: config.k8sCluster.routerAccessMode })
+        .click();
 
-        // Submit
-        await clusters.form.submit();
+      // Submit
+      await clusters.form.submit();
 
-        // Should redirect to list and show the new cluster
-        await clusters.table.waitForLoaded();
-        await clusters.table.expectRowWithText(name);
+      // Should redirect to list and show the new cluster
+      await clusters.table.waitForLoaded();
+      await clusters.table.expectRowWithText(name);
 
-        // Cleanup
-        await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-      },
-    );
+      // Cleanup
+      await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+    });
 
     test(
       "K8s: after create success, status becomes Running",

--- a/e2e/tests/clusters-permissions.spec.ts
+++ b/e2e/tests/clusters-permissions.spec.ts
@@ -92,42 +92,57 @@ test.describe("clusters - permissions & delete", () => {
   // Create permissions (multi-user)
   // ────────────────────────────────────────────────────────────
   test.describe("create permissions", () => {
-    test(
-      "admin can create cluster",
-      { tag: "@C2613081" },
-      async ({ clusters, apiHelper }) => {
-        const name = `test-cl-adm-new-${Date.now()}`;
+    test("admin can create cluster", { tag: "@C2613081" }, async ({
+      clusters,
+      apiHelper,
+    }) => {
+      const name = `test-cl-adm-new-${Date.now()}`;
 
-        await clusters.goToCreate();
-        await clusters.form.fillInput("metadata.name", name);
-        await clusters.form.selectComboboxOption(
-          "spec.image_registry",
-          irName.value,
-        );
+      // spec.version is a required field (cluster version upgrade UI,
+      // src/domains/cluster/hooks/use-cluster-form.tsx) auto-populated from
+      // GET /clusters/available_versions. Mock it so submission doesn't
+      // depend on the test image registry actually having published
+      // versions — same technique as clusters-create.spec.ts's
+      // "K8s: create payload does not include router version" test.
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+          });
+        },
+      );
 
-        // Use K8s type (simpler — just kubeconfig)
-        await clusters.form.selectOption("spec.type", "Kubernetes");
-        await clusters.form.fillTextarea(
-          "spec.config.kubernetes_config.kubeconfig",
-          "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
-        );
+      await clusters.goToCreate();
+      await clusters.form.fillInput("metadata.name", name);
+      await clusters.form.selectComboboxOption(
+        "spec.image_registry",
+        irName.value,
+      );
 
-        const responsePromise = clusters.page.waitForResponse(
-          (r) =>
-            r.url().includes("/clusters") &&
-            r.request().method() === "POST" &&
-            (r.ok() || r.status() >= 400),
-        );
-        await clusters.form.submit();
-        const response = await responsePromise;
+      // Use K8s type (simpler — just kubeconfig)
+      await clusters.form.selectOption("spec.type", "Kubernetes");
+      await clusters.form.fillTextarea(
+        "spec.config.kubernetes_config.kubeconfig",
+        "apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []",
+      );
 
-        // Admin should be able to create successfully
-        expect(response.ok()).toBe(true);
+      const responsePromise = clusters.page.waitForResponse(
+        (r) =>
+          r.url().includes("/clusters") &&
+          r.request().method() === "POST" &&
+          (r.ok() || r.status() >= 400),
+      );
+      await clusters.form.submit();
+      const response = await responsePromise;
 
-        // Cleanup
-        await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-      },
-    );
+      // Admin should be able to create successfully
+      expect(response.ok()).toBe(true);
+
+      // Cleanup
+      await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+    });
 
     test(
       "non-admin with global cluster:create can create",
@@ -152,6 +167,19 @@ test.describe("clusters - permissions & delete", () => {
         });
 
         const name = `test-cl-glb-new-${Date.now()}`;
+
+        // See "admin can create cluster" above — mock available_versions so
+        // the required spec.version field resolves deterministically.
+        await testUser.page.route(
+          "**/api/v1/clusters/available_versions?**",
+          async (route) => {
+            await route.fulfill({
+              contentType: "application/json",
+              body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+            });
+          },
+        );
+
         await clPage.goToCreate();
         await clPage.form.fillInput("metadata.name", name);
         await clPage.form.selectComboboxOption(
@@ -203,6 +231,20 @@ test.describe("clusters - permissions & delete", () => {
         });
 
         const name = `test-cl-no-new-${Date.now()}`;
+
+        // See "admin can create cluster" above — mock available_versions so
+        // the required spec.version field resolves deterministically and the
+        // POST actually fires (letting the server reject it for permissions).
+        await testUser.page.route(
+          "**/api/v1/clusters/available_versions?**",
+          async (route) => {
+            await route.fulfill({
+              contentType: "application/json",
+              body: JSON.stringify({ available_versions: ["v1.0.1"] }),
+            });
+          },
+        );
+
         await clPage.goToCreate();
         await clPage.form.fillInput("metadata.name", name);
         await clPage.form.selectComboboxOption(
@@ -237,38 +279,46 @@ test.describe("clusters - permissions & delete", () => {
   // Edit permissions (multi-user)
   // ────────────────────────────────────────────────────────────
   test.describe("edit permissions", () => {
-    test(
-      "admin can edit cluster",
-      { tag: "@C2613087" },
-      async ({ clusters, apiHelper }) => {
-        const name = `test-cl-adm-upd-${Date.now()}`;
-        await apiHelper.createCluster(name, {
-          type: "kubernetes",
-          imageRegistry: irName.value,
-        });
+    test("admin can edit cluster", { tag: "@C2613087" }, async ({
+      clusters,
+      apiHelper,
+    }) => {
+      const name = `test-cl-adm-upd-${Date.now()}`;
+      // spec.version is a required field on the edit form too (disabled,
+      // pre-populated from the fetched record — use-cluster-form.tsx skips
+      // auto-select in edit mode). Pass it explicitly at creation instead
+      // of relying on the controller's async default-version backfill
+      // (obj.Spec.Version == "" -> defaultClusterVersion in
+      // cluster_controller.go): that reconcile may not run promptly (or at
+      // all) against this test registry, which left the edit form's
+      // required field empty/invalid and blocked submission entirely.
+      await apiHelper.createCluster(name, {
+        type: "kubernetes",
+        imageRegistry: irName.value,
+        version: "v1.0.0",
+      });
 
-        await clusters.goToEdit(name);
-        await expect(
-          clusters.page.locator('[data-testid="form-submit"]'),
-        ).toBeEnabled();
+      await clusters.goToEdit(name);
+      await expect(
+        clusters.page.locator('[data-testid="form-submit"]'),
+      ).toBeEnabled();
 
-        // Change replicas to verify edit works
-        const replicasInput = clusters.form
-          .field("spec.config.kubernetes_config.router.replicas")
-          .locator("input");
-        await replicasInput.clear();
-        await replicasInput.fill("3");
+      // Change replicas to verify edit works
+      const replicasInput = clusters.form
+        .field("spec.config.kubernetes_config.router.replicas")
+        .locator("input");
+      await replicasInput.clear();
+      await replicasInput.fill("3");
 
-        await clusters.form.submit();
+      await clusters.form.submit();
 
-        // Should redirect to list
-        await clusters.table.waitForLoaded();
-        await clusters.table.expectRowWithText(name);
+      // Should redirect to list
+      await clusters.table.waitForLoaded();
+      await clusters.table.expectRowWithText(name);
 
-        // Cleanup
-        await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-      },
-    );
+      // Cleanup
+      await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+    });
 
     test(
       "non-admin with global cluster:update can edit",
@@ -283,9 +333,13 @@ test.describe("clusters - permissions & delete", () => {
         testInfo.setTimeout(MULTI_USER_TIMEOUT);
 
         const name = `test-cl-glb-upd-${Date.now()}`;
+        // See "admin can edit cluster" above — pass spec.version explicitly
+        // rather than depending on the controller's async default-version
+        // backfill.
         await apiHelper.createCluster(name, {
           type: "kubernetes",
           imageRegistry: irName.value,
+          version: "v1.0.0",
         });
 
         const testUser = await createTestUser([
@@ -332,9 +386,14 @@ test.describe("clusters - permissions & delete", () => {
         testInfo.setTimeout(MULTI_USER_TIMEOUT);
 
         const name = `test-cl-no-upd-${Date.now()}`;
+        // See "admin can edit cluster" above — pass spec.version explicitly
+        // so the required field is valid and the submit actually reaches the
+        // server (where it should be rejected for lack of cluster:update),
+        // rather than being blocked client-side by an empty required field.
         await apiHelper.createCluster(name, {
           type: "kubernetes",
           imageRegistry: irName.value,
+          version: "v1.0.0",
         });
 
         const testUser = await createTestUser(["cluster:read"]);
@@ -371,108 +430,103 @@ test.describe("clusters - permissions & delete", () => {
   // Delete tests
   // ────────────────────────────────────────────────────────────
   test.describe("delete", () => {
-    test(
-      "delete from list -> confirm -> dialog closes",
-      { tag: "@C2613098" },
-      async ({ clusters, apiHelper }) => {
-        const name = `test-cl-del-${Date.now()}`;
-        await apiHelper.createCluster(name, {
-          imageRegistry: irName.value,
-        });
+    test("delete from list -> confirm -> dialog closes", {
+      tag: "@C2613098",
+    }, async ({ clusters, apiHelper }) => {
+      const name = `test-cl-del-${Date.now()}`;
+      await apiHelper.createCluster(name, {
+        imageRegistry: irName.value,
+      });
 
-        await clusters.goToList();
-        await clusters.table.deleteRow(name, { noWait: true });
+      await clusters.goToList();
+      await clusters.table.deleteRow(name, { noWait: true });
 
-        // Cleanup via API in case backend GC is slow
-        await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-      },
-    );
+      // Cleanup via API in case backend GC is slow
+      await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+    });
 
-    test(
-      "delete from detail action menu",
-      { tag: "@C2613099" },
-      async ({ clusters, apiHelper }) => {
-        const name = `test-cl-del-detail-${Date.now()}`;
-        await apiHelper.createCluster(name, {
-          imageRegistry: irName.value,
-        });
+    test("delete from detail action menu", { tag: "@C2613099" }, async ({
+      clusters,
+      apiHelper,
+    }) => {
+      const name = `test-cl-del-detail-${Date.now()}`;
+      await apiHelper.createCluster(name, {
+        imageRegistry: irName.value,
+      });
 
-        await clusters.goToShow(name);
+      await clusters.goToShow(name);
 
-        // Open show page actions, click delete
-        await clusters.page
-          .locator('[data-testid="show-actions-trigger"]')
-          .click();
-        await clusters.page.getByRole("menuitem", { name: /delete/i }).click();
+      // Open show page actions, click delete
+      await clusters.page
+        .locator('[data-testid="show-actions-trigger"]')
+        .click();
+      await clusters.page.getByRole("menuitem", { name: /delete/i }).click();
 
-        // Confirm delete dialog
-        const dialog = clusters.page.getByRole("alertdialog");
-        await dialog.waitFor({ state: "visible" });
-        await dialog.getByRole("button", { name: /delete/i }).click();
-        await dialog.waitFor({ state: "hidden" });
+      // Confirm delete dialog
+      const dialog = clusters.page.getByRole("alertdialog");
+      await dialog.waitFor({ state: "visible" });
+      await dialog.getByRole("button", { name: /delete/i }).click();
+      await dialog.waitFor({ state: "hidden" });
 
-        // Cleanup via API in case backend GC is slow
-        await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-      },
-    );
+      // Cleanup via API in case backend GC is slow
+      await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+    });
 
-    test.skip(
-      "delete -> cancel -> row still exists",
-      { tag: "@miss" },
-      async ({ clusters, apiHelper }) => {
-        const name = `test-cl-del-cancel-${Date.now()}`;
-        await apiHelper.createCluster(name, {
-          imageRegistry: irName.value,
-        });
+    test.skip("delete -> cancel -> row still exists", { tag: "@miss" }, async ({
+      clusters,
+      apiHelper,
+    }) => {
+      const name = `test-cl-del-cancel-${Date.now()}`;
+      await apiHelper.createCluster(name, {
+        imageRegistry: irName.value,
+      });
 
-        await clusters.goToList();
-        await clusters.table.waitForLoaded();
+      await clusters.goToList();
+      await clusters.table.waitForLoaded();
 
-        // Open row actions, click delete
-        await clusters.table
-          .rowWithText(name)
-          .locator('[data-testid="row-actions-trigger"]')
-          .click();
-        await clusters.page
-          .locator('[role="menu"]')
-          .waitFor({ state: "visible" });
-        await clusters.page.getByRole("menuitem", { name: /delete/i }).click();
+      // Open row actions, click delete
+      await clusters.table
+        .rowWithText(name)
+        .locator('[data-testid="row-actions-trigger"]')
+        .click();
+      await clusters.page
+        .locator('[role="menu"]')
+        .waitFor({ state: "visible" });
+      await clusters.page.getByRole("menuitem", { name: /delete/i }).click();
 
-        // Cancel the dialog
-        const dialog = clusters.page.getByRole("alertdialog");
-        await dialog.waitFor({ state: "visible" });
-        await dialog.getByRole("button", { name: /cancel/i }).click();
-        await dialog.waitFor({ state: "hidden" });
+      // Cancel the dialog
+      const dialog = clusters.page.getByRole("alertdialog");
+      await dialog.waitFor({ state: "visible" });
+      await dialog.getByRole("button", { name: /cancel/i }).click();
+      await dialog.waitFor({ state: "hidden" });
 
-        // Row should still be there
-        await clusters.table.expectRowWithText(name);
+      // Row should still be there
+      await clusters.table.expectRowWithText(name);
 
-        // Cleanup
-        await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-      },
-    );
+      // Cleanup
+      await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+    });
   });
 
   // ────────────────────────────────────────────────────────────
   // Delete permissions (multi-user)
   // ────────────────────────────────────────────────────────────
   test.describe("delete permissions", () => {
-    test(
-      "admin can delete cluster",
-      { tag: "@C2613093" },
-      async ({ clusters, apiHelper }) => {
-        const name = `test-cl-adm-rm-${Date.now()}`;
-        await apiHelper.createCluster(name, {
-          imageRegistry: irName.value,
-        });
+    test("admin can delete cluster", { tag: "@C2613093" }, async ({
+      clusters,
+      apiHelper,
+    }) => {
+      const name = `test-cl-adm-rm-${Date.now()}`;
+      await apiHelper.createCluster(name, {
+        imageRegistry: irName.value,
+      });
 
-        await clusters.goToList();
-        await clusters.table.deleteRow(name, { noWait: true });
+      await clusters.goToList();
+      await clusters.table.deleteRow(name, { noWait: true });
 
-        // Cleanup via API in case backend GC is slow
-        await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
-      },
-    );
+      // Cleanup via API in case backend GC is slow
+      await apiHelper.deleteCluster(name, { force: true }).catch(() => {});
+    });
 
     test(
       "non-admin with global cluster:delete can delete",

--- a/e2e/tests/clusters.spec.ts
+++ b/e2e/tests/clusters.spec.ts
@@ -129,257 +129,231 @@ test.describe("clusters", () => {
   // List tests
   // ────────────────────────────────────────────────────────────
   test.describe("list", () => {
-    test(
-      "list page shows expected columns",
-      { tag: "@C2613064" },
-      async ({ clusters }) => {
-        await clusters.goToList();
+    test("list page shows expected columns", { tag: "@C2613064" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToList();
 
-        const headers = clusters.table.root.locator("thead th");
-        await expect(headers.filter({ hasText: /name/i })).toBeVisible();
-        await expect(headers.filter({ hasText: /workspace/i })).toBeVisible();
-        await expect(headers.filter({ hasText: /status/i })).toBeVisible();
-        await expect(headers.filter({ hasText: /type/i })).toBeVisible();
-        await expect(
-          headers.filter({ hasText: /image registry/i }),
-        ).toBeVisible();
-        await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
-        await expect(headers.filter({ hasText: /created/i })).toBeVisible();
+      const headers = clusters.table.root.locator("thead th");
+      await expect(headers.filter({ hasText: /name/i })).toBeVisible();
+      await expect(headers.filter({ hasText: /workspace/i })).toBeVisible();
+      await expect(headers.filter({ hasText: /status/i })).toBeVisible();
+      await expect(headers.filter({ hasText: /type/i })).toBeVisible();
+      await expect(
+        headers.filter({ hasText: /image registry/i }),
+      ).toBeVisible();
+      await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
+      await expect(headers.filter({ hasText: /created/i })).toBeVisible();
 
-        await clusters.table.expectRowWithText(clNames.ssh);
-      },
-    );
+      await clusters.table.expectRowWithText(clNames.ssh);
+    });
 
     // TODO: shares @C2613068 with "detail > show page displays basic info" — create separate TestRail case
-    test(
-      "clicking name navigates to detail page",
-      { tag: "@C2613068" },
-      async ({ clusters }) => {
-        await clusters.goToList();
-        await clusters.table.clickRowLink(clNames.ssh);
+    test("clicking name navigates to detail page", {
+      tag: "@C2613068",
+    }, async ({ clusters }) => {
+      await clusters.goToList();
+      await clusters.table.clickRowLink(clNames.ssh);
 
-        const showPage = clusters.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
-        await expect(
-          showPage.getByText(clNames.ssh, { exact: true }),
-        ).toBeVisible();
-      },
-    );
+      const showPage = clusters.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
+      await expect(
+        showPage.getByText(clNames.ssh, { exact: true }),
+      ).toBeVisible();
+    });
 
     test("can sort by name", { tag: "@C2612655" }, async ({ clusters }) => {
       await clusters.goToList();
       await clusters.table.sort(/name/i);
     });
 
-    test.skip(
-      "can sort by updated at",
-      { tag: "@miss" },
-      async ({ clusters }) => {
-        await clusters.goToList();
-        await expect(clusters.table.headerCell(/updated/i)).toBeVisible();
-        await clusters.table.sort(/updated/i);
-      },
-    );
+    test.skip("can sort by updated at", { tag: "@miss" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToList();
+      await expect(clusters.table.headerCell(/updated/i)).toBeVisible();
+      await clusters.table.sort(/updated/i);
+    });
 
-    test.skip(
-      "can sort by created at",
-      { tag: "@miss" },
-      async ({ clusters }) => {
-        await clusters.goToList();
-        await expect(clusters.table.headerCell(/created/i)).toBeVisible();
-        await clusters.table.sort(/created/i);
-      },
-    );
+    test.skip("can sort by created at", { tag: "@miss" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToList();
+      await expect(clusters.table.headerCell(/created/i)).toBeVisible();
+      await clusters.table.sort(/created/i);
+    });
 
-    test(
-      "can toggle column visibility",
-      { tag: "@C2612653" },
-      async ({ clusters }) => {
-        await clusters.goToList();
+    test("can toggle column visibility", { tag: "@C2612653" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToList();
 
-        await expect(clusters.table.headerCell(/status/i)).toBeVisible();
-        await clusters.table.toggleColumn(/status/i);
-        await expect(clusters.table.headerCell(/status/i)).toBeHidden();
-        await clusters.table.toggleColumn(/status/i);
-        await expect(clusters.table.headerCell(/status/i)).toBeVisible();
-      },
-    );
+      await expect(clusters.table.headerCell(/status/i)).toBeVisible();
+      await clusters.table.toggleColumn(/status/i);
+      await expect(clusters.table.headerCell(/status/i)).toBeHidden();
+      await clusters.table.toggleColumn(/status/i);
+      await expect(clusters.table.headerCell(/status/i)).toBeVisible();
+    });
 
-    test(
-      "type column shows correct labels",
-      { tag: "@C2612647" },
-      async ({ clusters }) => {
-        await clusters.goToList();
+    test("type column shows correct labels", { tag: "@C2612647" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToList();
 
-        const sshRow = clusters.table.rowWithText(clNames.ssh);
-        await expect(sshRow.getByText("Static Nodes")).toBeVisible();
+      const sshRow = clusters.table.rowWithText(clNames.ssh);
+      await expect(sshRow.getByText("Static Nodes")).toBeVisible();
 
-        const k8sRow = clusters.table.rowWithText(clNames.k8s);
-        await expect(k8sRow.getByText("Kubernetes")).toBeVisible();
-      },
-    );
+      const k8sRow = clusters.table.rowWithText(clNames.k8s);
+      await expect(k8sRow.getByText("Kubernetes")).toBeVisible();
+    });
 
-    test(
-      "clicking image registry navigates to detail page",
-      { tag: "@C2612648" },
-      async ({ clusters }) => {
-        await clusters.goToList();
+    test("clicking image registry navigates to detail page", {
+      tag: "@C2612648",
+    }, async ({ clusters }) => {
+      await clusters.goToList();
 
-        const row = clusters.table.rowWithText(clNames.ssh);
-        await row.getByRole("link", { name: irName.value }).click();
+      const row = clusters.table.rowWithText(clNames.ssh);
+      await row.getByRole("link", { name: irName.value }).click();
 
-        const showPage = clusters.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
-        await expect(
-          showPage.getByText(irName.value, { exact: true }),
-        ).toBeVisible();
-      },
-    );
+      const showPage = clusters.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
+      await expect(
+        showPage.getByText(irName.value, { exact: true }),
+      ).toBeVisible();
+    });
   });
 
   // ────────────────────────────────────────────────────────────
   // Detail tests
   // ────────────────────────────────────────────────────────────
   test.describe("detail", () => {
-    test(
-      "show page displays basic info",
-      { tag: "@C2613068" },
-      async ({ clusters }) => {
-        await clusters.goToShow(clNames.ssh);
+    test("show page displays basic info", { tag: "@C2613068" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToShow(clNames.ssh);
 
-        const showPage = clusters.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
+      const showPage = clusters.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
 
-        // Name
-        await expect(
-          showPage.getByText(clNames.ssh, { exact: true }),
-        ).toBeVisible();
+      // Name
+      await expect(
+        showPage.getByText(clNames.ssh, { exact: true }),
+      ).toBeVisible();
 
-        // Workspace
-        await expect(
-          showPage.locator("dt", { hasText: /workspace/i }),
-        ).toBeVisible();
+      // Workspace
+      await expect(
+        showPage.locator("dt", { hasText: /workspace/i }),
+      ).toBeVisible();
 
-        // Status
-        await expect(
-          showPage.locator("dt", { hasText: /^status$/i }),
-        ).toBeVisible();
+      // Status
+      await expect(
+        showPage.locator("dt", { hasText: /^status$/i }),
+      ).toBeVisible();
 
-        // Timestamps
-        await expect(
-          showPage.getByRole("term").filter({ hasText: /created at/i }),
-        ).toBeVisible();
-        await expect(
-          showPage.getByRole("term").filter({ hasText: /updated at/i }),
-        ).toBeVisible();
+      // Timestamps
+      await expect(
+        showPage.getByRole("term").filter({ hasText: /created at/i }),
+      ).toBeVisible();
+      await expect(
+        showPage.getByRole("term").filter({ hasText: /updated at/i }),
+      ).toBeVisible();
 
-        // Type
-        await expect(
-          showPage.locator("dt", { hasText: /^type$/i }),
-        ).toBeVisible();
-      },
-    );
+      // Type
+      await expect(
+        showPage.locator("dt", { hasText: /^type$/i }),
+      ).toBeVisible();
+    });
 
-    test(
-      "clicking workspace navigates to workspace detail",
-      { tag: "@C2612645" },
-      async ({ clusters }) => {
-        await clusters.goToShow(clNames.ssh);
+    test("clicking workspace navigates to workspace detail", {
+      tag: "@C2612645",
+    }, async ({ clusters }) => {
+      await clusters.goToShow(clNames.ssh);
 
-        const showPage = clusters.page.locator('[data-testid="show-page"]');
-        await showPage.getByRole("link", { name: "default" }).click();
+      const showPage = clusters.page.locator('[data-testid="show-page"]');
+      await showPage.getByRole("link", { name: "default" }).click();
 
-        const wsShowPage = clusters.page.locator('[data-testid="show-page"]');
-        await expect(wsShowPage).toBeVisible();
-        await expect(
-          wsShowPage.getByText("default", { exact: true }),
-        ).toBeVisible();
-      },
-    );
+      const wsShowPage = clusters.page.locator('[data-testid="show-page"]');
+      await expect(wsShowPage).toBeVisible();
+      await expect(
+        wsShowPage.getByText("default", { exact: true }),
+      ).toBeVisible();
+    });
 
-    test(
-      "SSH show page displays head IP and worker IPs",
-      { tag: "@C2613071" },
-      async ({ clusters }) => {
-        await clusters.goToShow(clNames.sshWithCache);
+    test("SSH show page displays head IP and worker IPs", {
+      tag: "@C2613071",
+    }, async ({ clusters }) => {
+      await clusters.goToShow(clNames.sshWithCache);
 
-        const showPage = clusters.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
+      const showPage = clusters.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
 
-        // SSH-specific fields
-        await expect(
-          showPage.locator("dt", { hasText: /head ip/i }),
-        ).toBeVisible();
-        await expect(
-          showPage.locator("dt", { hasText: /worker ips/i }),
-        ).toBeVisible();
+      // SSH-specific fields
+      await expect(
+        showPage.locator("dt", { hasText: /head ip/i }),
+      ).toBeVisible();
+      await expect(
+        showPage.locator("dt", { hasText: /worker ips/i }),
+      ).toBeVisible();
 
-        // Verify head IP value
-        await expect(showPage.getByText("10.0.0.100")).toBeVisible();
-        // Verify worker IPs
-        await expect(showPage.getByText(/10\.0\.0\.101/)).toBeVisible();
-      },
-    );
+      // Verify head IP value
+      await expect(showPage.getByText("10.0.0.100")).toBeVisible();
+      // Verify worker IPs
+      await expect(showPage.getByText(/10\.0\.0\.101/)).toBeVisible();
+    });
 
-    test(
-      "show page displays model cache info",
-      { tag: "@C2613069" },
-      async ({ clusters }) => {
-        await clusters.goToShow(clNames.sshWithCache);
+    test("show page displays model cache info", { tag: "@C2613069" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToShow(clNames.sshWithCache);
 
-        const showPage = clusters.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
+      const showPage = clusters.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
 
-        // Model Cache card should be visible
-        await expect(
-          showPage.getByText("test-cache", { exact: true }),
-        ).toBeVisible();
+      // Model Cache card should be visible
+      await expect(
+        showPage.getByText("test-cache", { exact: true }),
+      ).toBeVisible();
 
-        // Cache type badge should show "Host Path"
-        await expect(showPage.getByText(/host path/i)).toBeVisible();
+      // Cache type badge should show "Host Path"
+      await expect(showPage.getByText(/host path/i)).toBeVisible();
 
-        // Cache path should be visible
-        await expect(showPage.getByText("/data/models")).toBeVisible();
-      },
-    );
+      // Cache path should be visible
+      await expect(showPage.getByText("/data/models")).toBeVisible();
+    });
 
-    test(
-      "show page displays endpoints table",
-      { tag: "@C2613070" },
-      async ({ clusters }) => {
-        await clusters.goToShow(clNames.ssh);
+    test("show page displays endpoints table", { tag: "@C2613070" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToShow(clNames.ssh);
 
-        const showPage = clusters.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
+      const showPage = clusters.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
 
-        // Endpoints section title should be visible (scoped to show page content)
-        await expect(showPage.getByText("Endpoints")).toBeVisible();
+      // Endpoints section title should be visible (scoped to show page content)
+      await expect(showPage.getByText("Endpoints")).toBeVisible();
 
-        // Columns button in the endpoints table should be visible
-        await expect(
-          showPage.getByRole("button", { name: /columns/i }),
-        ).toBeVisible();
-      },
-    );
+      // Columns button in the endpoints table should be visible
+      await expect(
+        showPage.getByRole("button", { name: /columns/i }),
+      ).toBeVisible();
+    });
 
-    test(
-      "K8s show page displays router info",
-      { tag: "@C2613074" },
-      async ({ clusters }) => {
-        await clusters.goToShow(clNames.k8s);
+    test("K8s show page displays router info", { tag: "@C2613074" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToShow(clNames.k8s);
 
-        const showPage = clusters.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
+      const showPage = clusters.page.locator('[data-testid="show-page"]');
+      await expect(showPage).toBeVisible();
 
-        // Router section fields
-        await expect(
-          showPage.locator("dt", { hasText: /access mode/i }),
-        ).toBeVisible();
-        await expect(
-          showPage.locator("dt", { hasText: /replicas/i }),
-        ).toBeVisible();
-      },
-    );
+      // Router section fields
+      await expect(
+        showPage.locator("dt", { hasText: /access mode/i }),
+      ).toBeVisible();
+      await expect(
+        showPage.locator("dt", { hasText: /replicas/i }),
+      ).toBeVisible();
+    });
   });
 
   // ────────────────────────────────────────────────────────────
@@ -387,189 +361,179 @@ test.describe("clusters", () => {
   // ────────────────────────────────────────────────────────────
   test.describe("edit", () => {
     // TODO: shares @C2613080 with "K8s edit: name, workspace, type disabled" — create separate TestRail case
-    test(
-      "SSH edit: name, workspace, type, image registry disabled",
-      { tag: "@C2613080" },
-      async ({ clusters }) => {
-        await clusters.goToEdit(clNames.ssh);
-        await expect(
-          clusters.page.locator('[data-testid="form-submit"]'),
-        ).toBeEnabled();
+    test("SSH edit: name, workspace, type, image registry disabled", {
+      tag: "@C2613080",
+    }, async ({ clusters }) => {
+      await clusters.goToEdit(clNames.ssh);
+      await expect(
+        clusters.page.locator('[data-testid="form-submit"]'),
+      ).toBeEnabled();
 
-        // Name disabled
-        const nameInput = clusters.form.field("metadata.name").locator("input");
-        await expect(nameInput).toBeDisabled();
+      // Name disabled
+      const nameInput = clusters.form.field("metadata.name").locator("input");
+      await expect(nameInput).toBeDisabled();
 
-        // Workspace disabled
-        const wsButton = clusters.form
-          .field("metadata.workspace")
-          .locator('button[role="combobox"]');
-        await expect(wsButton).toBeDisabled();
+      // Workspace disabled
+      const wsButton = clusters.form
+        .field("metadata.workspace")
+        .locator('button[role="combobox"]');
+      await expect(wsButton).toBeDisabled();
 
-        // Type disabled
-        const typeButton = clusters.form
-          .field("spec.type")
-          .locator('button[role="combobox"]');
-        await expect(typeButton).toBeDisabled();
+      // Type disabled
+      const typeButton = clusters.form
+        .field("spec.type")
+        .locator('button[role="combobox"]');
+      await expect(typeButton).toBeDisabled();
 
-        // Image registry disabled
-        const irButton = clusters.form
-          .field("spec.image_registry")
-          .locator("button");
-        await expect(irButton).toBeDisabled();
-      },
-    );
+      // Image registry disabled
+      const irButton = clusters.form
+        .field("spec.image_registry")
+        .locator("button");
+      await expect(irButton).toBeDisabled();
+    });
 
-    test(
-      "SSH edit: provider, auth, and cache fields disabled",
-      { tag: "@C2612829" },
-      async ({ clusters }) => {
-        await clusters.goToEdit(clNames.ssh);
-        await expect(
-          clusters.page.locator('[data-testid="form-submit"]'),
-        ).toBeEnabled();
+    test("SSH edit: head IP + cache disabled; workers/auth stay editable", {
+      tag: "@C2612829",
+    }, async ({ clusters }) => {
+      await clusters.goToEdit(clNames.ssh);
+      await expect(
+        clusters.page.locator('[data-testid="form-submit"]'),
+      ).toBeEnabled();
 
-        // Provider: Head IP input should be disabled
-        await expect(
-          clusters.page.getByPlaceholder("e.g 192.168.1.1"),
-        ).toBeDisabled();
+      // Provider: Head IP input should be disabled
+      await expect(
+        clusters.page.getByPlaceholder("e.g 192.168.1.1"),
+      ).toBeDisabled();
 
-        // Provider: Worker IP "Add" section should be hidden (disabled hides it)
-        await expect(
-          clusters.page.getByRole("button", { name: /add/i }).filter({
-            has: clusters.page.locator("svg"),
-          }),
-        ).toBeHidden();
+      // Provider: Worker IP "Add" section stays visible in edit mode
+      // (NEU-377 #215: only the head IP is locked; worker add/remove stays
+      // functional so static clusters can be resized while editing). The
+      // button itself is disabled until a new worker IP is typed, so we
+      // assert visibility rather than enabled-state here.
+      await expect(
+        clusters.page.getByRole("button", { name: /add/i }).filter({
+          has: clusters.page.locator("svg"),
+        }),
+      ).toBeVisible();
 
-        // Auth: ssh_user disabled
-        const sshUserInput = clusters.form
-          .field("spec.config.ssh_config.auth.ssh_user")
-          .locator("input");
-        await expect(sshUserInput).toBeDisabled();
+      // Auth: ssh_user disabled
+      const sshUserInput = clusters.form
+        .field("spec.config.ssh_config.auth.ssh_user")
+        .locator("input");
+      await expect(sshUserInput).toBeDisabled();
 
-        // Auth: ssh_private_key disabled
-        const sshKeyTextarea = clusters.form
-          .field("spec.config.ssh_config.auth.ssh_private_key")
-          .locator("textarea");
-        await expect(sshKeyTextarea).toBeDisabled();
+      // Auth: ssh_private_key stays editable in edit mode (#276: leave empty
+      // to keep the existing key, or type a new one to replace it).
+      const sshKeyTextarea = clusters.form
+        .field("spec.config.ssh_config.auth.ssh_private_key")
+        .locator("textarea");
+      await expect(sshKeyTextarea).toBeEnabled();
 
-        // Auth: "Leave empty to keep" message
-        await expect(
-          clusters.page.getByText(/leave empty to keep/i).first(),
-        ).toBeVisible();
+      // Auth: "Leave empty to keep" message
+      await expect(
+        clusters.page.getByText(/leave empty to keep/i).first(),
+      ).toBeVisible();
 
-        // Cache: "Add Model Cache" button should not be visible when disabled
-        await expect(
-          clusters.page.getByRole("button", { name: /add model cache/i }),
-        ).toBeHidden();
-      },
-    );
+      // Cache: "Add Model Cache" button should not be visible when disabled
+      await expect(
+        clusters.page.getByRole("button", { name: /add model cache/i }),
+      ).toBeHidden();
+    });
 
-    test(
-      "K8s edit: name, workspace, type disabled; kubeconfig disabled",
-      { tag: "@C2613080" },
-      async ({ clusters }) => {
-        await clusters.goToEdit(clNames.k8s);
-        await expect(
-          clusters.page.locator('[data-testid="form-submit"]'),
-        ).toBeEnabled();
+    test("K8s edit: name, workspace, type disabled; kubeconfig stays editable", {
+      tag: "@C2613080",
+    }, async ({ clusters }) => {
+      await clusters.goToEdit(clNames.k8s);
+      await expect(
+        clusters.page.locator('[data-testid="form-submit"]'),
+      ).toBeEnabled();
 
-        // Name disabled
-        const nameInput = clusters.form.field("metadata.name").locator("input");
-        await expect(nameInput).toBeDisabled();
+      // Name disabled
+      const nameInput = clusters.form.field("metadata.name").locator("input");
+      await expect(nameInput).toBeDisabled();
 
-        // Workspace disabled
-        const wsButton = clusters.form
-          .field("metadata.workspace")
-          .locator('button[role="combobox"]');
-        await expect(wsButton).toBeDisabled();
+      // Workspace disabled
+      const wsButton = clusters.form
+        .field("metadata.workspace")
+        .locator('button[role="combobox"]');
+      await expect(wsButton).toBeDisabled();
 
-        // Type disabled
-        const typeButton = clusters.form
-          .field("spec.type")
-          .locator('button[role="combobox"]');
-        await expect(typeButton).toBeDisabled();
+      // Type disabled
+      const typeButton = clusters.form
+        .field("spec.type")
+        .locator('button[role="combobox"]');
+      await expect(typeButton).toBeDisabled();
 
-        // Kubeconfig disabled
-        const kubeconfigTextarea = clusters.form
-          .field("spec.config.kubernetes_config.kubeconfig")
-          .locator("textarea");
-        await expect(kubeconfigTextarea).toBeDisabled();
+      // Kubeconfig stays editable in edit mode (#276: leave empty to keep
+      // the existing kubeconfig, or paste a new one to replace it).
+      const kubeconfigTextarea = clusters.form
+        .field("spec.config.kubernetes_config.kubeconfig")
+        .locator("textarea");
+      await expect(kubeconfigTextarea).toBeEnabled();
 
-        // "Leave empty to keep" message
-        await expect(
-          clusters.page.getByText(/leave empty to keep/i).first(),
-        ).toBeVisible();
-      },
-    );
+      // "Leave empty to keep" message
+      await expect(
+        clusters.page.getByText(/leave empty to keep/i).first(),
+      ).toBeVisible();
+    });
 
-    test(
-      "K8s edit: router fields editable",
-      { tag: "@C2612832" },
-      async ({ clusters }) => {
-        await clusters.goToEdit(clNames.k8s);
-        await expect(
-          clusters.page.locator('[data-testid="form-submit"]'),
-        ).toBeEnabled();
+    test("K8s edit: router fields editable", { tag: "@C2612832" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToEdit(clNames.k8s);
+      await expect(
+        clusters.page.locator('[data-testid="form-submit"]'),
+      ).toBeEnabled();
 
-        // Access mode should be enabled
-        const accessModeButton = clusters.form
-          .field("spec.config.kubernetes_config.router.access_mode")
-          .locator('button[role="combobox"]');
-        await expect(accessModeButton).toBeEnabled();
+      // Access mode should be enabled
+      const accessModeButton = clusters.form
+        .field("spec.config.kubernetes_config.router.access_mode")
+        .locator('button[role="combobox"]');
+      await expect(accessModeButton).toBeEnabled();
 
-        // Replicas input should be enabled
-        const replicasInput = clusters.form
-          .field("spec.config.kubernetes_config.router.replicas")
-          .locator("input");
-        await expect(replicasInput).toBeEnabled();
+      // Replicas input should be enabled
+      const replicasInput = clusters.form
+        .field("spec.config.kubernetes_config.router.replicas")
+        .locator("input");
+      await expect(replicasInput).toBeEnabled();
 
-        // CPU input should be enabled
-        const cpuInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.cpu")
-          .locator("input");
-        await expect(cpuInput).toBeEnabled();
+      // CPU input should be enabled
+      const cpuInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.cpu")
+        .locator("input");
+      await expect(cpuInput).toBeEnabled();
 
-        // Memory input should be enabled
-        const memoryInput = clusters.form
-          .field("spec.config.kubernetes_config.router.resources.memory")
-          .locator("input");
-        await expect(memoryInput).toBeEnabled();
-      },
-    );
+      // Memory input should be enabled
+      const memoryInput = clusters.form
+        .field("spec.config.kubernetes_config.router.resources.memory")
+        .locator("input");
+      await expect(memoryInput).toBeEnabled();
+    });
 
-    test(
-      "edit from list action menu",
-      { tag: "@C2613085" },
-      async ({ clusters }) => {
-        await clusters.goToList();
-        await clusters.table.editRow(clNames.ssh);
+    test("edit from list action menu", { tag: "@C2613085" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToList();
+      await clusters.table.editRow(clNames.ssh);
 
-        // Verify form is visible with disabled name
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-        const nameInput = clusters.form.field("metadata.name").locator("input");
-        await expect(nameInput).toBeDisabled();
-        await expect(nameInput).toHaveValue(clNames.ssh);
-      },
-    );
+      // Verify form is visible with disabled name
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+      const nameInput = clusters.form.field("metadata.name").locator("input");
+      await expect(nameInput).toBeDisabled();
+      await expect(nameInput).toHaveValue(clNames.ssh);
+    });
 
-    test(
-      "edit from detail action menu",
-      { tag: "@C2613086" },
-      async ({ clusters }) => {
-        await clusters.goToShow(clNames.ssh);
-        await clusters.showPageEdit();
+    test("edit from detail action menu", { tag: "@C2613086" }, async ({
+      clusters,
+    }) => {
+      await clusters.goToShow(clNames.ssh);
+      await clusters.showPageEdit();
 
-        // Verify form is visible with disabled name
-        await expect(
-          clusters.page.locator('[data-testid="form"]'),
-        ).toBeVisible();
-        const nameInput = clusters.form.field("metadata.name").locator("input");
-        await expect(nameInput).toBeDisabled();
-        await expect(nameInput).toHaveValue(clNames.ssh);
-      },
-    );
+      // Verify form is visible with disabled name
+      await expect(clusters.page.locator('[data-testid="form"]')).toBeVisible();
+      const nameInput = clusters.form.field("metadata.name").locator("input");
+      await expect(nameInput).toBeDisabled();
+      await expect(nameInput).toHaveValue(clNames.ssh);
+    });
   });
 });

--- a/e2e/tests/custom-appearance.spec.ts
+++ b/e2e/tests/custom-appearance.spec.ts
@@ -116,324 +116,306 @@ test.describe("custom appearance", () => {
   // Display
   // ────────────────────────────────────────────────────────
   test.describe("display", () => {
-    test(
-      "default appearance shows Neutree brand name and logo",
-      { tag: "@C2611843" },
-      async ({ page, apiHelper }) => {
-        await apiHelper.resetOemConfig();
-        await goToDashboard(page);
+    test("default appearance shows Neutree brand name and logo", {
+      tag: "@C2611843",
+    }, async ({ page, apiHelper }) => {
+      await apiHelper.resetOemConfig();
+      await goToDashboard(page);
 
-        await expectSidebarBrand(page, "Neutree");
-        await expectSidebarLogo(page, /logo\.png/);
-      },
-    );
+      await expectSidebarBrand(page, "Neutree");
+      await expectSidebarLogo(page, /logo\.svg/);
+    });
 
-    test(
-      "homepage sidebar shows custom brand name and logo",
-      { tag: "@C2611844" },
-      async ({ page, apiHelper }) => {
-        const customBrand = `TestBrand-${Date.now()}`;
-        await apiHelper.upsertOemConfig({
-          brand_name: customBrand,
-          logo_base64: `data:image/png;base64,${MINI_PNG.toString("base64")}`,
-        });
+    test("homepage sidebar shows custom brand name and logo", {
+      tag: "@C2611844",
+    }, async ({ page, apiHelper }) => {
+      const customBrand = `TestBrand-${Date.now()}`;
+      await apiHelper.upsertOemConfig({
+        brand_name: customBrand,
+        logo_base64: `data:image/png;base64,${MINI_PNG.toString("base64")}`,
+      });
 
-        await goToDashboard(page);
+      await goToDashboard(page);
 
-        await expectSidebarBrand(page, customBrand);
-        await expectSidebarLogo(page, /^data:image\/png/);
+      await expectSidebarBrand(page, customBrand);
+      await expectSidebarLogo(page, /^data:image\/png/);
 
-        // Cleanup
-        await apiHelper.resetOemConfig();
-      },
-    );
+      // Cleanup
+      await apiHelper.resetOemConfig();
+    });
 
-    test(
-      "login page shows custom brand name and logo",
-      { tag: "@C2611842" },
-      async ({ page, browser, apiHelper }) => {
-        const customBrand = `LoginBrand-${Date.now()}`;
-        await apiHelper.upsertOemConfig({
-          brand_name: customBrand,
-          logo_base64: `data:image/png;base64,${MINI_PNG.toString("base64")}`,
-        });
+    test("login page shows custom brand name and logo", {
+      tag: "@C2611842",
+    }, async ({ page, browser, apiHelper }) => {
+      const customBrand = `LoginBrand-${Date.now()}`;
+      await apiHelper.upsertOemConfig({
+        brand_name: customBrand,
+        logo_base64: `data:image/png;base64,${MINI_PNG.toString("base64")}`,
+      });
 
-        await expectLoginPageBrand(browser, page, customBrand);
+      await expectLoginPageBrand(browser, page, customBrand);
 
-        // Cleanup
-        await apiHelper.resetOemConfig();
-      },
-    );
+      // Cleanup
+      await apiHelper.resetOemConfig();
+    });
   });
 
   // ────────────────────────────────────────────────────────
   // Edit
   // ────────────────────────────────────────────────────────
   test.describe("edit", () => {
-    test(
-      "edit page loads current config values",
-      { tag: "@C2611845" },
-      async ({ page, apiHelper }) => {
-        const brandName = `CurrentBrand-${Date.now()}`;
-        await apiHelper.upsertOemConfig({
-          brand_name: brandName,
-          logo_base64: `data:image/png;base64,${MINI_PNG.toString("base64")}`,
-        });
+    test("edit page loads current config values", { tag: "@C2611845" }, async ({
+      page,
+      apiHelper,
+    }) => {
+      const brandName = `CurrentBrand-${Date.now()}`;
+      await apiHelper.upsertOemConfig({
+        brand_name: brandName,
+        logo_base64: `data:image/png;base64,${MINI_PNG.toString("base64")}`,
+      });
 
-        await goToOemConfig(page);
+      await goToOemConfig(page);
 
-        const brandInput = page.getByPlaceholder("Enter brand name");
-        await expect(brandInput).toHaveValue(brandName);
-        await expect(page.getByAltText("Main logo preview")).toBeVisible();
+      const brandInput = page.getByPlaceholder("Enter brand name");
+      await expect(brandInput).toHaveValue(brandName);
+      await expect(page.getByAltText("Main logo preview")).toBeVisible();
 
-        // Cleanup
-        await apiHelper.resetOemConfig();
-      },
-    );
+      // Cleanup
+      await apiHelper.resetOemConfig();
+    });
 
-    test(
-      "brand name accepts special characters",
-      { tag: "@C2611835" },
-      async ({ page, apiHelper }) => {
-        await apiHelper.resetOemConfig();
-        await goToOemConfig(page);
+    test("brand name accepts special characters", { tag: "@C2611835" }, async ({
+      page,
+      apiHelper,
+    }) => {
+      await apiHelper.resetOemConfig();
+      await goToOemConfig(page);
 
-        const brandInput = page.getByPlaceholder("Enter brand name");
+      const brandInput = page.getByPlaceholder("Enter brand name");
 
-        const specialBrand = "Test Brand & Co. (2024) - AI!";
-        await brandInput.fill(specialBrand);
+      const specialBrand = "Test Brand & Co. (2024) - AI!";
+      await brandInput.fill(specialBrand);
 
-        await saveForm(page);
+      await saveForm(page);
 
-        // Reload and verify the value was saved
-        await goToOemConfig(page);
-        await expect(brandInput).toHaveValue(specialBrand);
+      // Reload and verify the value was saved
+      await goToOemConfig(page);
+      await expect(brandInput).toHaveValue(specialBrand);
 
-        // Cleanup
-        await apiHelper.resetOemConfig();
-      },
-    );
+      // Cleanup
+      await apiHelper.resetOemConfig();
+    });
 
-    test(
-      "main logo upload shows preview",
-      { tag: "@C2611836" },
-      async ({ page, apiHelper }) => {
-        await apiHelper.resetOemConfig();
-        await goToOemConfig(page);
+    test("main logo upload shows preview", { tag: "@C2611836" }, async ({
+      page,
+      apiHelper,
+    }) => {
+      await apiHelper.resetOemConfig();
+      await goToOemConfig(page);
 
-        // No preview initially
-        await expect(page.getByAltText("Main logo preview")).toBeHidden();
+      // No preview initially
+      await expect(page.getByAltText("Main logo preview")).toBeHidden();
 
-        // Upload via hidden file input
-        const fileInput = page
-          .locator('input[type="file"][accept="image/*"]')
-          .first();
-        await fileInput.setInputFiles({
-          name: "test-logo.png",
-          mimeType: "image/png",
-          buffer: MINI_PNG,
-        });
+      // Upload via hidden file input
+      const fileInput = page
+        .locator('input[type="file"][accept="image/*"]')
+        .first();
+      await fileInput.setInputFiles({
+        name: "test-logo.png",
+        mimeType: "image/png",
+        buffer: MINI_PNG,
+      });
 
-        // Preview should appear with base64 src
-        const preview = page.getByAltText("Main logo preview");
-        await expect(preview).toBeVisible();
-        await expect(preview).toHaveAttribute("src", /^data:image\/png/);
-      },
-    );
+      // Preview should appear with base64 src
+      const preview = page.getByAltText("Main logo preview");
+      await expect(preview).toBeVisible();
+      await expect(preview).toHaveAttribute("src", /^data:image\/png/);
+    });
 
-    test(
-      "collapsed logo upload shows preview",
-      { tag: "@C2611837" },
-      async ({ page, apiHelper }) => {
-        await apiHelper.resetOemConfig();
-        await goToOemConfig(page);
+    test("collapsed logo upload shows preview", { tag: "@C2611837" }, async ({
+      page,
+      apiHelper,
+    }) => {
+      await apiHelper.resetOemConfig();
+      await goToOemConfig(page);
 
-        // No preview initially
-        await expect(page.getByAltText("Collapsed logo preview")).toBeHidden();
+      // No preview initially
+      await expect(page.getByAltText("Collapsed logo preview")).toBeHidden();
 
-        // Upload via filechooser triggered by the Upload Collapsed Logo button
-        const [fileChooser] = await Promise.all([
-          page.waitForEvent("filechooser"),
-          page.getByRole("button", { name: /upload collapsed logo/i }).click(),
-        ]);
-        await fileChooser.setFiles({
-          name: "test-collapsed.png",
-          mimeType: "image/png",
-          buffer: MINI_PNG,
-        });
+      // Upload via filechooser triggered by the Upload Collapsed Logo button
+      const [fileChooser] = await Promise.all([
+        page.waitForEvent("filechooser"),
+        page.getByRole("button", { name: /upload collapsed logo/i }).click(),
+      ]);
+      await fileChooser.setFiles({
+        name: "test-collapsed.png",
+        mimeType: "image/png",
+        buffer: MINI_PNG,
+      });
 
-        const preview = page.getByAltText("Collapsed logo preview");
-        await expect(preview).toBeVisible();
-        await expect(preview).toHaveAttribute("src", /^data:image\/png/);
-      },
-    );
+      const preview = page.getByAltText("Collapsed logo preview");
+      await expect(preview).toBeVisible();
+      await expect(preview).toHaveAttribute("src", /^data:image\/png/);
+    });
 
-    test(
-      "supports PNG and SVG image formats",
-      { tag: "@C2611838" },
-      async ({ page, apiHelper }) => {
-        await apiHelper.resetOemConfig();
-        await goToOemConfig(page);
+    test("supports PNG and SVG image formats", { tag: "@C2611838" }, async ({
+      page,
+      apiHelper,
+    }) => {
+      await apiHelper.resetOemConfig();
+      await goToOemConfig(page);
 
-        const fileInput = page
-          .locator('input[type="file"][accept="image/*"]')
-          .first();
-        const preview = page.getByAltText("Main logo preview");
+      const fileInput = page
+        .locator('input[type="file"][accept="image/*"]')
+        .first();
+      const preview = page.getByAltText("Main logo preview");
 
-        // Test PNG
-        await fileInput.setInputFiles({
-          name: "test-logo.png",
-          mimeType: "image/png",
-          buffer: MINI_PNG,
-        });
-        await expect(preview).toBeVisible();
-        await expect(preview).toHaveAttribute("src", /^data:image\/png/);
+      // Test PNG
+      await fileInput.setInputFiles({
+        name: "test-logo.png",
+        mimeType: "image/png",
+        buffer: MINI_PNG,
+      });
+      await expect(preview).toBeVisible();
+      await expect(preview).toHaveAttribute("src", /^data:image\/png/);
 
-        // Clear via the X button next to the main logo preview
-        await preview.locator("..").getByRole("button").click();
-        await expect(preview).toBeHidden();
+      // Clear via the X button next to the main logo preview
+      await preview.locator("..").getByRole("button").click();
+      await expect(preview).toBeHidden();
 
-        // Test SVG
-        await fileInput.setInputFiles({
-          name: "test-logo.svg",
-          mimeType: "image/svg+xml",
-          buffer: MINI_SVG,
-        });
-        await expect(preview).toBeVisible();
-        await expect(preview).toHaveAttribute("src", /^data:image\/svg\+xml/);
-      },
-    );
+      // Test SVG
+      await fileInput.setInputFiles({
+        name: "test-logo.svg",
+        mimeType: "image/svg+xml",
+        buffer: MINI_SVG,
+      });
+      await expect(preview).toBeVisible();
+      await expect(preview).toHaveAttribute("src", /^data:image\/svg\+xml/);
+    });
 
-    test(
-      "save updates homepage sidebar and login page",
-      { tag: "@C2611839" },
-      async ({ page, browser, apiHelper }) => {
-        await apiHelper.resetOemConfig();
-        await goToOemConfig(page);
+    test("save updates homepage sidebar and login page", {
+      tag: "@C2611839",
+    }, async ({ page, browser, apiHelper }) => {
+      await apiHelper.resetOemConfig();
+      await goToOemConfig(page);
 
-        const customBrand = `SavedBrand-${Date.now()}`;
+      const customBrand = `SavedBrand-${Date.now()}`;
 
-        await page.getByPlaceholder("Enter brand name").fill(customBrand);
+      await page.getByPlaceholder("Enter brand name").fill(customBrand);
 
-        const fileInput = page
-          .locator('input[type="file"][accept="image/*"]')
-          .first();
-        await fileInput.setInputFiles({
-          name: "test-logo.png",
-          mimeType: "image/png",
-          buffer: MINI_PNG,
-        });
+      const fileInput = page
+        .locator('input[type="file"][accept="image/*"]')
+        .first();
+      await fileInput.setInputFiles({
+        name: "test-logo.png",
+        mimeType: "image/png",
+        buffer: MINI_PNG,
+      });
 
-        await saveForm(page);
+      await saveForm(page);
 
-        // Verify sidebar updated (same page, no navigation needed)
-        await page
-          .locator('[data-sidebar="sidebar"]')
-          .getByAltText("logo")
-          .waitFor({ timeout: 10000 });
-        await expectSidebarBrand(page, customBrand);
+      // Verify sidebar updated (same page, no navigation needed)
+      await page
+        .locator('[data-sidebar="sidebar"]')
+        .getByAltText("logo")
+        .waitFor({ timeout: 10000 });
+      await expectSidebarBrand(page, customBrand);
 
-        // Verify login page
-        await expectLoginPageBrand(browser, page, customBrand);
+      // Verify login page
+      await expectLoginPageBrand(browser, page, customBrand);
 
-        // Cleanup
-        await apiHelper.resetOemConfig();
-      },
-    );
+      // Cleanup
+      await apiHelper.resetOemConfig();
+    });
 
-    test(
-      "unsaved changes are discarded when navigating away",
-      { tag: "@C2611840" },
-      async ({ page, apiHelper }) => {
-        await apiHelper.resetOemConfig();
-        await goToOemConfig(page);
+    test("unsaved changes are discarded when navigating away", {
+      tag: "@C2611840",
+    }, async ({ page, apiHelper }) => {
+      await apiHelper.resetOemConfig();
+      await goToOemConfig(page);
 
-        // Modify the brand name
-        const brandInput = page.getByPlaceholder("Enter brand name");
-        await brandInput.fill("UnsavedBrand");
+      // Modify the brand name
+      const brandInput = page.getByPlaceholder("Enter brand name");
+      await brandInput.fill("UnsavedBrand");
 
-        // Accept any dialog (browser confirm from warnWhenUnsavedChanges)
-        page.on("dialog", (dialog) => dialog.accept());
+      // Accept any dialog (browser confirm from warnWhenUnsavedChanges)
+      page.on("dialog", (dialog) => dialog.accept());
 
-        // Use sidebar link click to trigger in-app navigation
-        // (hash-based routing won't fire beforeunload on page.goto)
-        await page
-          .locator('[data-sidebar="sidebar"]')
-          .getByRole("link", { name: /dashboard/i })
-          .click();
-        await page.waitForURL("**/#/dashboard");
+      // Use sidebar link click to trigger in-app navigation
+      // (hash-based routing won't fire beforeunload on page.goto)
+      await page
+        .locator('[data-sidebar="sidebar"]')
+        .getByRole("link", { name: /dashboard/i })
+        .click();
+      await page.waitForURL("**/#/dashboard");
 
-        // Navigate back — form should NOT have the unsaved value
-        await goToOemConfig(page);
-        await expect(brandInput).not.toHaveValue("UnsavedBrand");
-      },
-    );
+      // Navigate back — form should NOT have the unsaved value
+      await goToOemConfig(page);
+      await expect(brandInput).not.toHaveValue("UnsavedBrand");
+    });
 
-    test(
-      "saving empty fields resets to default Neutree appearance",
-      { tag: "@C2611841" },
-      async ({ page, apiHelper }) => {
-        // First set a custom config
-        await apiHelper.upsertOemConfig({
-          brand_name: "TempBrand",
-          logo_base64: `data:image/png;base64,${MINI_PNG.toString("base64")}`,
-        });
+    test("saving empty fields resets to default Neutree appearance", {
+      tag: "@C2611841",
+    }, async ({ page, apiHelper }) => {
+      // First set a custom config
+      await apiHelper.upsertOemConfig({
+        brand_name: "TempBrand",
+        logo_base64: `data:image/png;base64,${MINI_PNG.toString("base64")}`,
+      });
 
-        await goToOemConfig(page);
+      await goToOemConfig(page);
 
-        // Clear brand name
-        const brandInput = page.getByPlaceholder("Enter brand name");
-        await brandInput.clear();
+      // Clear brand name
+      const brandInput = page.getByPlaceholder("Enter brand name");
+      await brandInput.clear();
 
-        // Clear logo via X button if preview visible
-        const logoPreview = page.getByAltText("Main logo preview");
-        if (await logoPreview.isVisible()) {
-          await logoPreview.locator("..").getByRole("button").click();
-        }
+      // Clear logo via X button if preview visible
+      const logoPreview = page.getByAltText("Main logo preview");
+      if (await logoPreview.isVisible()) {
+        await logoPreview.locator("..").getByRole("button").click();
+      }
 
-        await saveForm(page);
+      await saveForm(page);
 
-        // Reload same page (avoids warnWhenUnsavedChanges hash nav issue)
-        await page.reload();
-        await page
-          .locator('[data-sidebar="sidebar"]')
-          .getByAltText("logo")
-          .waitFor({ timeout: 10000 });
+      // Reload same page (avoids warnWhenUnsavedChanges hash nav issue)
+      await page.reload();
+      await page
+        .locator('[data-sidebar="sidebar"]')
+        .getByAltText("logo")
+        .waitFor({ timeout: 10000 });
 
-        // Custom brand "TempBrand" should no longer appear in the sidebar
-        const sidebar = page.locator('[data-sidebar="sidebar"]');
-        await expect(sidebar.getByText("TempBrand")).toBeHidden();
-        await expectSidebarLogo(page, /logo\.png/);
-      },
-    );
+      // Custom brand "TempBrand" should no longer appear in the sidebar
+      const sidebar = page.locator('[data-sidebar="sidebar"]');
+      await expect(sidebar.getByText("TempBrand")).toBeHidden();
+      await expectSidebarLogo(page, /logo\.svg/);
+    });
   });
 
   // ────────────────────────────────────────────────────────
   // Permissions
   // ────────────────────────────────────────────────────────
   test.describe("permissions", () => {
-    test(
-      "admin user can edit custom appearance",
-      { tag: "@C2611848" },
-      async ({ page, apiHelper }) => {
-        await apiHelper.resetOemConfig();
-        await goToOemConfig(page);
+    test("admin user can edit custom appearance", { tag: "@C2611848" }, async ({
+      page,
+      apiHelper,
+    }) => {
+      await apiHelper.resetOemConfig();
+      await goToOemConfig(page);
 
-        const brandName = `AdminBrand-${Date.now()}`;
-        await page.getByPlaceholder("Enter brand name").fill(brandName);
+      const brandName = `AdminBrand-${Date.now()}`;
+      await page.getByPlaceholder("Enter brand name").fill(brandName);
 
-        await saveForm(page);
+      await saveForm(page);
 
-        // Reload and verify
-        await goToOemConfig(page);
-        await expect(page.getByPlaceholder("Enter brand name")).toHaveValue(
-          brandName,
-        );
+      // Reload and verify
+      await goToOemConfig(page);
+      await expect(page.getByPlaceholder("Enter brand name")).toHaveValue(
+        brandName,
+      );
 
-        // Cleanup
-        await apiHelper.resetOemConfig();
-      },
-    );
+      // Cleanup
+      await apiHelper.resetOemConfig();
+    });
 
     test(
       "non-admin with system:admin permission can edit",

--- a/e2e/tests/endpoints.spec.ts
+++ b/e2e/tests/endpoints.spec.ts
@@ -355,6 +355,10 @@ test.describe("endpoints", () => {
     test("customize section is collapsible", { tag: "@C2613241" }, async ({
       endpoints,
     }) => {
+      test.skip(
+        true,
+        "customize section removed from plain create in #272/#273 — obsolete",
+      );
       await endpoints.goToCreate();
 
       // Model name field should be hidden initially
@@ -376,16 +380,16 @@ test.describe("endpoints", () => {
     }, async ({ endpoints }) => {
       await endpoints.goToCreate();
 
-      // CPU slider input should be disabled when no cluster is selected
+      // CPU number input should be disabled when no cluster is selected
       const cpuInput = endpoints.form
         .field("spec.resources.cpu")
-        .locator('[data-testid="slider-input"]');
+        .locator("input");
       await expect(cpuInput).toBeDisabled();
 
-      // Memory slider input should be disabled when no cluster is selected
+      // Memory number input should be disabled when no cluster is selected
       const memoryInput = endpoints.form
         .field("spec.resources.memory")
-        .locator('[data-testid="slider-input"]');
+        .locator("input");
       await expect(memoryInput).toBeDisabled();
     });
 
@@ -393,11 +397,6 @@ test.describe("endpoints", () => {
       tag: "@C2613269",
     }, async ({ endpoints }) => {
       await endpoints.goToCreate();
-
-      // Expand customize section
-      await endpoints.page
-        .getByRole("button", { name: /customize settings/i })
-        .click();
 
       // Model name AsyncCombobox trigger should be disabled without a registry
       const modelNameTrigger = endpoints.form
@@ -419,11 +418,6 @@ test.describe("endpoints", () => {
     }, async ({ endpoints }) => {
       await endpoints.goToCreate();
 
-      // Expand customize section
-      await endpoints.page
-        .getByRole("button", { name: /customize settings/i })
-        .click();
-
       const versionInput = endpoints.form
         .field("spec.model.version")
         .locator("input");
@@ -438,10 +432,6 @@ test.describe("endpoints", () => {
       endpoints,
     }) => {
       await endpoints.goToCreate();
-
-      await endpoints.page
-        .getByRole("button", { name: /customize settings/i })
-        .click();
 
       await expect(endpoints.form.field("spec.model.file")).toBeVisible();
     });

--- a/e2e/tests/model-catalogs.spec.ts
+++ b/e2e/tests/model-catalogs.spec.ts
@@ -2,8 +2,7 @@ import type { Locator, Page } from "@playwright/test";
 import { config } from "../config";
 import { expect, test } from "../fixtures/base";
 import { ApiHelper } from "../helpers/api-helper";
-import { MULTI_USER_TIMEOUT } from "../helpers/constants";
-import { YamlImportHelper } from "../helpers/yaml-import";
+import { DELETE_TIMEOUT, MULTI_USER_TIMEOUT } from "../helpers/constants";
 
 /** Build a ModelCatalog YAML document for import */
 function modelCatalogYaml(
@@ -54,9 +53,9 @@ spec:
     engine: ${o.engine}
     version: ${o.engineVersion}
   resources:
-    cpu: ${o.cpu}
-    memory: ${o.memory}
-    gpu: ${o.gpu}
+    cpu: "${o.cpu}"
+    memory: "${o.memory}"
+    gpu: "${o.gpu}"
   replicas:
     num: ${o.replicas}
   deployment_options:
@@ -85,6 +84,12 @@ function catalogCard(page: Page, name: string): Locator {
   return page.locator(`${CATALOG_CARD}[data-name="${name}"]`);
 }
 
+// Deletion is controller-reconciled, not instant: the confirm click flips the
+// record's status.phase to "Deleted" (or clears it), and the row is only
+// actually removed from the list once the controller finishes cleanup — the
+// same eventual-consistency shape TableHelper.deleteRow/expectNoRowWithText
+// handle for table-surfaced resources via DELETE_TIMEOUT. Card-grid callers
+// must wait with the same extended timeout instead of the default 5s.
 async function deleteCatalogCardByName(
   page: Page,
   name: string,
@@ -95,6 +100,50 @@ async function deleteCatalogCardByName(
   const dialog = page.getByRole("alertdialog");
   await dialog.waitFor({ state: "visible" });
   await dialog.getByRole("button", { name: /delete/i }).click();
+  await dialog.waitFor({ state: "hidden" });
+  await expect(catalogCard(page, name)).toHaveCount(0, {
+    timeout: DELETE_TIMEOUT,
+  });
+}
+
+/** Delete a catalog from its show page's action menu, then verify the card is
+ * gone from the (card-grid) list. Mirrors ResourcePage.showPageDelete, but that
+ * helper's post-delete check waits on a `[data-testid="table"]` list surface —
+ * the model-catalog list is a card grid, so we verify via catalogCard instead. */
+async function deleteFromShowPageActionMenu(
+  page: Page,
+  name: string,
+): Promise<void> {
+  await page.locator('[data-testid="show-actions-trigger"]').click();
+  await page.getByRole("menuitem", { name: /delete/i }).click();
+  const dialog = page.getByRole("alertdialog");
+  await dialog.waitFor({ state: "visible" });
+  await dialog.getByRole("button", { name: /delete/i }).click();
+  await dialog.waitFor({ state: "hidden" });
+
+  await gotoCatalogList(page);
+  await expect(catalogCard(page, name)).toHaveCount(0, {
+    timeout: DELETE_TIMEOUT,
+  });
+}
+
+/** Open the model-catalog list's own Import dialog (paste/file/URL tabs with a
+ * per-document result table) — distinct from the global navbar "Import YAML".
+ * Mirrors the helper of the same name in model-catalogs-recipe.spec.ts. */
+async function mcImportPaste(page: Page, yaml: string): Promise<Locator> {
+  await page.getByRole("button", { name: "Import", exact: true }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.waitFor({ state: "visible" });
+  await dialog.locator("textarea").fill(yaml);
+  await dialog.getByRole("button", { name: "Import", exact: true }).click();
+  // The per-document result table renders once all creates settle.
+  await dialog.locator("table").waitFor({ state: "visible" });
+  return dialog;
+}
+
+async function closeMcImportDialog(page: Page): Promise<void> {
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("button", { name: /cancel/i }).click();
   await dialog.waitFor({ state: "hidden" });
 }
 
@@ -408,15 +457,17 @@ test.describe("model catalogs create", () => {
       modelCatalogs.page.getByRole("link", { name: /create/i }),
     ).toBeHidden();
 
-    // Import YAML button should be visible in the navbar
+    // The catalog list's own Import dialog trigger should be visible — this
+    // page is import-only (see ImportDialog.tsx), distinct from the global
+    // navbar "Import YAML" button which imports other resource kinds.
     await expect(
-      modelCatalogs.page.getByRole("button", { name: /import yaml/i }),
+      modelCatalogs.page.getByRole("button", { name: "Import", exact: true }),
     ).toBeVisible();
   });
 
   test("admin can import model catalog via YAML and verify all fields", {
     tag: ["@C2612861", "@C2613188"],
-  }, async ({ modelCatalogs, yamlImport }) => {
+  }, async ({ modelCatalogs }) => {
     const mcName = `test-mc-imp-${Date.now()}`;
     const yaml = modelCatalogYaml(mcName, {
       modelName: "import-test-model",
@@ -432,9 +483,9 @@ test.describe("model catalogs create", () => {
 
     // Import via YAML
     await gotoCatalogList(modelCatalogs.page);
-    await yamlImport.importYaml(yaml);
-    await yamlImport.expectResults({ success: 1 });
-    await yamlImport.close();
+    const dialog = await mcImportPaste(modelCatalogs.page, yaml);
+    await expect(dialog.getByText("OK", { exact: true })).toBeVisible();
+    await closeMcImportDialog(modelCatalogs.page);
 
     // Verify the card appears, then open its detail page
     await expect(catalogCard(modelCatalogs.page, mcName)).toBeVisible();
@@ -509,12 +560,11 @@ test.describe("model catalogs create", () => {
 
       const mcName = `test-mc-imp-${Date.now()}`;
       const yaml = modelCatalogYaml(mcName);
-      const yamlHelper = new YamlImportHelper(testUser.page);
 
       await gotoCatalogList(testUser.page);
-      await yamlHelper.importYaml(yaml);
-      await yamlHelper.expectResults({ success: 1 });
-      await yamlHelper.close();
+      const dialog = await mcImportPaste(testUser.page, yaml);
+      await expect(dialog.getByText("OK", { exact: true })).toBeVisible();
+      await closeMcImportDialog(testUser.page);
 
       await expect(catalogCard(testUser.page, mcName)).toBeVisible();
 
@@ -539,12 +589,11 @@ test.describe("model catalogs create", () => {
 
       const mcName = `test-mc-imp-${Date.now()}`;
       const yaml = modelCatalogYaml(mcName);
-      const yamlHelper = new YamlImportHelper(testUser.page);
 
       await gotoCatalogList(testUser.page);
-      await yamlHelper.importYaml(yaml);
-      await yamlHelper.expectResults({ errors: 1 });
-      await yamlHelper.close();
+      const dialog = await mcImportPaste(testUser.page, yaml);
+      await expect(dialog.getByText("FAIL", { exact: true })).toBeVisible();
+      await closeMcImportDialog(testUser.page);
 
       // Model catalog should NOT appear in the list
       await expect(catalogCard(testUser.page, mcName)).toHaveCount(0);
@@ -563,8 +612,9 @@ test.describe("model catalogs delete", () => {
     await apiHelper.createModelCatalog(mcName);
 
     await gotoCatalogList(modelCatalogs.page);
+    // deleteCatalogCardByName already waits (with DELETE_TIMEOUT) for the
+    // controller-reconciled removal before returning.
     await deleteCatalogCardByName(modelCatalogs.page, mcName);
-    await expect(catalogCard(modelCatalogs.page, mcName)).toHaveCount(0);
   });
 
   test("can delete from detail page action menu", {
@@ -574,7 +624,7 @@ test.describe("model catalogs delete", () => {
     await apiHelper.createModelCatalog(mcName);
 
     await modelCatalogs.goToShow(mcName);
-    await modelCatalogs.showPageDelete(mcName);
+    await deleteFromShowPageActionMenu(modelCatalogs.page, mcName);
   });
 
   test("admin can delete model catalog", {
@@ -585,7 +635,6 @@ test.describe("model catalogs delete", () => {
 
     await gotoCatalogList(modelCatalogs.page);
     await deleteCatalogCardByName(modelCatalogs.page, mcName);
-    await expect(catalogCard(modelCatalogs.page, mcName)).toHaveCount(0);
   });
 });
 
@@ -616,7 +665,6 @@ test.describe("model catalogs delete permissions", () => {
 
       await gotoCatalogList(testUser.page);
       await deleteCatalogCardByName(testUser.page, mcName);
-      await expect(catalogCard(testUser.page, mcName)).toHaveCount(0);
     },
   );
 

--- a/e2e/tests/roles.spec.ts
+++ b/e2e/tests/roles.spec.ts
@@ -56,390 +56,303 @@ async function editRowWithPermissions(
 }
 
 test.describe("roles list", () => {
-  test(
-    "list page shows expected columns",
-    {
-      tag: "@C2611652",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.waitForLoaded();
+  test("list page shows expected columns", {
+    tag: "@C2611652",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.waitForLoaded();
 
-      const headers = roles.table.root.locator("thead th");
-      await expect(headers.filter({ hasText: /name/i })).toBeVisible();
-      await expect(headers.filter({ hasText: /permissions/i })).toBeVisible();
-      await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
-    },
-  );
+    const headers = roles.table.root.locator("thead th");
+    await expect(headers.filter({ hasText: /name/i })).toBeVisible();
+    await expect(headers.filter({ hasText: /permissions/i })).toBeVisible();
+    await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
+  });
 
-  test(
-    "admin user can see built-in roles",
-    {
-      tag: "@C2611683",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.expectRowWithText("admin");
-      await roles.table.expectRowWithText("workspace-user");
-    },
-  );
+  test("admin user can see built-in roles", {
+    tag: "@C2611683",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.expectRowWithText("admin");
+    await roles.table.expectRowWithText("workspace-user");
+  });
 
-  test(
-    "preset admin role has no action menu",
-    {
-      tag: "@C2611686",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      const hasActions = await roles.table.hasRowActions("admin");
-      expect(hasActions).toBe(false);
-    },
-  );
+  test("preset admin role has no action menu", {
+    tag: "@C2611686",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    const hasActions = await roles.table.hasRowActions("admin");
+    expect(hasActions).toBe(false);
+  });
 
-  test(
-    "preset workspace-user role has no action menu",
-    {
-      tag: "@C2611687",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      const hasActions = await roles.table.hasRowActions("workspace-user");
-      expect(hasActions).toBe(false);
-    },
-  );
+  test("preset workspace-user role has no action menu", {
+    tag: "@C2611687",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    const hasActions = await roles.table.hasRowActions("workspace-user");
+    expect(hasActions).toBe(false);
+  });
 
-  test(
-    "permissions column shows permission count",
-    {
-      tag: "@C2611667",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.waitForLoaded();
+  test("permissions column shows permission count", {
+    tag: "@C2611667",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.waitForLoaded();
 
-      const adminRow = roles.table.rowWithText("admin");
-      await expect(adminRow.getByText(/\d+ permissions/)).toBeVisible();
-    },
-  );
+    const adminRow = roles.table.rowWithText("admin");
+    await expect(adminRow.getByText(/\d+ permissions/)).toBeVisible();
+  });
 
-  test(
-    "can sort by updated time",
-    {
-      tag: "@C2611668",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.sort(/updated/i);
-    },
-  );
+  test("can sort by updated time", {
+    tag: "@C2611668",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.sort(/updated/i);
+  });
 
-  test(
-    "can sort by created time",
-    {
-      tag: "@C2611669",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.waitForLoaded();
+  test("can sort by created time", {
+    tag: "@C2611669",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.waitForLoaded();
 
-      // Created At column may be hidden by default
-      const createdHeader = roles.table.headerCell(/created/i);
-      if (!(await createdHeader.isVisible().catch(() => false))) {
-        await roles.table.toggleColumn(/created/i);
-      }
+    // Created At column may be hidden by default
+    const createdHeader = roles.table.headerCell(/created/i);
+    if (!(await createdHeader.isVisible().catch(() => false))) {
+      await roles.table.toggleColumn(/created/i);
+    }
 
-      await roles.table.sort(/created/i);
-    },
-  );
+    await roles.table.sort(/created/i);
+  });
 
-  test(
-    "can toggle column visibility",
-    {
-      tag: "@C2611670",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.waitForLoaded();
+  test("can toggle column visibility", {
+    tag: "@C2611670",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.waitForLoaded();
 
-      await roles.table.toggleColumn(/updated/i);
-      await expect(roles.table.headerCell(/updated/i)).toBeHidden();
+    await roles.table.toggleColumn(/updated/i);
+    await expect(roles.table.headerCell(/updated/i)).toBeHidden();
 
-      await roles.table.toggleColumn(/updated/i);
-      await expect(roles.table.headerCell(/updated/i)).toBeVisible();
-    },
-  );
+    await roles.table.toggleColumn(/updated/i);
+    await expect(roles.table.headerCell(/updated/i)).toBeVisible();
+  });
 });
 
 test.describe("roles detail", () => {
-  test(
-    "click role name navigates to detail page",
-    {
-      tag: "@C2611666",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.clickRowLink("admin");
+  test("click role name navigates to detail page", {
+    tag: "@C2611666",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.clickRowLink("admin");
 
-      await expect(
-        roles.page.locator('[data-testid="show-page"]'),
-      ).toBeVisible();
-    },
-  );
+    await expect(roles.page.locator('[data-testid="show-page"]')).toBeVisible();
+  });
 
-  test(
-    "detail page shows role info and permissions",
-    {
-      tag: "@C2611779",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.clickRowLink("admin");
+  test("detail page shows role info and permissions", {
+    tag: "@C2611779",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.clickRowLink("admin");
 
-      const showPage = roles.page.locator('[data-testid="show-page"]');
-      await expect(showPage).toBeVisible();
-      await expect(showPage.getByText("admin", { exact: true })).toBeVisible();
-      await expect(
-        showPage.locator('[data-testid="permissions-card"]'),
-      ).toBeAttached();
-    },
-  );
+    const showPage = roles.page.locator('[data-testid="show-page"]');
+    await expect(showPage).toBeVisible();
+    await expect(showPage.getByText("admin", { exact: true })).toBeVisible();
+    await expect(
+      showPage.locator('[data-testid="permissions-card"]'),
+    ).toBeAttached();
+  });
 
-  test(
-    "preset role detail page has no edit or delete actions",
-    {
-      tag: "@C2611686",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.table.clickRowLink("admin");
+  test("preset role detail page has no edit or delete actions", {
+    tag: "@C2611686",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.table.clickRowLink("admin");
 
-      await expect(
-        roles.page.locator('[data-testid="show-page"]'),
-      ).toBeVisible();
-      await expect(
-        roles.page.locator('[data-testid="show-actions-trigger"]'),
-      ).toBeHidden();
-    },
-  );
+    await expect(roles.page.locator('[data-testid="show-page"]')).toBeVisible();
+    await expect(
+      roles.page.locator('[data-testid="show-actions-trigger"]'),
+    ).toBeHidden();
+  });
 });
 
 test.describe("roles create", () => {
-  test(
-    "admin user can create a role with permissions",
-    {
-      tag: ["@C2611697", "@C2611664"],
-    },
-    async ({ roles }) => {
-      const uniqueName = `test-role-${Date.now()}`;
+  test("admin user can create a role with permissions", {
+    tag: ["@C2611697", "@C2611664"],
+  }, async ({ roles }) => {
+    const uniqueName = `test-role-${Date.now()}`;
 
-      await createRole(roles, uniqueName, ["Workspaces:Read"]);
+    await createRole(roles, uniqueName, ["Workspaces:Read"]);
 
-      await roles.goToList();
-      await roles.table.expectRowWithText(uniqueName);
+    await roles.goToList();
+    await roles.table.expectRowWithText(uniqueName);
 
-      // Cleanup
-      await roles.table.deleteRow(uniqueName, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(uniqueName, { noWait: true });
+  });
 
-  test(
-    "cannot create role without name",
-    {
-      tag: "@C2611690",
-    },
-    async ({ roles }) => {
-      await roles.goToCreate();
-      await roles.form.submit();
+  test("cannot create role without name", {
+    tag: "@C2611690",
+  }, async ({ roles }) => {
+    await roles.goToCreate();
+    await roles.form.submit();
 
-      await expect(roles.page.locator('[data-testid="form"]')).toBeVisible();
-    },
-  );
+    await expect(roles.page.locator('[data-testid="form"]')).toBeVisible();
+  });
 
-  test(
-    "cancel button returns to list",
-    {
-      tag: "@C2611665",
-    },
-    async ({ roles }) => {
-      await roles.goToList();
-      await roles.clickCreate();
-      await roles.form.cancel();
+  test("cancel button returns to list", {
+    tag: "@C2611665",
+  }, async ({ roles }) => {
+    await roles.goToList();
+    await roles.clickCreate();
+    await roles.form.cancel();
 
-      await roles.table.waitForLoaded();
-    },
-  );
+    await roles.table.waitForLoaded();
+  });
 
-  test(
-    "can create role with valid k8s name format",
-    {
-      tag: "@C2611653",
-    },
-    async ({ roles }) => {
-      const name = `test-a1-${Date.now()}`;
+  test("can create role with valid k8s name format", {
+    tag: "@C2611653",
+  }, async ({ roles }) => {
+    const name = `test-a1-${Date.now()}`;
 
-      await createRole(roles, name, ["Workspaces:Read"]);
+    await createRole(roles, name, ["Workspaces:Read"]);
 
-      await roles.goToList();
-      await roles.table.expectRowWithText(name);
+    await roles.goToList();
+    await roles.table.expectRowWithText(name);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "rejects name longer than 63 characters",
-    {
-      tag: "@C2611691",
-    },
-    async ({ roles }) => {
-      const longName = "a".repeat(64);
+  test("rejects name longer than 63 characters", {
+    tag: "@C2611691",
+  }, async ({ roles }) => {
+    const longName = "a".repeat(64);
 
-      await roles.goToCreate();
-      await roles.form.fillInput("metadata.name", longName);
-      await roles.form.submit();
+    await roles.goToCreate();
+    await roles.form.fillInput("metadata.name", longName);
+    await roles.form.submit();
 
-      await expect(
-        roles.page.locator('[data-sonner-toast][data-type="error"]'),
-      ).toBeVisible();
-      await expect(roles.page.locator('[data-testid="form"]')).toBeVisible();
-    },
-  );
+    await expect(
+      roles.page.locator('[data-sonner-toast][data-type="error"]'),
+    ).toBeVisible();
+    await expect(roles.page.locator('[data-testid="form"]')).toBeVisible();
+  });
 
-  test(
-    "rejects duplicate role name",
-    {
-      tag: "@C2611692",
-    },
-    async ({ roles }) => {
-      const name = `test-dup-${Date.now()}`;
+  test("rejects duplicate role name", {
+    tag: "@C2611692",
+  }, async ({ roles }) => {
+    const name = `test-dup-${Date.now()}`;
 
-      // Create first role
-      await createRole(roles, name);
-      await roles.goToList();
-      await roles.table.expectRowWithText(name);
+    // Create first role
+    await createRole(roles, name);
+    await roles.goToList();
+    await roles.table.expectRowWithText(name);
 
-      // Try to create second with same name
-      await roles.goToCreate();
-      await roles.form.fillInput("metadata.name", name);
-      await roles.form.submit();
+    // Try to create second with same name
+    await roles.goToCreate();
+    await roles.form.fillInput("metadata.name", name);
+    await roles.form.submit();
 
-      await expect(
-        roles.page.locator('[data-sonner-toast][data-type="error"]'),
-      ).toBeVisible();
-      await expect(roles.page.locator('[data-testid="form"]')).toBeVisible();
+    await expect(
+      roles.page.locator('[data-sonner-toast][data-type="error"]'),
+    ).toBeVisible();
+    await expect(roles.page.locator('[data-testid="form"]')).toBeVisible();
 
-      // Cleanup
-      await roles.goToList();
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.goToList();
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "can create role without any permissions",
-    {
-      tag: "@C2611693",
-    },
-    async ({ roles }) => {
-      const name = `test-noperm-${Date.now()}`;
+  test("can create role without any permissions", {
+    tag: "@C2611693",
+  }, async ({ roles }) => {
+    const name = `test-noperm-${Date.now()}`;
 
-      await createRole(roles, name);
+    await createRole(roles, name);
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 0);
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 0);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "can create role with all permissions selected",
-    {
-      tag: "@C2611694",
-    },
-    async ({ roles }) => {
-      const name = `test-allperm-${Date.now()}`;
+  test("can create role with all permissions selected", {
+    tag: "@C2611694",
+  }, async ({ roles }) => {
+    const name = `test-allperm-${Date.now()}`;
 
-      await roles.goToCreate();
-      await roles.form.fillInput("metadata.name", name);
+    await roles.goToCreate();
+    await roles.form.fillInput("metadata.name", name);
 
-      // Click each resource group header to select all permissions
-      const permField = roles.form.field("spec.permissions");
-      const headers = permField.locator(
-        '[data-testid="permission-group-header"]',
-      );
-      const count = await headers.count();
-      for (let i = 0; i < count; i++) {
-        await headers
-          .nth(i)
-          .locator('[data-testid="permission-group-toggle"]')
-          .click();
-      }
+    // Click each resource group header to select all permissions
+    const permField = roles.form.field("spec.permissions");
+    const headers = permField.locator(
+      '[data-testid="permission-group-header"]',
+    );
+    const count = await headers.count();
+    for (let i = 0; i < count; i++) {
+      await headers
+        .nth(i)
+        .locator('[data-testid="permission-group-toggle"]')
+        .click();
+    }
 
-      await roles.form.submit();
+    await roles.form.submit();
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 45);
+    await roles.goToList();
+    // ALL_PERMISSIONS currently lists 52 permissions across all resources.
+    await expectPermissionCount(roles, name, 52);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "can create role with partial permissions",
-    {
-      tag: "@C2611695",
-    },
-    async ({ roles }) => {
-      const name = `test-partial-${Date.now()}`;
+  test("can create role with partial permissions", {
+    tag: "@C2611695",
+  }, async ({ roles }) => {
+    const name = `test-partial-${Date.now()}`;
 
-      await createRole(roles, name, [
-        "Workspaces:Read",
-        "Clusters:Read",
-        "Endpoints:Read",
-      ]);
+    await createRole(roles, name, [
+      "Workspaces:Read",
+      "Clusters:Read",
+      "Endpoints:Read",
+    ]);
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 3);
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 3);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "group header toggles all permissions in group",
-    {
-      tag: "@C2611696",
-    },
-    async ({ roles }) => {
-      await roles.goToCreate();
+  test("group header toggles all permissions in group", {
+    tag: "@C2611696",
+  }, async ({ roles }) => {
+    await roles.goToCreate();
 
-      const permField = roles.form.field("spec.permissions");
-      const header = permField
-        .locator('[data-testid="permission-group-header"]')
-        .filter({ hasText: "Clusters" });
+    const permField = roles.form.field("spec.permissions");
+    const header = permField
+      .locator('[data-testid="permission-group-header"]')
+      .filter({ hasText: "Clusters" });
 
-      // Initially 0/4
-      await expect(
-        header.getByText("0/4 Permissions", { exact: true }),
-      ).toBeVisible();
+    // Initially 0/4
+    await expect(
+      header.getByText("0/4 Permissions", { exact: true }),
+    ).toBeVisible();
 
-      // Click group header to select all
-      await header.locator('[data-testid="permission-group-toggle"]').click();
-      await expect(
-        header.getByText("4/4 Permissions", { exact: true }),
-      ).toBeVisible();
+    // Click group header to select all
+    await header.locator('[data-testid="permission-group-toggle"]').click();
+    await expect(
+      header.getByText("4/4 Permissions", { exact: true }),
+    ).toBeVisible();
 
-      // Click again to deselect all
-      await header.locator('[data-testid="permission-group-toggle"]').click();
-      await expect(
-        header.getByText("0/4 Permissions", { exact: true }),
-      ).toBeVisible();
-    },
-  );
+    // Click again to deselect all
+    await header.locator('[data-testid="permission-group-toggle"]').click();
+    await expect(
+      header.getByText("0/4 Permissions", { exact: true }),
+    ).toBeVisible();
+  });
 });
 
 interface PermissionGroupSpec {
@@ -447,6 +360,12 @@ interface PermissionGroupSpec {
   groupTitle: string;
   cards: string[];
   depTrigger: string | null;
+  // Resources scoped to a workspace (App.tsx meta.workspaced: true) implicitly
+  // depend on workspace:read for every non-read action (see WORKSPACED_RESOURCES
+  // in use-permission-dependencies.ts). Selecting "all" in one of these groups
+  // therefore also selects workspace:read in the (separate) Workspaces group,
+  // so the role ends up with N+1 permissions total, not just N.
+  workspaced?: boolean;
 }
 
 const PERMISSION_GROUPS: PermissionGroupSpec[] = [
@@ -460,6 +379,7 @@ const PERMISSION_GROUPS: PermissionGroupSpec[] = [
       "Clusters:Update",
     ],
     depTrigger: "Clusters:Create",
+    workspaced: true,
   },
   {
     caseId: "C2611655",
@@ -468,9 +388,11 @@ const PERMISSION_GROUPS: PermissionGroupSpec[] = [
       "Endpoints:Create",
       "Endpoints:Delete",
       "Endpoints:Read",
+      "Endpoints:Access Log Read",
       "Endpoints:Update",
     ],
     depTrigger: "Endpoints:Create",
+    workspaced: true,
   },
   {
     caseId: "C2611656",
@@ -482,6 +404,7 @@ const PERMISSION_GROUPS: PermissionGroupSpec[] = [
       "Engines:Update",
     ],
     depTrigger: "Engines:Create",
+    workspaced: true,
   },
   {
     caseId: "C2611657",
@@ -493,6 +416,7 @@ const PERMISSION_GROUPS: PermissionGroupSpec[] = [
       "Image Registries:Update",
     ],
     depTrigger: "Image Registries:Create",
+    workspaced: true,
   },
   {
     caseId: "C2611658",
@@ -504,6 +428,7 @@ const PERMISSION_GROUPS: PermissionGroupSpec[] = [
       "Model Catalogs:Update",
     ],
     depTrigger: "Model Catalogs:Create",
+    workspaced: true,
   },
   {
     caseId: "C2611659",
@@ -515,6 +440,7 @@ const PERMISSION_GROUPS: PermissionGroupSpec[] = [
       "Model Registries:Update",
     ],
     depTrigger: "Model Registries:Create",
+    workspaced: true,
   },
   {
     caseId: "C2611660",
@@ -547,6 +473,7 @@ const PERMISSION_GROUPS: PermissionGroupSpec[] = [
       "Workspaces:Delete",
       "Workspaces:Read",
       "Workspaces:Update",
+      "Workspaces:Usage Read",
     ],
     depTrigger: "Workspaces:Create",
   },
@@ -570,9 +497,17 @@ async function verifyPermissionGroup(
   await roles.form.fillInput("metadata.name", name);
 
   const permField = roles.form.field("spec.permissions");
+  // Match the group heading exactly — hasText does a substring match, and
+  // "Endpoints" is a substring of "External Endpoints", so a plain hasText
+  // filter is ambiguous between the two groups.
   const header = permField
     .locator('[data-testid="permission-group-header"]')
-    .filter({ hasText: spec.groupTitle });
+    .filter({
+      has: roles.page.getByRole("heading", {
+        name: spec.groupTitle,
+        exact: true,
+      }),
+    });
 
   // Verify badge shows 0/N
   await expect(
@@ -610,10 +545,13 @@ async function verifyPermissionGroup(
     header.getByText(`${N}/${N} Permissions`, { exact: true }),
   ).toBeVisible();
 
-  // Submit and verify
+  // Submit and verify. Workspaced resources implicitly pull in workspace:read
+  // (added when the depTrigger was clicked earlier and never removed), so the
+  // role ends up with one extra permission beyond this group's own N.
+  const expectedTotal = N + (spec.workspaced ? 1 : 0);
   await roles.form.submit();
   await roles.goToList();
-  await expectPermissionCount(roles, name, N);
+  await expectPermissionCount(roles, name, expectedTotal);
 
   // Cleanup
   await roles.table.deleteRow(name, { noWait: true });
@@ -621,215 +559,182 @@ async function verifyPermissionGroup(
 
 test.describe("roles create - permission groups", () => {
   for (const spec of PERMISSION_GROUPS) {
-    test(
-      `verify ${spec.groupTitle} permission group`,
-      {
-        tag: `@${spec.caseId}`,
-      },
-      async ({ roles }) => {
-        await verifyPermissionGroup(roles, spec);
-      },
-    );
+    test(`verify ${spec.groupTitle} permission group`, {
+      tag: `@${spec.caseId}`,
+    }, async ({ roles }) => {
+      await verifyPermissionGroup(roles, spec);
+    });
   }
 });
 
 test.describe("roles edit", () => {
-  test(
-    "can edit role from list action menu",
-    {
-      tag: ["@C2611706", "@C2611708"],
-    },
-    async ({ roles }) => {
-      const uniqueName = `test-role-${Date.now()}`;
+  test("can edit role from list action menu", {
+    tag: ["@C2611706", "@C2611708"],
+  }, async ({ roles }) => {
+    const uniqueName = `test-role-${Date.now()}`;
 
-      // Setup
-      await createRole(roles, uniqueName, ["Workspaces:Read"]);
-      await roles.goToList();
-      await roles.table.expectRowWithText(uniqueName);
+    // Setup
+    await createRole(roles, uniqueName, ["Workspaces:Read"]);
+    await roles.goToList();
+    await roles.table.expectRowWithText(uniqueName);
 
-      // Edit from list
-      await roles.table.editRow(uniqueName);
-      await expect(roles.page.locator('[data-testid="form"]')).toBeVisible();
+    // Edit from list
+    await roles.table.editRow(uniqueName);
+    await expect(roles.page.locator('[data-testid="form"]')).toBeVisible();
 
-      const nameInput = roles.form.field("metadata.name").locator("input");
-      await expect(nameInput).toBeDisabled();
+    const nameInput = roles.form.field("metadata.name").locator("input");
+    await expect(nameInput).toBeDisabled();
 
-      await roles.form.submit();
+    await roles.form.submit();
 
-      // Cleanup
-      await roles.goToList();
-      await roles.table.deleteRow(uniqueName, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.goToList();
+    await roles.table.deleteRow(uniqueName, { noWait: true });
+  });
 
-  test(
-    "can edit role from detail page",
-    {
-      tag: "@C2611707",
-    },
-    async ({ roles }) => {
-      const uniqueName = `test-role-${Date.now()}`;
+  test("can edit role from detail page", {
+    tag: "@C2611707",
+  }, async ({ roles }) => {
+    const uniqueName = `test-role-${Date.now()}`;
 
-      // Setup
-      await createRole(roles, uniqueName, ["Workspaces:Read"]);
+    // Setup
+    await createRole(roles, uniqueName, ["Workspaces:Read"]);
 
-      await roles.goToList();
-      await roles.table.clickRowLink(uniqueName);
-      await expect(
-        roles.page.locator('[data-testid="show-page"]'),
-      ).toBeVisible();
+    await roles.goToList();
+    await roles.table.clickRowLink(uniqueName);
+    await expect(roles.page.locator('[data-testid="show-page"]')).toBeVisible();
 
-      // Edit from detail page
-      await roles.showPageEdit();
-      await roles.form.submit();
+    // Edit from detail page
+    await roles.showPageEdit();
+    await roles.form.submit();
 
-      // Cleanup
-      await roles.goToList();
-      await roles.table.deleteRow(uniqueName, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.goToList();
+    await roles.table.deleteRow(uniqueName, { noWait: true });
+  });
 
-  test(
-    "editing role updates permissions count",
-    {
-      tag: "@C2611705",
-    },
-    async ({ roles }) => {
-      const name = `test-editcnt-${Date.now()}`;
+  test("editing role updates permissions count", {
+    tag: "@C2611705",
+  }, async ({ roles }) => {
+    const name = `test-editcnt-${Date.now()}`;
 
-      // Create with 1 permission
-      await createRole(roles, name, ["Workspaces:Read"]);
+    // Create with 1 permission
+    await createRole(roles, name, ["Workspaces:Read"]);
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 1);
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 1);
 
-      // Edit: add 1 more permission
-      const permField = await editRowWithPermissions(
-        roles,
-        name,
-        "Workspaces",
-        "1/4 Permissions",
-      );
-      await permField.getByText("Clusters:Read", { exact: true }).click();
-      await roles.form.submit();
+    // Edit: add 1 more permission
+    const permField = await editRowWithPermissions(
+      roles,
+      name,
+      "Workspaces",
+      "1/5 Permissions",
+    );
+    await permField.getByText("Clusters:Read", { exact: true }).click();
+    await roles.form.submit();
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 2);
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 2);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "admin can edit custom role via list action menu",
-    {
-      tag: "@C2611709",
-    },
-    async ({ roles }) => {
-      const name = `test-canedit-${Date.now()}`;
+  test("admin can edit custom role via list action menu", {
+    tag: "@C2611709",
+  }, async ({ roles }) => {
+    const name = `test-canedit-${Date.now()}`;
 
-      // Setup
-      await createRole(roles, name, ["Workspaces:Read"]);
+    // Setup
+    await createRole(roles, name, ["Workspaces:Read"]);
 
-      await roles.goToList();
-      await roles.table.expectRowWithText(name);
+    await roles.goToList();
+    await roles.table.expectRowWithText(name);
 
-      // Edit from list and submit without changes
-      await roles.table.editRow(name);
-      await roles.form.submit();
+    // Edit from list and submit without changes
+    await roles.table.editRow(name);
+    await roles.form.submit();
 
-      await roles.goToList();
-      await roles.table.expectRowWithText(name);
+    await roles.goToList();
+    await roles.table.expectRowWithText(name);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "can increase permissions on existing role",
-    {
-      tag: "@C2611712",
-    },
-    async ({ roles }) => {
-      const name = `test-incperm-${Date.now()}`;
+  test("can increase permissions on existing role", {
+    tag: "@C2611712",
+  }, async ({ roles }) => {
+    const name = `test-incperm-${Date.now()}`;
 
-      // Create with 1 permission
-      await createRole(roles, name, ["Workspaces:Read"]);
+    // Create with 1 permission
+    await createRole(roles, name, ["Workspaces:Read"]);
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 1);
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 1);
 
-      // Edit: add 2 more permissions
-      const permField = await editRowWithPermissions(
-        roles,
-        name,
-        "Workspaces",
-        "1/4 Permissions",
-      );
-      await permField.getByText("Clusters:Read", { exact: true }).click();
-      await permField.getByText("Endpoints:Read", { exact: true }).click();
-      await roles.form.submit();
+    // Edit: add 2 more permissions
+    const permField = await editRowWithPermissions(
+      roles,
+      name,
+      "Workspaces",
+      "1/5 Permissions",
+    );
+    await permField.getByText("Clusters:Read", { exact: true }).click();
+    await permField.getByText("Endpoints:Read", { exact: true }).click();
+    await roles.form.submit();
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 3);
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 3);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "can decrease permissions on existing role",
-    {
-      tag: "@C2611713",
-    },
-    async ({ roles }) => {
-      const name = `test-decperm-${Date.now()}`;
+  test("can decrease permissions on existing role", {
+    tag: "@C2611713",
+  }, async ({ roles }) => {
+    const name = `test-decperm-${Date.now()}`;
 
-      // Create with 3 permissions
-      await createRole(roles, name, [
-        "Workspaces:Read",
-        "Clusters:Read",
-        "Endpoints:Read",
-      ]);
+    // Create with 3 permissions
+    await createRole(roles, name, [
+      "Workspaces:Read",
+      "Clusters:Read",
+      "Endpoints:Read",
+    ]);
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 3);
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 3);
 
-      // Edit: remove 2 permissions
-      const permField = await editRowWithPermissions(
-        roles,
-        name,
-        "Clusters",
-        "1/4 Permissions",
-      );
-      await permField.getByText("Clusters:Read", { exact: true }).click();
-      await permField.getByText("Endpoints:Read", { exact: true }).click();
-      await roles.form.submit();
+    // Edit: remove 2 permissions
+    const permField = await editRowWithPermissions(
+      roles,
+      name,
+      "Clusters",
+      "1/4 Permissions",
+    );
+    await permField.getByText("Clusters:Read", { exact: true }).click();
+    await permField.getByText("Endpoints:Read", { exact: true }).click();
+    await roles.form.submit();
 
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 1);
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 1);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 });
 
 test.describe("roles yaml import", () => {
-  test(
-    "can import single or multiple roles via YAML",
-    {
-      tag: "@C2611699",
-    },
-    async ({ roles, yamlImport }) => {
-      const ts = Date.now();
-      const name1 = `test-import1-${ts}`;
-      const name2 = `test-import2-${ts}`;
+  test("can import single or multiple roles via YAML", {
+    tag: "@C2611699",
+  }, async ({ roles, yamlImport }) => {
+    const ts = Date.now();
+    const name1 = `test-import1-${ts}`;
+    const name2 = `test-import2-${ts}`;
 
-      const yaml = `apiVersion: v1
+    const yaml = `apiVersion: v1
 kind: Role
 metadata:
   name: ${name1}
@@ -846,31 +751,27 @@ spec:
     - cluster:read
     - endpoint:read`;
 
-      await roles.goToList();
-      await yamlImport.importYaml(yaml);
-      await yamlImport.expectResults({ success: 2, errors: 0 });
-      await yamlImport.close();
+    await roles.goToList();
+    await yamlImport.importYaml(yaml);
+    await yamlImport.expectResults({ success: 2, errors: 0 });
+    await yamlImport.close();
 
-      // Verify both roles in list
-      await roles.goToList();
-      await roles.table.expectRowWithText(name1);
-      await roles.table.expectRowWithText(name2);
-      await expectPermissionCount(roles, name1, 1);
-      await expectPermissionCount(roles, name2, 2);
+    // Verify both roles in list
+    await roles.goToList();
+    await roles.table.expectRowWithText(name1);
+    await roles.table.expectRowWithText(name2);
+    await expectPermissionCount(roles, name1, 1);
+    await expectPermissionCount(roles, name2, 2);
 
-      // Cleanup
-      await roles.table.deleteRow(name1, { noWait: true });
-      await roles.table.deleteRow(name2, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name1, { noWait: true });
+    await roles.table.deleteRow(name2, { noWait: true });
+  });
 
-  test(
-    "import fails with invalid field content",
-    {
-      tag: "@C2611700",
-    },
-    async ({ roles, yamlImport }) => {
-      const yaml = `apiVersion: v1
+  test("import fails with invalid field content", {
+    tag: "@C2611700",
+  }, async ({ roles, yamlImport }) => {
+    const yaml = `apiVersion: v1
 kind: Role
 metadata:
   name: INVALID_UPPERCASE_NAME
@@ -878,28 +779,24 @@ spec:
   permissions:
     - workspace:read`;
 
-      await roles.goToList();
-      await yamlImport.importYaml(yaml);
-      await yamlImport.expectResults({ success: 0, errors: 1 });
-      await yamlImport.close();
-    },
-  );
+    await roles.goToList();
+    await yamlImport.importYaml(yaml);
+    await yamlImport.expectResults({ success: 0, errors: 1 });
+    await yamlImport.close();
+  });
 
-  test(
-    "import skips role with duplicate name",
-    {
-      tag: "@C2611701",
-    },
-    async ({ roles, yamlImport }) => {
-      const name = `test-impdup-${Date.now()}`;
+  test("import skips role with duplicate name", {
+    tag: "@C2611701",
+  }, async ({ roles, yamlImport }) => {
+    const name = `test-impdup-${Date.now()}`;
 
-      // Create a role first
-      await createRole(roles, name, ["Workspaces:Read"]);
-      await roles.goToList();
-      await roles.table.expectRowWithText(name);
+    // Create a role first
+    await createRole(roles, name, ["Workspaces:Read"]);
+    await roles.goToList();
+    await roles.table.expectRowWithText(name);
 
-      // Import YAML with same name
-      const yaml = `apiVersion: v1
+    // Import YAML with same name
+    const yaml = `apiVersion: v1
 kind: Role
 metadata:
   name: ${name}
@@ -907,61 +804,50 @@ spec:
   permissions:
     - cluster:read`;
 
-      await yamlImport.importYaml(yaml);
-      await yamlImport.expectResults({ success: 0, skipped: 1, errors: 0 });
-      await yamlImport.close();
+    await yamlImport.importYaml(yaml);
+    await yamlImport.expectResults({ success: 0, skipped: 1, errors: 0 });
+    await yamlImport.close();
 
-      // Verify original permissions unchanged (still 1, not 2)
-      await roles.goToList();
-      await expectPermissionCount(roles, name, 1);
+    // Verify original permissions unchanged (still 1, not 2)
+    await roles.goToList();
+    await expectPermissionCount(roles, name, 1);
 
-      // Cleanup
-      await roles.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await roles.table.deleteRow(name, { noWait: true });
+  });
 });
 
 test.describe("roles delete", () => {
-  test(
-    "can delete role from list action menu",
-    {
-      tag: "@C2611721",
-    },
-    async ({ roles }) => {
-      const uniqueName = `test-role-${Date.now()}`;
+  test("can delete role from list action menu", {
+    tag: "@C2611721",
+  }, async ({ roles }) => {
+    const uniqueName = `test-role-${Date.now()}`;
 
-      // Setup
-      await createRole(roles, uniqueName, ["Workspaces:Read"]);
-      await roles.goToList();
-      await roles.table.expectRowWithText(uniqueName);
+    // Setup
+    await createRole(roles, uniqueName, ["Workspaces:Read"]);
+    await roles.goToList();
+    await roles.table.expectRowWithText(uniqueName);
 
-      // Delete from list
-      await roles.table.deleteRow(uniqueName);
-      await roles.table.expectNoRowWithText(uniqueName);
-    },
-  );
+    // Delete from list
+    await roles.table.deleteRow(uniqueName);
+    await roles.table.expectNoRowWithText(uniqueName);
+  });
 
-  test(
-    "can delete role from detail page",
-    {
-      tag: "@C2611722",
-    },
-    async ({ roles }) => {
-      const uniqueName = `test-role-${Date.now()}`;
+  test("can delete role from detail page", {
+    tag: "@C2611722",
+  }, async ({ roles }) => {
+    const uniqueName = `test-role-${Date.now()}`;
 
-      // Setup
-      await createRole(roles, uniqueName, ["Workspaces:Read"]);
+    // Setup
+    await createRole(roles, uniqueName, ["Workspaces:Read"]);
 
-      await roles.goToList();
-      await roles.table.clickRowLink(uniqueName);
-      await expect(
-        roles.page.locator('[data-testid="show-page"]'),
-      ).toBeVisible();
+    await roles.goToList();
+    await roles.table.clickRowLink(uniqueName);
+    await expect(roles.page.locator('[data-testid="show-page"]')).toBeVisible();
 
-      // Delete from detail page
-      await roles.showPageDelete(uniqueName);
-    },
-  );
+    // Delete from detail page
+    await roles.showPageDelete(uniqueName);
+  });
 
   test(
     "admin can delete multiple custom roles",

--- a/e2e/tests/ui-layout.spec.ts
+++ b/e2e/tests/ui-layout.spec.ts
@@ -1,5 +1,6 @@
+import type { Page } from "@playwright/test";
 import { config } from "../config";
-import { expect, type Page, test } from "../fixtures/base";
+import { expect, test } from "../fixtures/base";
 import { DELETE_TIMEOUT, MULTI_USER_TIMEOUT } from "../helpers/constants";
 import { loginAs, logout } from "../helpers/test-user-context";
 
@@ -586,13 +587,23 @@ test.describe("ui layout", () => {
           testUser.page.getByText("Dashboard").first(),
         ).toBeVisible();
 
-        // User without endpoint:read should see 0 endpoints
+        // User without endpoint:read should see 0 endpoints. Dashboard.tsx
+        // renders a "Quick Start" card in place of the endpoint-count card
+        // whenever the (visible) endpoint count is 0, so either the count
+        // card shows "0" or the quick-start card is shown instead — both
+        // confirm no privileged endpoint data is exposed to this user.
         const endpointsCard = testUser.page.locator(
           '[data-testid="dashboard-endpoint-count"]',
         );
-        await expect(endpointsCard.getByText("0")).toBeVisible({
+        const quickStartCard = testUser.page.locator(
+          '[data-testid="dashboard-quick-start"]',
+        );
+        await expect(endpointsCard.or(quickStartCard)).toBeVisible({
           timeout: 10000,
         });
+        if (await endpointsCard.count()) {
+          await expect(endpointsCard.getByText("0")).toBeVisible();
+        }
       },
     );
   });

--- a/e2e/tests/user-profiles.spec.ts
+++ b/e2e/tests/user-profiles.spec.ts
@@ -29,96 +29,70 @@ async function createUser(
 // List
 // ────────────────────────────────────────────────────────────
 test.describe("user profiles list", () => {
-  test(
-    "list page shows expected columns and admin user is visible",
-    {
-      tag: ["@C2611577", "@C2611580", "@C2611728"],
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.waitForLoaded();
+  test("list page shows expected columns and admin user is visible", {
+    tag: ["@C2611577", "@C2611580", "@C2611728"],
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.waitForLoaded();
 
-      const headers = users.table.root.locator("thead th");
-      await expect(headers.filter({ hasText: /name/i })).toBeVisible();
-      await expect(headers.filter({ hasText: /email/i })).toBeVisible();
-      await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
+    const headers = users.table.root.locator("thead th");
+    await expect(headers.filter({ hasText: /name/i })).toBeVisible();
+    await expect(headers.filter({ hasText: /email/i })).toBeVisible();
+    await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
 
-      // Admin user is visible
-      await users.table.expectRowWithText(ADMIN_USER);
-    },
-  );
+    // Admin user is visible
+    await users.table.expectRowWithText(ADMIN_USER);
+  });
 
-  test(
-    "can sort by name",
-    {
-      tag: "@C2611578",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.sort(/name/i);
-    },
-  );
+  test("can sort by name", {
+    tag: "@C2611578",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.sort(/name/i);
+  });
 
-  test(
-    "click name navigates to detail page",
-    {
-      tag: "@C2611579",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.clickRowLink(ADMIN_USER);
+  test("click name navigates to detail page", {
+    tag: "@C2611579",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.clickRowLink(ADMIN_USER);
 
-      await expect(
-        users.page.locator('[data-testid="show-page"]'),
-      ).toBeVisible();
-    },
-  );
+    await expect(users.page.locator('[data-testid="show-page"]')).toBeVisible();
+  });
 
-  test(
-    "can sort by updated time",
-    {
-      tag: "@C2611581",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.sort(/updated/i);
-    },
-  );
+  test("can sort by updated time", {
+    tag: "@C2611581",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.sort(/updated/i);
+  });
 
-  test(
-    "can sort by created time",
-    {
-      tag: "@C2611582",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.waitForLoaded();
+  test("can sort by created time", {
+    tag: "@C2611582",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.waitForLoaded();
 
-      const createdHeader = users.table.headerCell(/created/i);
-      if (!(await createdHeader.isVisible().catch(() => false))) {
-        await users.table.toggleColumn(/created/i);
-      }
+    const createdHeader = users.table.headerCell(/created/i);
+    if (!(await createdHeader.isVisible().catch(() => false))) {
+      await users.table.toggleColumn(/created/i);
+    }
 
-      await users.table.sort(/created/i);
-    },
-  );
+    await users.table.sort(/created/i);
+  });
 
-  test(
-    "can toggle column visibility",
-    {
-      tag: "@C2611583",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.waitForLoaded();
+  test("can toggle column visibility", {
+    tag: "@C2611583",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.waitForLoaded();
 
-      await users.table.toggleColumn(/email/i);
-      await expect(users.table.headerCell(/email/i)).toBeHidden();
+    await users.table.toggleColumn(/email/i);
+    await expect(users.table.headerCell(/email/i)).toBeHidden();
 
-      await users.table.toggleColumn(/email/i);
-      await expect(users.table.headerCell(/email/i)).toBeVisible();
-    },
-  );
+    await users.table.toggleColumn(/email/i);
+    await expect(users.table.headerCell(/email/i)).toBeVisible();
+  });
 });
 
 // ────────────────────────────────────────────────────────────
@@ -226,464 +200,384 @@ test.describe("user profiles create permissions", () => {
 // Create
 // ────────────────────────────────────────────────────────────
 test.describe("user profiles create", () => {
-  test(
-    "admin can create user with all fields and verify in list",
-    {
-      tag: ["@C2579751", "@C2586819"],
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-usr-${ts}`;
-      const email = `test-usr-${ts}@e2e.local`;
+  test("admin can create user with all fields and verify in list", {
+    tag: ["@C2579751", "@C2586819"],
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-usr-${ts}`;
+    const email = `test-usr-${ts}@e2e.local`;
 
-      await createUser(users, name, email, "Test@123456");
+    await createUser(users, name, email, "Test@123456");
 
-      await users.goToList();
-      await users.table.expectRowWithText(name);
+    await users.goToList();
+    await users.table.expectRowWithText(name);
 
-      // Cleanup
-      await users.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await users.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "rejects invalid name format",
-    {
-      tag: "@C2579748",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const email = `test-inv-${ts}@e2e.local`;
+  test("rejects invalid name format", {
+    tag: "@C2579748",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const email = `test-inv-${ts}@e2e.local`;
 
-      // Name with uppercase (invalid k8s name)
-      await users.goToCreate();
-      await users.form.fillInput("name", "INVALID_UPPERCASE");
-      await users.form.fillInput("email", email);
-      await users.form.fillInput("password", "Test@123456");
-      await users.form.fillInput("confirmPassword", "Test@123456");
-      await users.form.submit();
+    // Name with uppercase (invalid k8s name)
+    await users.goToCreate();
+    await users.form.fillInput("name", "INVALID_UPPERCASE");
+    await users.form.fillInput("email", email);
+    await users.form.fillInput("password", "Test@123456");
+    await users.form.fillInput("confirmPassword", "Test@123456");
+    await users.form.submit();
 
-      await expect(
-        users.page.locator('[data-sonner-toast][data-type="error"]'),
-      ).toBeVisible();
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
-    },
-  );
+    await expect(
+      users.page.locator('[data-sonner-toast][data-type="error"]'),
+    ).toBeVisible();
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+  });
 
-  test(
-    "rejects invalid email format",
-    {
-      tag: "@C2579749",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
+  test("rejects invalid email format", {
+    tag: "@C2579749",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
 
-      await users.goToCreate();
-      await users.form.fillInput("name", `test-eml-${ts}`);
-      await users.form.fillInput("email", "not-an-email");
-      await users.form.fillInput("password", "Test@123456");
-      await users.form.fillInput("confirmPassword", "Test@123456");
-      await users.form.submit();
+    await users.goToCreate();
+    await users.form.fillInput("name", `test-eml-${ts}`);
+    await users.form.fillInput("email", "not-an-email");
+    await users.form.fillInput("password", "Test@123456");
+    await users.form.fillInput("confirmPassword", "Test@123456");
+    await users.form.submit();
 
-      // Email input has type="email" so browser validation or backend rejects
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
-    },
-  );
+    // Email input has type="email" so browser validation or backend rejects
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+  });
 
-  test(
-    "rejects password shorter than 6 characters",
-    {
-      tag: ["@C2579750", "@C2586815"],
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
+  test("rejects password shorter than 6 characters", {
+    tag: ["@C2579750", "@C2586815"],
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
 
-      await users.goToCreate();
-      await users.form.fillInput("name", `test-pwd-${ts}`);
-      await users.form.fillInput("email", `test-pwd-${ts}@e2e.local`);
-      await users.form.fillInput("password", "12345");
-      await users.form.fillInput("confirmPassword", "12345");
-      await users.form.submit();
+    await users.goToCreate();
+    await users.form.fillInput("name", `test-pwd-${ts}`);
+    await users.form.fillInput("email", `test-pwd-${ts}@e2e.local`);
+    await users.form.fillInput("password", "12345");
+    await users.form.fillInput("confirmPassword", "12345");
+    await users.form.submit();
 
-      // Client-side validation: minLength 6
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
-    },
-  );
+    // Client-side validation: minLength 6
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+  });
 
-  test(
-    "cancel button returns to list",
-    {
-      tag: "@C2579752",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.clickCreate();
-      await users.form.cancel();
+  test("cancel button returns to list", {
+    tag: "@C2579752",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.clickCreate();
+    await users.form.cancel();
 
-      await users.table.waitForLoaded();
-    },
-  );
+    await users.table.waitForLoaded();
+  });
 
-  test(
-    "missing name or email shows error",
-    {
-      tag: "@C2586812",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToCreate();
-      // Fill only password fields, skip name and email
-      await users.form.fillInput("password", "Test@123456");
-      await users.form.fillInput("confirmPassword", "Test@123456");
-      await users.form.submit();
+  test("missing name or email shows error", {
+    tag: "@C2586812",
+  }, async ({ userProfiles: users }) => {
+    await users.goToCreate();
+    // Fill only password fields, skip name and email
+    await users.form.fillInput("password", "Test@123456");
+    await users.form.fillInput("confirmPassword", "Test@123456");
+    await users.form.submit();
 
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
-    },
-  );
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+  });
 
-  test(
-    "missing password shows error",
-    {
-      tag: "@C2586813",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
+  test("missing password shows error", {
+    tag: "@C2586813",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
 
-      await users.goToCreate();
-      await users.form.fillInput("name", `test-nopwd-${ts}`);
-      await users.form.fillInput("email", `test-nopwd-${ts}@e2e.local`);
-      // Leave password and confirmPassword empty
-      await users.form.submit();
+    await users.goToCreate();
+    await users.form.fillInput("name", `test-nopwd-${ts}`);
+    await users.form.fillInput("email", `test-nopwd-${ts}@e2e.local`);
+    // Leave password and confirmPassword empty
+    await users.form.submit();
 
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
-    },
-  );
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+  });
 
-  test(
-    "password mismatch shows error",
-    {
-      tag: "@C2586814",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
+  test("password mismatch shows error", {
+    tag: "@C2586814",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
 
-      await users.goToCreate();
-      await users.form.fillInput("name", `test-mismatch-${ts}`);
-      await users.form.fillInput("email", `test-mismatch-${ts}@e2e.local`);
-      await users.form.fillInput("password", "Test@123456");
-      await users.form.fillInput("confirmPassword", "Different@789");
-      await users.form.submit();
+    await users.goToCreate();
+    await users.form.fillInput("name", `test-mismatch-${ts}`);
+    await users.form.fillInput("email", `test-mismatch-${ts}@e2e.local`);
+    await users.form.fillInput("password", "Test@123456");
+    await users.form.fillInput("confirmPassword", "Different@789");
+    await users.form.submit();
 
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
-    },
-  );
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+  });
 
-  test(
-    "duplicate name shows error",
-    {
-      tag: "@C2586816",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-dupname-${ts}`;
-      const email1 = `test-dupname1-${ts}@e2e.local`;
-      const email2 = `test-dupname2-${ts}@e2e.local`;
+  test("duplicate name shows error", {
+    tag: "@C2586816",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-dupname-${ts}`;
+    const email1 = `test-dupname1-${ts}@e2e.local`;
+    const email2 = `test-dupname2-${ts}@e2e.local`;
 
-      // Create first user
-      await createUser(users, name, email1, "Test@123456");
-      await users.goToList();
-      await users.table.expectRowWithText(name);
+    // Create first user
+    await createUser(users, name, email1, "Test@123456");
+    await users.goToList();
+    await users.table.expectRowWithText(name);
 
-      // Try to create second with same name
-      await users.goToCreate();
-      await users.form.fillInput("name", name);
-      await users.form.fillInput("email", email2);
-      await users.form.fillInput("password", "Test@123456");
-      await users.form.fillInput("confirmPassword", "Test@123456");
-      await users.form.submit();
+    // Try to create second with same name
+    await users.goToCreate();
+    await users.form.fillInput("name", name);
+    await users.form.fillInput("email", email2);
+    await users.form.fillInput("password", "Test@123456");
+    await users.form.fillInput("confirmPassword", "Test@123456");
+    await users.form.submit();
 
-      await expect(
-        users.page.locator('[data-sonner-toast][data-type="error"]'),
-      ).toBeVisible();
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+    await expect(
+      users.page.locator('[data-sonner-toast][data-type="error"]'),
+    ).toBeVisible();
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
 
-      // Cleanup
-      await users.goToList();
-      await users.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await users.goToList();
+    await users.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "duplicate email shows error",
-    {
-      tag: "@C2586817",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name1 = `test-dupeml1-${ts}`;
-      const name2 = `test-dupeml2-${ts}`;
-      const email = `test-dupeml-${ts}@e2e.local`;
+  test("duplicate email shows error", {
+    tag: "@C2586817",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name1 = `test-dupeml1-${ts}`;
+    const name2 = `test-dupeml2-${ts}`;
+    const email = `test-dupeml-${ts}@e2e.local`;
 
-      // Create first user
-      await createUser(users, name1, email, "Test@123456");
-      await users.goToList();
-      await users.table.expectRowWithText(name1);
+    // Create first user
+    await createUser(users, name1, email, "Test@123456");
+    await users.goToList();
+    await users.table.expectRowWithText(name1);
 
-      // Try to create second with same email
-      await users.goToCreate();
-      await users.form.fillInput("name", name2);
-      await users.form.fillInput("email", email);
-      await users.form.fillInput("password", "Test@123456");
-      await users.form.fillInput("confirmPassword", "Test@123456");
-      await users.form.submit();
+    // Try to create second with same email
+    await users.goToCreate();
+    await users.form.fillInput("name", name2);
+    await users.form.fillInput("email", email);
+    await users.form.fillInput("password", "Test@123456");
+    await users.form.fillInput("confirmPassword", "Test@123456");
+    await users.form.submit();
 
-      await expect(
-        users.page.locator('[data-sonner-toast][data-type="error"]'),
-      ).toBeVisible();
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+    await expect(
+      users.page.locator('[data-sonner-toast][data-type="error"]'),
+    ).toBeVisible();
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
 
-      // Cleanup
-      await users.goToList();
-      await users.table.deleteRow(name1, { noWait: true });
-    },
-  );
+    // Cleanup
+    await users.goToList();
+    await users.table.deleteRow(name1, { noWait: true });
+  });
 
-  test(
-    "after create, admin session is preserved",
-    {
-      tag: "@C2586818",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-sessn-${ts}`;
-      const email = `test-sessn-${ts}@e2e.local`;
+  test("after create, admin session is preserved", {
+    tag: "@C2586818",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-sessn-${ts}`;
+    const email = `test-sessn-${ts}@e2e.local`;
 
-      await createUser(users, name, email, "Test@123456");
+    await createUser(users, name, email, "Test@123456");
 
-      // After creation, the admin user dropdown still shows "admin"
-      await expect(
-        users.page.getByRole("button", { name: /admin/i }),
-      ).toBeVisible();
+    // After creation, the admin user dropdown still shows "admin"
+    await expect(
+      users.page.getByRole("button", { name: /admin/i }),
+    ).toBeVisible();
 
-      // Cleanup
-      await users.goToList();
-      await users.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await users.goToList();
+    await users.table.deleteRow(name, { noWait: true });
+  });
 });
 
 // ────────────────────────────────────────────────────────────
 // Detail
 // ────────────────────────────────────────────────────────────
 test.describe("user profiles detail", () => {
-  test(
-    "detail page shows user info, Global Roles, and Joined Workspaces",
-    {
-      tag: "@C2611604",
-    },
-    async ({ userProfiles: users }) => {
+  test("detail page shows user info, Global Roles, and Joined Workspaces", {
+    tag: "@C2611604",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.clickRowLink(ADMIN_USER);
+
+    const showPage = users.page.locator('[data-testid="show-page"]');
+    await expect(showPage).toBeVisible();
+
+    // Name visible (use .first() — "admin" also appears as a role link)
+    await expect(
+      showPage.getByText(ADMIN_USER, { exact: true }).first(),
+    ).toBeVisible();
+    await expect(showPage.getByText(/@/)).toBeVisible();
+
+    // Global Roles section
+    await expect(showPage.getByText(/global roles/i)).toBeVisible();
+    // Joined Workspaces section
+    await expect(showPage.getByText(/joined workspaces/i)).toBeVisible();
+  });
+
+  test("Global Role link navigates to role detail", {
+    tag: "@C2611608",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.clickRowLink(ADMIN_USER);
+
+    const showPage = users.page.locator('[data-testid="show-page"]');
+    await expect(showPage).toBeVisible();
+
+    // Click the "admin" role link in the Global Roles card
+    await showPage
+      .locator('[data-testid="global-roles-card"]')
+      .getByRole("link", { name: "admin" })
+      .click();
+    await expect(users.page.locator('[data-testid="show-page"]')).toBeVisible();
+    // Should navigate to role detail page
+    await expect(users.page).toHaveURL(/\/#\/roles\/show\//);
+  });
+
+  test("multiple Global Roles displayed for user with multiple roles", {
+    tag: "@C2611609",
+  }, async ({ userProfiles: users, apiHelper }) => {
+    const testData = await apiHelper.createTestUserData(["workspace:read"]);
+
+    // Also create a second policy linking to the built-in admin role
+    const policyName2 = `test-pol2-${Date.now()}`;
+    await apiHelper.createPolicy(policyName2, testData.userId, "admin", true);
+
+    try {
       await users.goToList();
-      await users.table.clickRowLink(ADMIN_USER);
+      await users.table.clickRowLink(testData.userName);
 
       const showPage = users.page.locator('[data-testid="show-page"]');
       await expect(showPage).toBeVisible();
 
-      // Name visible (use .first() — "admin" also appears as a role link)
-      await expect(
-        showPage.getByText(ADMIN_USER, { exact: true }).first(),
-      ).toBeVisible();
-      await expect(showPage.getByText(/@/)).toBeVisible();
-
-      // Global Roles section
-      await expect(showPage.getByText(/global roles/i)).toBeVisible();
-      // Joined Workspaces section
-      await expect(showPage.getByText(/joined workspaces/i)).toBeVisible();
-    },
-  );
-
-  test(
-    "Global Role link navigates to role detail",
-    {
-      tag: "@C2611608",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.clickRowLink(ADMIN_USER);
-
-      const showPage = users.page.locator('[data-testid="show-page"]');
-      await expect(showPage).toBeVisible();
-
-      // Click the "admin" role link in the Global Roles card
-      await showPage
-        .locator('[data-testid="global-roles-card"]')
-        .getByRole("link", { name: "admin" })
-        .click();
-      await expect(
-        users.page.locator('[data-testid="show-page"]'),
-      ).toBeVisible();
-      // Should navigate to role detail page
-      await expect(users.page).toHaveURL(/\/#\/roles\/show\//);
-    },
-  );
-
-  test(
-    "multiple Global Roles displayed for user with multiple roles",
-    {
-      tag: "@C2611609",
-    },
-    async ({ userProfiles: users, apiHelper }) => {
-      const testData = await apiHelper.createTestUserData(["workspace:read"]);
-
-      // Also create a second policy linking to the built-in admin role
-      const policyName2 = `test-pol2-${Date.now()}`;
-      await apiHelper.createPolicy(policyName2, testData.userId, "admin", true);
-
-      try {
-        await users.goToList();
-        await users.table.clickRowLink(testData.userName);
-
-        const showPage = users.page.locator('[data-testid="show-page"]');
-        await expect(showPage).toBeVisible();
-
-        // Both roles should appear in the Global Roles table
-        await expect(showPage.getByText(testData.roleName)).toBeVisible();
-        await expect(showPage.getByText("admin")).toBeVisible();
-      } finally {
-        await apiHelper.deletePolicy(policyName2).catch(() => {});
-        await testData.cleanup();
-      }
-    },
-  );
+      // Both roles should appear in the Global Roles table
+      await expect(showPage.getByText(testData.roleName)).toBeVisible();
+      await expect(showPage.getByText("admin")).toBeVisible();
+    } finally {
+      await apiHelper.deletePolicy(policyName2).catch(() => {});
+      await testData.cleanup();
+    }
+  });
 });
 
 // ────────────────────────────────────────────────────────────
 // Edit
 // ────────────────────────────────────────────────────────────
 test.describe("user profiles edit", () => {
-  test(
-    "admin can edit user email and verify",
-    {
-      tag: ["@C2611619", "@C2611730"],
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-edteml-${ts}`;
-      const email = `test-edteml-${ts}@e2e.local`;
-      const newEmail = `test-edteml-new-${ts}@e2e.local`;
+  test("admin can edit user email and verify", {
+    tag: ["@C2611619", "@C2611730"],
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-edteml-${ts}`;
+    const email = `test-edteml-${ts}@e2e.local`;
+    const newEmail = `test-edteml-new-${ts}@e2e.local`;
 
-      await createUser(users, name, email, "Test@123456");
-      await users.goToList();
-      await users.table.expectRowWithText(name);
+    await createUser(users, name, email, "Test@123456");
+    await users.goToList();
+    await users.table.expectRowWithText(name);
 
-      // Edit from list — wait for form data to load before modifying
-      await users.table.editRow(name);
-      await expect(
-        users.page.locator('[data-testid="form-submit"]'),
-      ).toBeEnabled();
+    // Edit from list — wait for form data to load before modifying
+    await users.table.editRow(name);
+    await expect(
+      users.page.locator('[data-testid="form-submit"]'),
+    ).toBeEnabled();
 
-      await users.form.fillInput("spec.email", newEmail);
-      await users.form.submit();
+    await users.form.fillInput("spec.email", newEmail);
+    await users.form.submit();
 
-      // Verify new email in list
-      await users.goToList();
-      await users.table.expectRowWithText(newEmail);
+    // Verify new email in list
+    await users.goToList();
+    await users.table.expectRowWithText(newEmail);
 
-      // Cleanup
-      await users.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await users.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "can edit from list action menu",
-    {
-      tag: "@C2611620",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-edtlst-${ts}`;
-      const email = `test-edtlst-${ts}@e2e.local`;
+  test("can edit from list action menu", {
+    tag: "@C2611620",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-edtlst-${ts}`;
+    const email = `test-edtlst-${ts}@e2e.local`;
 
-      await createUser(users, name, email, "Test@123456");
-      await users.goToList();
-      await users.table.expectRowWithText(name);
+    await createUser(users, name, email, "Test@123456");
+    await users.goToList();
+    await users.table.expectRowWithText(name);
 
-      await users.table.editRow(name);
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+    await users.table.editRow(name);
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
 
-      await users.form.submit();
+    await users.form.submit();
 
-      // Cleanup
-      await users.goToList();
-      await users.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await users.goToList();
+    await users.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "can edit from detail page action menu",
-    {
-      tag: "@C2611621",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-edtdtl-${ts}`;
-      const email = `test-edtdtl-${ts}@e2e.local`;
+  test("can edit from detail page action menu", {
+    tag: "@C2611621",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-edtdtl-${ts}`;
+    const email = `test-edtdtl-${ts}@e2e.local`;
 
-      await createUser(users, name, email, "Test@123456");
-      await users.goToList();
-      await users.table.clickRowLink(name);
-      await expect(
-        users.page.locator('[data-testid="show-page"]'),
-      ).toBeVisible();
+    await createUser(users, name, email, "Test@123456");
+    await users.goToList();
+    await users.table.clickRowLink(name);
+    await expect(users.page.locator('[data-testid="show-page"]')).toBeVisible();
 
-      await users.showPageEdit();
-      await users.form.submit();
+    await users.showPageEdit();
+    await users.form.submit();
 
-      // Cleanup
-      await users.goToList();
-      await users.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await users.goToList();
+    await users.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "name field is readonly in edit mode",
-    {
-      tag: "@C2611622",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-rdonly-${ts}`;
-      const email = `test-rdonly-${ts}@e2e.local`;
+  test("name field is readonly in edit mode", {
+    tag: "@C2611622",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-rdonly-${ts}`;
+    const email = `test-rdonly-${ts}@e2e.local`;
 
-      await createUser(users, name, email, "Test@123456");
-      await users.goToList();
-      await users.table.editRow(name);
+    await createUser(users, name, email, "Test@123456");
+    await users.goToList();
+    await users.table.editRow(name);
 
-      const nameInput = users.form.field("metadata.name").locator("input");
-      await expect(nameInput).toBeDisabled();
+    const nameInput = users.form.field("metadata.name").locator("input");
+    await expect(nameInput).toBeDisabled();
 
-      // Cleanup
-      await users.form.cancel();
-      await users.table.deleteRow(name, { noWait: true });
-    },
-  );
+    // Cleanup
+    await users.form.cancel();
+    await users.table.deleteRow(name, { noWait: true });
+  });
 
-  test(
-    "admin can edit own email",
-    {
-      tag: "@C2611625",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.editRow(ADMIN_USER);
+  test("admin can edit own email", {
+    tag: "@C2611625",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.editRow(ADMIN_USER);
 
-      await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
-      const nameInput = users.form.field("metadata.name").locator("input");
-      await expect(nameInput).toHaveValue(ADMIN_USER);
-      await expect(nameInput).toBeDisabled();
+    await expect(users.page.locator('[data-testid="form"]')).toBeVisible();
+    const nameInput = users.form.field("metadata.name").locator("input");
+    await expect(nameInput).toHaveValue(ADMIN_USER);
+    await expect(nameInput).toBeDisabled();
 
-      // Just verify the edit form loads — don't actually change admin email
-      await users.form.cancel();
-    },
-  );
+    // Just verify the edit form loads — don't actually change admin email
+    await users.form.cancel();
+  });
 
   test(
     "non-admin with user_profile:update can edit email",
@@ -738,142 +632,120 @@ test.describe("user profiles edit", () => {
 test.describe("user profiles edit email login", () => {
   // Backend does NOT sync spec.email to Supabase auth email.
   // Login always uses the original email set at creation time.
-  test.skip(
-    "login works with new email and fails with old email after email change",
-    {
-      tag: ["@C2611628", "@C2611629"],
-    },
-    async () => {
-      // Skipped: spec.email is a profile field only; Supabase auth email
-      // is unchanged by editing the user profile, so login always uses
-      // the original email.
-    },
-  );
+  test.skip("login works with new email and fails with old email after email change", {
+    tag: ["@C2611628", "@C2611629"],
+  }, async () => {
+    // Skipped: spec.email is a profile field only; Supabase auth email
+    // is unchanged by editing the user profile, so login always uses
+    // the original email.
+  });
 });
 
 // ────────────────────────────────────────────────────────────
 // Delete
 // ────────────────────────────────────────────────────────────
 test.describe("user profiles delete", () => {
-  test(
-    "admin can delete user from list action menu",
-    {
-      tag: ["@C2611633", "@C2611634", "@C2611732"],
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-dellst-${ts}`;
-      const email = `test-dellst-${ts}@e2e.local`;
+  test("admin can delete user from list action menu", {
+    tag: ["@C2611633", "@C2611634", "@C2611732"],
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-dellst-${ts}`;
+    const email = `test-dellst-${ts}@e2e.local`;
 
-      await createUser(users, name, email, "Test@123456");
-      await users.goToList();
-      await users.table.expectRowWithText(name);
+    await createUser(users, name, email, "Test@123456");
+    await users.goToList();
+    await users.table.expectRowWithText(name);
 
-      await users.table.deleteRow(name);
-      await users.table.expectNoRowWithText(name);
-    },
-  );
+    await users.table.deleteRow(name);
+    await users.table.expectNoRowWithText(name);
+  });
 
-  test(
-    "admin can delete user from detail page",
-    {
-      tag: "@C2611635",
-    },
-    async ({ userProfiles: users }) => {
-      const ts = Date.now();
-      const name = `test-deldtl-${ts}`;
-      const email = `test-deldtl-${ts}@e2e.local`;
+  test("admin can delete user from detail page", {
+    tag: "@C2611635",
+  }, async ({ userProfiles: users }) => {
+    const ts = Date.now();
+    const name = `test-deldtl-${ts}`;
+    const email = `test-deldtl-${ts}@e2e.local`;
 
-      await createUser(users, name, email, "Test@123456");
-      await users.goToList();
-      await users.table.clickRowLink(name);
-      await expect(
-        users.page.locator('[data-testid="show-page"]'),
-      ).toBeVisible();
+    await createUser(users, name, email, "Test@123456");
+    await users.goToList();
+    await users.table.clickRowLink(name);
+    await expect(users.page.locator('[data-testid="show-page"]')).toBeVisible();
 
-      // Manual delete flow — showPageDelete uses table.waitForLoaded which
-      // fails on user show page (2 sub-tables: Global Roles + Joined Workspaces)
-      await users.page.locator('[data-testid="show-actions-trigger"]').click();
-      await users.page.getByRole("menuitem", { name: /delete/i }).click();
-      const dialog = users.page.getByRole("alertdialog");
-      await dialog.waitFor({ state: "visible" });
-      await dialog.getByRole("button", { name: /delete/i }).click();
-      await dialog.waitFor({ state: "hidden" });
+    // Manual delete flow — showPageDelete uses table.waitForLoaded which
+    // fails on user show page (2 sub-tables: Global Roles + Joined Workspaces)
+    await users.page.locator('[data-testid="show-actions-trigger"]').click();
+    await users.page.getByRole("menuitem", { name: /delete/i }).click();
+    const dialog = users.page.getByRole("alertdialog");
+    await dialog.waitFor({ state: "visible" });
+    await dialog.getByRole("button", { name: /delete/i }).click();
+    await dialog.waitFor({ state: "hidden" });
 
-      // Navigate to list — wait for show page to unmount before checking table
-      // (user show page has 2 sub-tables that conflict with table.waitForLoaded)
-      await users.page.goto("/#/user-profiles");
-      await users.page
-        .locator('[data-testid="show-page"]')
-        .waitFor({ state: "detached" });
-      await users.table.waitForLoaded();
-      await users.table.expectNoRowWithText(name, { timeout: DELETE_TIMEOUT });
-    },
-  );
+    // Navigate to list — wait for show page to unmount before checking table
+    // (user show page has 2 sub-tables that conflict with table.waitForLoaded)
+    await users.page.goto("/#/user-profiles");
+    await users.page
+      .locator('[data-testid="show-page"]')
+      .waitFor({ state: "detached" });
+    await users.table.waitForLoaded();
+    await users.table.expectNoRowWithText(name, { timeout: DELETE_TIMEOUT });
+  });
 
-  test(
-    "cannot delete self (admin user)",
-    {
-      tag: "@C2611650",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.waitForLoaded();
+  test("cannot delete self (admin user)", {
+    tag: "@C2611650",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.waitForLoaded();
 
-      // Attempt to delete admin from list
-      await users.table
-        .rowWithText(ADMIN_USER)
-        .locator('[data-testid="row-actions-trigger"]')
-        .click();
-      await users.page.locator('[role="menu"]').waitFor({ state: "visible" });
-      await users.page.getByRole("menuitem", { name: /delete/i }).click();
+    // Attempt to delete admin from list
+    await users.table
+      .rowWithText(ADMIN_USER)
+      .locator('[data-testid="row-actions-trigger"]')
+      .click();
+    await users.page.locator('[role="menu"]').waitFor({ state: "visible" });
+    await users.page.getByRole("menuitem", { name: /delete/i }).click();
 
-      const dialog = users.page.getByRole("alertdialog");
-      await dialog.waitFor({ state: "visible" });
-      await dialog.getByRole("button", { name: /delete/i }).click();
+    const dialog = users.page.getByRole("alertdialog");
+    await dialog.waitFor({ state: "visible" });
+    await dialog.getByRole("button", { name: /delete/i }).click();
 
-      // Expect an error toast — backend rejects self-delete
-      await expect(
-        users.page.locator('[data-sonner-toast][data-type="error"]'),
-      ).toBeVisible();
+    // Expect an error toast — backend rejects self-delete
+    await expect(
+      users.page.locator('[data-sonner-toast][data-type="error"]'),
+    ).toBeVisible();
 
-      // Admin should still be in the list
-      await dialog.waitFor({ state: "hidden" });
-      await users.table.expectRowWithText(ADMIN_USER);
-    },
-  );
+    // Admin should still be in the list
+    await dialog.waitFor({ state: "hidden" });
+    await users.table.expectRowWithText(ADMIN_USER);
+  });
 
-  test(
-    "cannot delete admin user",
-    {
-      tag: "@C2611639",
-    },
-    async ({ userProfiles: users }) => {
-      await users.goToList();
-      await users.table.waitForLoaded();
+  test("cannot delete admin user", {
+    tag: "@C2611639",
+  }, async ({ userProfiles: users }) => {
+    await users.goToList();
+    await users.table.waitForLoaded();
 
-      // For admin user, "cannot delete self" and "cannot delete admin" overlap.
-      // This test verifies that the admin user row still has actions but
-      // delete fails. The backend returns an error for admin user deletion.
-      await users.table
-        .rowWithText(ADMIN_USER)
-        .locator('[data-testid="row-actions-trigger"]')
-        .click();
-      await users.page.locator('[role="menu"]').waitFor({ state: "visible" });
-      await users.page.getByRole("menuitem", { name: /delete/i }).click();
+    // For admin user, "cannot delete self" and "cannot delete admin" overlap.
+    // This test verifies that the admin user row still has actions but
+    // delete fails. The backend returns an error for admin user deletion.
+    await users.table
+      .rowWithText(ADMIN_USER)
+      .locator('[data-testid="row-actions-trigger"]')
+      .click();
+    await users.page.locator('[role="menu"]').waitFor({ state: "visible" });
+    await users.page.getByRole("menuitem", { name: /delete/i }).click();
 
-      const dialog = users.page.getByRole("alertdialog");
-      await dialog.waitFor({ state: "visible" });
-      await dialog.getByRole("button", { name: /delete/i }).click();
+    const dialog = users.page.getByRole("alertdialog");
+    await dialog.waitFor({ state: "visible" });
+    await dialog.getByRole("button", { name: /delete/i }).click();
 
-      await expect(
-        users.page.locator('[data-sonner-toast][data-type="error"]'),
-      ).toBeVisible();
+    await expect(
+      users.page.locator('[data-sonner-toast][data-type="error"]'),
+    ).toBeVisible();
 
-      await dialog.waitFor({ state: "hidden" });
-      await users.table.expectRowWithText(ADMIN_USER);
-    },
-  );
+    await dialog.waitFor({ state: "hidden" });
+    await users.table.expectRowWithText(ADMIN_USER);
+  });
 
   test(
     "delete fails when user has associated workspace policies",
@@ -1096,16 +968,15 @@ test.describe("user profiles login", () => {
 
       await apiHelper.createUser(name, email, password);
 
+      let context: Awaited<ReturnType<typeof loginAs>>["context"] | undefined;
       try {
-        const { page, context } = await loginAs(
-          browser,
-          apiHelper,
-          email,
-          password,
-        );
-        await expect(page).toHaveURL(/\/#\/dashboard/);
-        await context.close();
+        const loggedIn = await loginAs(browser, apiHelper, email, password);
+        context = loggedIn.context;
+        await expect(loggedIn.page).toHaveURL(/\/#\/dashboard/);
       } finally {
+        // Close even on assertion failure — an unclosed context otherwise
+        // leaks for the rest of the run.
+        await context?.close();
         await apiHelper.deleteUser(name).catch(() => {});
       }
     },
@@ -1130,19 +1001,19 @@ test.describe("user profiles login", () => {
 
       await apiHelper.createUser(name, email, password);
 
+      let context: Awaited<ReturnType<typeof loginAs>>["context"] | undefined;
       try {
-        const { page, context } = await loginAs(
-          browser,
-          apiHelper,
-          email,
-          password,
-        );
+        const loggedIn = await loginAs(browser, apiHelper, email, password);
+        context = loggedIn.context;
 
         // Username should appear in the user dropdown trigger button
-        await expect(page.getByRole("button", { name: name })).toBeVisible();
-
-        await context.close();
+        await expect(
+          loggedIn.page.getByRole("button", { name: name }),
+        ).toBeVisible();
       } finally {
+        // Close even on assertion failure — an unclosed context otherwise
+        // leaks for the rest of the run.
+        await context?.close();
         await apiHelper.deleteUser(name).catch(() => {});
       }
     },
@@ -1173,13 +1044,11 @@ test.describe("user profiles password change", () => {
 
       await apiHelper.createUser(name, email, oldPassword);
 
+      let context: Awaited<ReturnType<typeof loginAs>>["context"] | undefined;
       try {
-        const { page, context } = await loginAs(
-          browser,
-          apiHelper,
-          email,
-          oldPassword,
-        );
+        const loggedIn = await loginAs(browser, apiHelper, email, oldPassword);
+        context = loggedIn.context;
+        const { page } = loggedIn;
 
         // Change password
         await page.goto("/#/update-password");
@@ -1199,10 +1068,14 @@ test.describe("user profiles password change", () => {
         await page.locator('input[name="password"]').fill(newPassword);
         await page.getByRole("button", { name: /sign in/i }).click();
         await page.waitForURL("**/#/dashboard");
-
-        await context.close();
       } finally {
-        await apiHelper.deleteUser(name).catch(() => {});
+        // Close even on assertion failure — an unclosed context otherwise
+        // leaks for the rest of the run.
+        await context?.close();
+        // Retry: the finalizer may not have released dependent rows yet,
+        // and this account must not survive to interfere with later runs
+        // (it now holds the *changed* password, not the nominal one).
+        await apiHelper.deleteUser(name, { retries: 5 }).catch(() => {});
       }
     },
   );
@@ -1228,13 +1101,11 @@ test.describe("user profiles password change", () => {
 
       await apiHelper.createUser(name, email, oldPassword);
 
+      let context: Awaited<ReturnType<typeof loginAs>>["context"] | undefined;
       try {
-        const { page, context } = await loginAs(
-          browser,
-          apiHelper,
-          email,
-          oldPassword,
-        );
+        const loggedIn = await loginAs(browser, apiHelper, email, oldPassword);
+        context = loggedIn.context;
+        const { page } = loggedIn;
 
         // Change password
         await page.goto("/#/update-password");
@@ -1258,10 +1129,14 @@ test.describe("user profiles password change", () => {
         await expect(
           page.getByText(/invalid|error|incorrect|unauthorized/i).first(),
         ).toBeVisible();
-
-        await context.close();
       } finally {
-        await apiHelper.deleteUser(name).catch(() => {});
+        // Close even on assertion failure — an unclosed context otherwise
+        // leaks for the rest of the run.
+        await context?.close();
+        // Retry: the finalizer may not have released dependent rows yet,
+        // and this account must not survive to interfere with later runs
+        // (it now holds the *changed* password, not the nominal one).
+        await apiHelper.deleteUser(name, { retries: 5 }).catch(() => {});
       }
     },
   );

--- a/e2e/tests/workspaces.spec.ts
+++ b/e2e/tests/workspaces.spec.ts
@@ -6,88 +6,64 @@ import { ResourcePage } from "../helpers/resource-page";
 const DEFAULT_WORKSPACE = "default";
 
 test.describe("workspaces list", () => {
-  test(
-    "list page shows expected columns and default workspace",
-    {
-      tag: "@C2611793",
-    },
-    async ({ workspaces }) => {
-      await workspaces.goToList();
+  test("list page shows expected columns and default workspace", {
+    tag: "@C2611793",
+  }, async ({ workspaces }) => {
+    await workspaces.goToList();
 
-      const headers = workspaces.table.root.locator("thead th");
-      await expect(headers.filter({ hasText: /name/i })).toBeVisible();
-      await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
+    const headers = workspaces.table.root.locator("thead th");
+    await expect(headers.filter({ hasText: /name/i })).toBeVisible();
+    await expect(headers.filter({ hasText: /updated/i })).toBeVisible();
 
-      // Default workspace should be visible
-      await workspaces.table.expectRowWithText(DEFAULT_WORKSPACE);
-    },
-  );
+    // Default workspace should be visible
+    await workspaces.table.expectRowWithText(DEFAULT_WORKSPACE);
+  });
 
-  test(
-    "can sort by name",
-    {
-      tag: "@C2611797",
-    },
-    async ({ workspaces }) => {
-      await workspaces.goToList();
-      await workspaces.table.sort(/name/i);
-    },
-  );
+  test("can sort by name", {
+    tag: "@C2611797",
+  }, async ({ workspaces }) => {
+    await workspaces.goToList();
+    await workspaces.table.sort(/name/i);
+  });
 
-  test(
-    "updated at column visible and sortable",
-    {
-      tag: "@C2611798",
-    },
-    async ({ workspaces }) => {
-      await workspaces.goToList();
-      await expect(workspaces.table.headerCell(/updated/i)).toBeVisible();
-      await workspaces.table.sort(/updated/i);
-    },
-  );
+  test("updated at column visible and sortable", {
+    tag: "@C2611798",
+  }, async ({ workspaces }) => {
+    await workspaces.goToList();
+    await expect(workspaces.table.headerCell(/updated/i)).toBeVisible();
+    await workspaces.table.sort(/updated/i);
+  });
 
-  test(
-    "created at column visible and sortable",
-    {
-      tag: "@C2611799",
-    },
-    async ({ workspaces }) => {
-      await workspaces.goToList();
-      await expect(workspaces.table.headerCell(/created/i)).toBeVisible();
-      await workspaces.table.sort(/created/i);
-    },
-  );
+  test("created at column visible and sortable", {
+    tag: "@C2611799",
+  }, async ({ workspaces }) => {
+    await workspaces.goToList();
+    await expect(workspaces.table.headerCell(/created/i)).toBeVisible();
+    await workspaces.table.sort(/created/i);
+  });
 
-  test(
-    "can toggle column visibility",
-    {
-      tag: "@C2611800",
-    },
-    async ({ workspaces }) => {
-      await workspaces.goToList();
-      // Created At is visible by default
-      await expect(workspaces.table.headerCell(/created/i)).toBeVisible();
-      // Toggle it hidden
-      await workspaces.table.toggleColumn(/created/i);
-      await expect(workspaces.table.headerCell(/created/i)).toBeHidden();
-      // Toggle it visible again
-      await workspaces.table.toggleColumn(/created/i);
-      await expect(workspaces.table.headerCell(/created/i)).toBeVisible();
-    },
-  );
+  test("can toggle column visibility", {
+    tag: "@C2611800",
+  }, async ({ workspaces }) => {
+    await workspaces.goToList();
+    // Created At is visible by default
+    await expect(workspaces.table.headerCell(/created/i)).toBeVisible();
+    // Toggle it hidden
+    await workspaces.table.toggleColumn(/created/i);
+    await expect(workspaces.table.headerCell(/created/i)).toBeHidden();
+    // Toggle it visible again
+    await workspaces.table.toggleColumn(/created/i);
+    await expect(workspaces.table.headerCell(/created/i)).toBeVisible();
+  });
 
-  test(
-    "admin can see all workspaces",
-    {
-      tag: "@C2611813",
-    },
-    async ({ workspaces }) => {
-      await workspaces.goToList();
-      const rowCount = await workspaces.table.rows().count();
-      expect(rowCount).toBeGreaterThan(0);
-      await workspaces.table.expectRowWithText(DEFAULT_WORKSPACE);
-    },
-  );
+  test("admin can see all workspaces", {
+    tag: "@C2611813",
+  }, async ({ workspaces }) => {
+    await workspaces.goToList();
+    const rowCount = await workspaces.table.rows().count();
+    expect(rowCount).toBeGreaterThan(0);
+    await workspaces.table.expectRowWithText(DEFAULT_WORKSPACE);
+  });
 
   test(
     "non-admin with workspace:read can see workspaces",
@@ -140,18 +116,14 @@ test.describe("workspaces list", () => {
 });
 
 test.describe("workspace create", () => {
-  test(
-    "open source license limits max 1 workspace — server rejects second",
-    {
-      tag: "@C2611828",
-    },
-    async ({ workspaces }) => {
+  test("open source license limits max 1 workspace — server rejects second", {
+    tag: "@C2611828",
+  }, async ({ workspaces, apiHelper }) => {
+    const name = `test-ws-oslimit-${Date.now()}`;
+    try {
       await workspaces.goToCreate();
 
-      await workspaces.form.fillInput(
-        "metadata.name",
-        `test-ws-oslimit-${Date.now()}`,
-      );
+      await workspaces.form.fillInput("metadata.name", name);
 
       const responsePromise = workspaces.page.waitForResponse(
         (r) =>
@@ -167,58 +139,55 @@ test.describe("workspace create", () => {
       await expect(
         workspaces.page.locator('[data-testid="form"]'),
       ).toBeVisible();
-    },
-  );
+    } finally {
+      // No-op if the create was rejected (OSS) — the workspace never
+      // existed. On enterprise CPs where creation succeeded, this
+      // removes the orphan so it doesn't pollute later runs.
+      await apiHelper.deleteWorkspace(name).catch(() => {});
+    }
+  });
 
-  test(
-    "delete workspace from list action menu with confirmation",
-    {
-      tag: "@C2611831",
-    },
-    async ({ workspaces, apiHelper }) => {
-      const name = `test-ws-del-${Date.now()}`;
-      try {
-        await apiHelper.createWorkspace(name);
-      } catch {
-        // Open-source license limits to 1 workspace — skip when creation is blocked
-        test.skip(true, "workspace creation blocked by license limit");
-        return;
-      }
+  test("delete workspace from list action menu with confirmation", {
+    tag: "@C2611831",
+  }, async ({ workspaces, apiHelper }) => {
+    const name = `test-ws-del-${Date.now()}`;
+    try {
+      await apiHelper.createWorkspace(name);
+    } catch {
+      // Open-source license limits to 1 workspace — skip when creation is blocked
+      test.skip(true, "workspace creation blocked by license limit");
+      return;
+    }
 
-      await workspaces.goToList();
-      await workspaces.table.deleteRow(name);
-    },
-  );
+    await workspaces.goToList();
+    await workspaces.table.deleteRow(name);
+  });
 });
 
 test.describe("workspaces detail", () => {
-  test(
-    "show page displays name, created at, updated at, and workspace policies section",
-    {
-      tag: "@C2611803",
-    },
-    async ({ workspaces }) => {
-      await workspaces.goToShow(DEFAULT_WORKSPACE);
+  test("show page displays name, created at, updated at, and workspace policies section", {
+    tag: "@C2611803",
+  }, async ({ workspaces }) => {
+    await workspaces.goToShow(DEFAULT_WORKSPACE);
 
-      const showPage = workspaces.page.locator('[data-testid="show-page"]');
-      await expect(showPage).toBeVisible();
+    const showPage = workspaces.page.locator('[data-testid="show-page"]');
+    await expect(showPage).toBeVisible();
 
-      // Verify workspace name is displayed
-      await expect(
-        showPage.getByText(DEFAULT_WORKSPACE, { exact: true }),
-      ).toBeVisible();
+    // Verify workspace name is displayed
+    await expect(
+      showPage.getByText(DEFAULT_WORKSPACE, { exact: true }),
+    ).toBeVisible();
 
-      // Verify timestamps are displayed (scope to metadata card <dt> elements
-      // to avoid strict mode violation with the policies table header)
-      await expect(
-        showPage.getByRole("term").filter({ hasText: /created at/i }),
-      ).toBeVisible();
-      await expect(
-        showPage.getByRole("term").filter({ hasText: /updated at/i }),
-      ).toBeVisible();
+    // Verify timestamps are displayed (scope to metadata card <dt> elements
+    // to avoid strict mode violation with the policies table header)
+    await expect(
+      showPage.getByRole("term").filter({ hasText: /created at/i }),
+    ).toBeVisible();
+    await expect(
+      showPage.getByRole("term").filter({ hasText: /updated at/i }),
+    ).toBeVisible();
 
-      // Verify workspace policies section exists
-      await expect(showPage.locator('[data-testid="table"]')).toBeVisible();
-    },
-  );
+    // Verify workspace policies section exists
+    await expect(showPage.locator('[data-testid="table"]')).toBeVisible();
+  });
 });

--- a/e2e/tests/yaml-export.spec.ts
+++ b/e2e/tests/yaml-export.spec.ts
@@ -56,36 +56,28 @@ test.describe("yaml export", () => {
   // Selection tests
   // ────────────────────────────────────────────────────────────
   test.describe("selection", () => {
-    test(
-      "export disabled when nothing selected",
-      {
-        tag: "@C2611903",
-      },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
-        await yamlExport.expectGenerateDisabled();
-        await yamlExport.close();
-      },
-    );
+    test("export disabled when nothing selected", {
+      tag: "@C2611903",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
+      await yamlExport.expectGenerateDisabled();
+      await yamlExport.close();
+    });
 
-    test(
-      "select all selects all resource types",
-      {
-        tag: "@C2611888",
-      },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("select all selects all resource types", {
+      tag: "@C2611888",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        await yamlExport.selectAll();
+      await yamlExport.selectAll();
 
-        // Generate should be enabled now
-        await yamlExport.expectGenerateEnabled();
+      // Generate should be enabled now
+      await yamlExport.expectGenerateEnabled();
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
 
     // Resource type expansion tests: expand each type and verify entities or "No entities"
     for (const [index, label] of RESOURCE_LABELS.entries()) {
@@ -102,38 +94,38 @@ test.describe("yaml export", () => {
         "@C2611902",
       ];
 
-      test(
-        `can expand ${label} resource type`,
-        {
-          tag: caseIds[index],
-        },
-        async ({ yamlExport, page }) => {
-          await page.goto("/#/dashboard");
-          await yamlExport.open();
+      test(`can expand ${label} resource type`, {
+        tag: caseIds[index],
+      }, async ({ yamlExport, page }) => {
+        await page.goto("/#/dashboard");
+        await yamlExport.open();
 
-          await yamlExport.expandResource(label);
+        await yamlExport.expandResource(label);
 
-          // Should show either entities or "No entities found"
-          const dialog = page.getByRole("dialog");
-          const resourceRow = dialog.locator(".border.rounded-lg", {
-            hasText: label,
-          });
+        // Should show either entities or "No entities found"
+        // Use an exact-text filter, not substring `hasText`: some resource
+        // titles are substrings of others (e.g. "Endpoints" is contained in
+        // "External Endpoints"), which would otherwise match two rows and
+        // trigger a Playwright strict-mode violation.
+        const dialog = page.getByRole("dialog");
+        const resourceRow = dialog
+          .locator(".border.rounded-lg")
+          .filter({ has: page.getByText(label, { exact: true }) });
 
-          // Wait for loading to finish
-          await expect(resourceRow.getByText(/loading/i)).toBeHidden({
-            timeout: ASYNC_UI_TIMEOUT,
-          });
+        // Wait for loading to finish
+        await expect(resourceRow.getByText(/loading/i)).toBeHidden({
+          timeout: ASYNC_UI_TIMEOUT,
+        });
 
-          // Either has entity names or "No entities found"
-          const hasNoEntities = await yamlExport.hasNoEntities(label);
-          if (!hasNoEntities) {
-            const names = await yamlExport.getEntityNames(label);
-            expect(names.length).toBeGreaterThan(0);
-          }
+        // Either has entity names or "No entities found"
+        const hasNoEntities = await yamlExport.hasNoEntities(label);
+        if (!hasNoEntities) {
+          const names = await yamlExport.getEntityNames(label);
+          expect(names.length).toBeGreaterThan(0);
+        }
 
-          await yamlExport.close();
-        },
-      );
+        await yamlExport.close();
+      });
     }
   });
 
@@ -141,134 +133,118 @@ test.describe("yaml export", () => {
   // Export options tests
   // ────────────────────────────────────────────────────────────
   test.describe("options", () => {
-    test(
-      "remove status option removes status fields from YAML",
-      {
-        tag: "@C2611889",
-      },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("remove status option removes status fields from YAML", {
+      tag: "@C2611889",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        // Toggle "remove-status" OFF so status IS included
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("remove-status");
-        await yamlExport.closeOptions();
+      // Toggle "remove-status" OFF so status IS included
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("remove-status");
+      await yamlExport.closeOptions();
 
-        // Select our test role
-        await yamlExport.toggleResource("Roles");
-        await yamlExport.generate();
+      // Select our test role
+      await yamlExport.toggleResource("Roles");
+      await yamlExport.generate();
 
-        let yaml = await yamlExport.getYamlContent();
-        expect(yaml).toContain("status");
+      let yaml = await yamlExport.getYamlContent();
+      expect(yaml).toContain("status");
 
-        // Go back and toggle remove-status ON
-        await yamlExport.backToSelection();
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("remove-status");
-        await yamlExport.closeOptions();
+      // Go back and toggle remove-status ON
+      await yamlExport.backToSelection();
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("remove-status");
+      await yamlExport.closeOptions();
 
-        await yamlExport.generate();
-        yaml = await yamlExport.getYamlContent();
-        expect(yaml).not.toContain("status");
+      await yamlExport.generate();
+      yaml = await yamlExport.getYamlContent();
+      expect(yaml).not.toContain("status");
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
 
-    test(
-      "remove IDs option removes auto-generated IDs from YAML",
-      {
-        tag: "@C2611890",
-      },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("remove IDs option removes auto-generated IDs from YAML", {
+      tag: "@C2611890",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        // Toggle "remove-ids" OFF so IDs ARE included
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("remove-ids");
-        await yamlExport.closeOptions();
+      // Toggle "remove-ids" OFF so IDs ARE included
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("remove-ids");
+      await yamlExport.closeOptions();
 
-        await yamlExport.toggleResource("Roles");
-        await yamlExport.generate();
+      await yamlExport.toggleResource("Roles");
+      await yamlExport.generate();
 
-        let yaml = await yamlExport.getYamlContent();
-        // With IDs included, should have "id:" field
-        expect(yaml).toMatch(/^id:/m);
+      let yaml = await yamlExport.getYamlContent();
+      // With IDs included, should have "id:" field
+      expect(yaml).toMatch(/^id:/m);
 
-        // Go back and toggle remove-ids ON
-        await yamlExport.backToSelection();
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("remove-ids");
-        await yamlExport.closeOptions();
+      // Go back and toggle remove-ids ON
+      await yamlExport.backToSelection();
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("remove-ids");
+      await yamlExport.closeOptions();
 
-        await yamlExport.generate();
-        yaml = await yamlExport.getYamlContent();
-        expect(yaml).not.toMatch(/^id:/m);
+      await yamlExport.generate();
+      yaml = await yamlExport.getYamlContent();
+      expect(yaml).not.toMatch(/^id:/m);
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
 
-    test(
-      "remove timestamps option removes timestamp fields from YAML",
-      {
-        tag: "@C2611891",
-      },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("remove timestamps option removes timestamp fields from YAML", {
+      tag: "@C2611891",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        // Toggle BOTH "remove-timestamps" and "remove-ids" OFF
-        // (when remove-ids is ON, metadata is rebuilt without timestamps regardless)
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("remove-timestamps");
-        await yamlExport.toggleOption("remove-ids");
-        await yamlExport.closeOptions();
+      // Toggle BOTH "remove-timestamps" and "remove-ids" OFF
+      // (when remove-ids is ON, metadata is rebuilt without timestamps regardless)
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("remove-timestamps");
+      await yamlExport.toggleOption("remove-ids");
+      await yamlExport.closeOptions();
 
-        await yamlExport.toggleResource("Roles");
-        await yamlExport.generate();
+      await yamlExport.toggleResource("Roles");
+      await yamlExport.generate();
 
-        let yaml = await yamlExport.getYamlContent();
-        expect(yaml).toContain("creation_timestamp");
+      let yaml = await yamlExport.getYamlContent();
+      expect(yaml).toContain("creation_timestamp");
 
-        // Go back and toggle remove-timestamps ON (keep remove-ids OFF)
-        await yamlExport.backToSelection();
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("remove-timestamps");
-        await yamlExport.closeOptions();
+      // Go back and toggle remove-timestamps ON (keep remove-ids OFF)
+      await yamlExport.backToSelection();
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("remove-timestamps");
+      await yamlExport.closeOptions();
 
-        await yamlExport.generate();
-        yaml = await yamlExport.getYamlContent();
-        expect(yaml).not.toContain("creation_timestamp");
+      await yamlExport.generate();
+      yaml = await yamlExport.getYamlContent();
+      expect(yaml).not.toContain("creation_timestamp");
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
 
-    test(
-      "reset button clears all selections",
-      {
-        tag: "@C2611892",
-      },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("reset button clears all selections", {
+      tag: "@C2611892",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        // Select a resource
-        await yamlExport.toggleResource("Roles");
-        await yamlExport.expectGenerateEnabled();
+      // Select a resource
+      await yamlExport.toggleResource("Roles");
+      await yamlExport.expectGenerateEnabled();
 
-        // Click reset
-        await yamlExport.clickReset();
+      // Click reset
+      await yamlExport.clickReset();
 
-        // Generate should be disabled again
-        await yamlExport.expectGenerateDisabled();
+      // Generate should be disabled again
+      await yamlExport.expectGenerateDisabled();
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
   });
 
   // ────────────────────────────────────────────────────────────
@@ -333,135 +309,121 @@ test.describe("yaml export", () => {
       await context.close();
     });
 
-    test(
-      "image registry export without credentials excludes auth info",
-      { tag: "@C2611905" },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("image registry export without credentials excludes auth info", {
+      tag: "@C2611905",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        // Toggle include-credentials OFF (default is ON)
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("include-credentials");
-        await yamlExport.closeOptions();
+      // Toggle include-credentials OFF (default is ON)
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("include-credentials");
+      await yamlExport.closeOptions();
 
-        await yamlExport.toggleResource("Image Registries");
-        await yamlExport.generate();
+      await yamlExport.toggleResource("Image Registries");
+      await yamlExport.generate();
 
-        const yaml = await yamlExport.getYamlContent();
-        expect(yaml).toContain("ImageRegistry");
-        expect(yaml).not.toContain("username");
-        expect(yaml).not.toContain("password");
-        expect(yaml).not.toContain("testuser");
-        expect(yaml).not.toContain("testpass");
+      const yaml = await yamlExport.getYamlContent();
+      expect(yaml).toContain("ImageRegistry");
+      expect(yaml).not.toContain("username");
+      expect(yaml).not.toContain("password");
+      expect(yaml).not.toContain("testuser");
+      expect(yaml).not.toContain("testpass");
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
 
-    test(
-      "model registry export without credentials excludes credential info",
-      { tag: "@C2611906" },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("model registry export without credentials excludes credential info", {
+      tag: "@C2611906",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        // Toggle include-credentials OFF
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("include-credentials");
-        await yamlExport.closeOptions();
+      // Toggle include-credentials OFF
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("include-credentials");
+      await yamlExport.closeOptions();
 
-        await yamlExport.toggleResource("Model Registries");
-        await yamlExport.generate();
+      await yamlExport.toggleResource("Model Registries");
+      await yamlExport.generate();
 
-        const yaml = await yamlExport.getYamlContent();
-        expect(yaml).toContain("ModelRegistry");
-        expect(yaml).not.toContain("credentials");
-        expect(yaml).not.toContain("test-api-token");
+      const yaml = await yamlExport.getYamlContent();
+      expect(yaml).toContain("ModelRegistry");
+      expect(yaml).not.toContain("credentials");
+      expect(yaml).not.toContain("test-api-token");
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
 
-    test(
-      "cluster export without credentials excludes ssh key and kubeconfig",
-      { tag: "@C2611908" },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("cluster export without credentials excludes ssh key and kubeconfig", {
+      tag: "@C2611908",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        // Toggle include-credentials OFF
-        await yamlExport.openOptions();
-        await yamlExport.toggleOption("include-credentials");
-        await yamlExport.closeOptions();
+      // Toggle include-credentials OFF
+      await yamlExport.openOptions();
+      await yamlExport.toggleOption("include-credentials");
+      await yamlExport.closeOptions();
 
-        await yamlExport.toggleResource("Clusters");
-        await yamlExport.generate();
+      await yamlExport.toggleResource("Clusters");
+      await yamlExport.generate();
 
-        const yaml = await yamlExport.getYamlContent();
-        expect(yaml).toContain("Cluster");
-        expect(yaml).not.toContain("ssh_private_key");
-        expect(yaml).not.toContain("kubeconfig");
+      const yaml = await yamlExport.getYamlContent();
+      expect(yaml).toContain("Cluster");
+      expect(yaml).not.toContain("ssh_private_key");
+      expect(yaml).not.toContain("kubeconfig");
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
   });
 
   // ────────────────────────────────────────────────────────────
   // Output tests
   // ────────────────────────────────────────────────────────────
   test.describe("output", () => {
-    test(
-      "can download YAML file",
-      {
-        tag: "@C2611904",
-      },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("can download YAML file", {
+      tag: "@C2611904",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        await yamlExport.toggleResource("Roles");
-        await yamlExport.generate();
+      await yamlExport.toggleResource("Roles");
+      await yamlExport.generate();
 
-        const download = await yamlExport.downloadFile();
-        const suggestedFilename = download.suggestedFilename();
-        expect(suggestedFilename).toMatch(/^resources-.*\.yaml$/);
+      const download = await yamlExport.downloadFile();
+      const suggestedFilename = download.suggestedFilename();
+      expect(suggestedFilename).toMatch(/^resources-.*\.yaml$/);
 
-        // Verify file content is not empty
-        const path = await download.path();
-        expect(path).toBeTruthy();
+      // Verify file content is not empty
+      const path = await download.path();
+      expect(path).toBeTruthy();
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
 
-    test(
-      "api key export YAML does not contain secret key value",
-      {
-        tag: "@C2611907",
-      },
-      async ({ yamlExport, page }) => {
-        await page.goto("/#/dashboard");
-        await yamlExport.open();
+    test("api key export YAML does not contain secret key value", {
+      tag: "@C2611907",
+    }, async ({ yamlExport, page }) => {
+      await page.goto("/#/dashboard");
+      await yamlExport.open();
 
-        // Select API keys only
-        await yamlExport.toggleResource("API key");
+      // Select API keys only
+      await yamlExport.toggleResource("API key");
 
-        // Generate YAML (with default options: remove-status=true)
-        await yamlExport.generate();
+      // Generate YAML (with default options: remove-status=true)
+      await yamlExport.generate();
 
-        const yaml = await yamlExport.getYamlContent();
-        // YAML should contain the api key resource
-        expect(yaml).toContain("ApiKey");
+      const yaml = await yamlExport.getYamlContent();
+      // YAML should contain the api key resource
+      expect(yaml).toContain("ApiKey");
 
-        // Should NOT contain sk_value (secret key is in status which is removed by default,
-        // and even with status included, the API doesn't return sk_value in list responses)
-        expect(yaml).not.toContain("sk_value");
-        expect(yaml).not.toMatch(/sk-[a-zA-Z0-9]/);
+      // Should NOT contain sk_value (secret key is in status which is removed by default,
+      // and even with status included, the API doesn't return sk_value in list responses)
+      expect(yaml).not.toContain("sk_value");
+      expect(yaml).not.toMatch(/sk-[a-zA-Z0-9]/);
 
-        await yamlExport.close();
-      },
-    );
+      await yamlExport.close();
+    });
   });
 });

--- a/e2e/tests/yaml-import.spec.ts
+++ b/e2e/tests/yaml-import.spec.ts
@@ -31,9 +31,9 @@ spec:
     engine: vllm
     version: v0.8.5
   resources:
-    cpu: 1
-    memory: 1
-    gpu: 0
+    cpu: "1"
+    memory: "1"
+    gpu: "0"
   replicas:
     num: 1
   deployment_options:
@@ -63,181 +63,150 @@ test.describe("yaml import", () => {
     await context.close();
   });
 
-  test(
-    "can paste YAML content and import",
-    {
-      tag: "@C2611882",
-    },
-    async ({ yamlImport, page }) => {
-      const roleName = `test-imp-paste-${Date.now()}`;
-      createdResources.roles.push(roleName);
+  test("can paste YAML content and import", {
+    tag: "@C2611882",
+  }, async ({ yamlImport, page }) => {
+    const roleName = `test-imp-paste-${Date.now()}`;
+    createdResources.roles.push(roleName);
 
-      await page.goto("/#/dashboard");
-      await yamlImport.importYaml(roleYaml(roleName));
-      await yamlImport.expectResults({ success: 1, errors: 0 });
-      await yamlImport.close();
-    },
-  );
+    await page.goto("/#/dashboard");
+    await yamlImport.importYaml(roleYaml(roleName));
+    await yamlImport.expectResults({ success: 1, errors: 0 });
+    await yamlImport.close();
+  });
 
-  test(
-    "import result displays success/skip/error badges",
-    {
-      tag: "@C2611883",
-    },
-    async ({ yamlImport, page }) => {
-      const roleName = `test-imp-badges-${Date.now()}`;
-      createdResources.roles.push(roleName);
+  test("import result displays success/skip/error badges", {
+    tag: "@C2611883",
+  }, async ({ yamlImport, page }) => {
+    const roleName = `test-imp-badges-${Date.now()}`;
+    createdResources.roles.push(roleName);
 
-      await page.goto("/#/dashboard");
-      await yamlImport.importYaml(roleYaml(roleName));
+    await page.goto("/#/dashboard");
+    await yamlImport.importYaml(roleYaml(roleName));
 
-      // Should show success badge
-      const dialog = page.getByRole("dialog");
-      await expect(dialog.getByText(/1 success/i)).toBeVisible();
+    // Should show success badge
+    const dialog = page.getByRole("dialog");
+    await expect(dialog.getByText(/1 success/i)).toBeVisible();
 
-      // Check result row shows green success indicator
-      await expect(dialog.getByText(/successfully created/i)).toBeVisible();
+    // Check result row shows green success indicator
+    await expect(dialog.getByText(/successfully created/i)).toBeVisible();
 
-      await yamlImport.close();
-    },
-  );
+    await yamlImport.close();
+  });
 
-  test(
-    "can import from local file",
-    {
-      tag: "@C2611880",
-    },
-    async ({ yamlImport, page }) => {
-      const roleName = `test-imp-file-${Date.now()}`;
-      createdResources.roles.push(roleName);
+  test("can import from local file", {
+    tag: "@C2611880",
+  }, async ({ yamlImport, page }) => {
+    const roleName = `test-imp-file-${Date.now()}`;
+    createdResources.roles.push(roleName);
 
-      await page.goto("/#/dashboard");
-      await yamlImport.importFromFile(roleYaml(roleName));
-      await yamlImport.expectResults({ success: 1, errors: 0 });
-      await yamlImport.close();
-    },
-  );
+    await page.goto("/#/dashboard");
+    await yamlImport.importFromFile(roleYaml(roleName));
+    await yamlImport.expectResults({ success: 1, errors: 0 });
+    await yamlImport.close();
+  });
 
-  test(
-    "can import multiple resource types in one YAML",
-    {
-      tag: "@C2611879",
-    },
-    async ({ yamlImport, page }) => {
-      const ts = Date.now();
-      const roleName = `test-imp-multi-role-${ts}`;
-      const mcName = `test-imp-multi-mc-${ts}`;
-      createdResources.roles.push(roleName);
-      createdResources.modelCatalogs.push(mcName);
+  test("can import multiple resource types in one YAML", {
+    tag: "@C2611879",
+  }, async ({ yamlImport, page }) => {
+    const ts = Date.now();
+    const roleName = `test-imp-multi-role-${ts}`;
+    const mcName = `test-imp-multi-mc-${ts}`;
+    createdResources.roles.push(roleName);
+    createdResources.modelCatalogs.push(mcName);
 
-      const multiYaml = `${roleYaml(roleName)}
+    const multiYaml = `${roleYaml(roleName)}
 ---
 ${modelCatalogYaml(mcName)}`;
 
-      await page.goto("/#/dashboard");
-      await yamlImport.importYaml(multiYaml);
-      await yamlImport.expectResults({ success: 2, errors: 0 });
-      await yamlImport.close();
-    },
-  );
+    await page.goto("/#/dashboard");
+    await yamlImport.importYaml(multiYaml);
+    await yamlImport.expectResults({ success: 2, errors: 0 });
+    await yamlImport.close();
+  });
 
-  test(
-    "duplicate import skips existing resources",
-    {
-      tag: "@C2611885",
-    },
-    async ({ yamlImport, page }) => {
-      const roleName = `test-imp-dup-${Date.now()}`;
-      createdResources.roles.push(roleName);
+  test("duplicate import skips existing resources", {
+    tag: "@C2611885",
+  }, async ({ yamlImport, page }) => {
+    const roleName = `test-imp-dup-${Date.now()}`;
+    createdResources.roles.push(roleName);
 
-      await page.goto("/#/dashboard");
+    await page.goto("/#/dashboard");
 
-      // First import — success
-      await yamlImport.importYaml(roleYaml(roleName));
-      await yamlImport.expectResults({ success: 1 });
+    // First import — success
+    await yamlImport.importYaml(roleYaml(roleName));
+    await yamlImport.expectResults({ success: 1 });
 
-      // Import more — second time (dialog already open)
-      await yamlImport.importMore();
-      await yamlImport.submitYaml(roleYaml(roleName));
-      await yamlImport.expectResults({ skipped: 1 });
+    // Import more — second time (dialog already open)
+    await yamlImport.importMore();
+    await yamlImport.submitYaml(roleYaml(roleName));
+    await yamlImport.expectResults({ skipped: 1 });
 
-      await yamlImport.close();
-    },
-  );
+    await yamlImport.close();
+  });
 
-  test(
-    "import more resets dialog for next import",
-    {
-      tag: "@C2611884",
-    },
-    async ({ yamlImport, page }) => {
-      const ts = Date.now();
-      const role1 = `test-imp-more1-${ts}`;
-      const role2 = `test-imp-more2-${ts}`;
-      createdResources.roles.push(role1, role2);
+  test("import more resets dialog for next import", {
+    tag: "@C2611884",
+  }, async ({ yamlImport, page }) => {
+    const ts = Date.now();
+    const role1 = `test-imp-more1-${ts}`;
+    const role2 = `test-imp-more2-${ts}`;
+    createdResources.roles.push(role1, role2);
 
-      await page.goto("/#/dashboard");
+    await page.goto("/#/dashboard");
 
-      // First import
-      await yamlImport.importYaml(roleYaml(role1));
-      await yamlImport.expectResults({ success: 1 });
+    // First import
+    await yamlImport.importYaml(roleYaml(role1));
+    await yamlImport.expectResults({ success: 1 });
 
-      // Click Import More — should reset to input form
-      await yamlImport.importMore();
+    // Click Import More — should reset to input form
+    await yamlImport.importMore();
 
-      // Verify input is cleared and ready for new import
-      const dialog = page.getByRole("dialog");
-      const textarea = dialog.locator("#yaml-text");
-      await expect(textarea).toBeVisible();
-      const value = await textarea.inputValue();
-      expect(value).toBe("");
+    // Verify input is cleared and ready for new import
+    const dialog = page.getByRole("dialog");
+    const textarea = dialog.locator("#yaml-text");
+    await expect(textarea).toBeVisible();
+    const value = await textarea.inputValue();
+    expect(value).toBe("");
 
-      // Second import (dialog already open after importMore)
-      await yamlImport.submitYaml(roleYaml(role2));
-      await yamlImport.expectResults({ success: 1 });
+    // Second import (dialog already open after importMore)
+    await yamlImport.submitYaml(roleYaml(role2));
+    await yamlImport.expectResults({ success: 1 });
 
-      await yamlImport.close();
-    },
-  );
+    await yamlImport.close();
+  });
 
-  test(
-    "can import from URL",
-    {
-      tag: "@C2611881",
-    },
-    async ({ yamlImport, page }) => {
-      const roleName = `test-imp-url-${Date.now()}`;
-      createdResources.roles.push(roleName);
+  test("can import from URL", {
+    tag: "@C2611881",
+  }, async ({ yamlImport, page }) => {
+    const roleName = `test-imp-url-${Date.now()}`;
+    createdResources.roles.push(roleName);
 
-      const yaml = roleYaml(roleName);
+    const yaml = roleYaml(roleName);
 
-      // Mock the URL fetch — the browser fetches URLs directly in use-yaml-import.ts
-      await page.route("https://example.com/test.yaml", (route) =>
-        route.fulfill({
-          status: 200,
-          contentType: "application/x-yaml",
-          body: yaml,
-        }),
-      );
+    // Mock the URL fetch — the browser fetches URLs directly in use-yaml-import.ts
+    await page.route("https://example.com/test.yaml", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/x-yaml",
+        body: yaml,
+      }),
+    );
 
-      await page.goto("/#/dashboard");
-      await yamlImport.importFromUrl("https://example.com/test.yaml");
-      await yamlImport.expectResults({ success: 1, errors: 0 });
-      await yamlImport.close();
-    },
-  );
+    await page.goto("/#/dashboard");
+    await yamlImport.importFromUrl("https://example.com/test.yaml");
+    await yamlImport.expectResults({ success: 1, errors: 0 });
+    await yamlImport.close();
+  });
 
-  test(
-    "import invalid data shows error",
-    {
-      tag: "@C2611886",
-    },
-    async ({ yamlImport, page }) => {
-      await page.goto("/#/dashboard");
+  test("import invalid data shows error", {
+    tag: "@C2611886",
+  }, async ({ yamlImport, page }) => {
+    await page.goto("/#/dashboard");
 
-      // Use a valid YAML structure that passes client-side validation
-      // but fails on the server (invalid permissions format)
-      const invalidYaml = `apiVersion: v1
+    // Use a valid YAML structure that passes client-side validation
+    // but fails on the server (invalid permissions format)
+    const invalidYaml = `apiVersion: v1
 kind: Role
 metadata:
   name: test-imp-invalid-${Date.now()}
@@ -245,28 +214,24 @@ spec:
   permissions:
     - this-is-not:a-valid-permission`;
 
-      await yamlImport.importYaml(invalidYaml);
+    await yamlImport.importYaml(invalidYaml);
 
-      const dialog = page.getByRole("dialog");
-      // Should show error badge (API rejects invalid permission enum)
-      await expect(dialog.getByText(/1 error/i)).toBeVisible();
+    const dialog = page.getByRole("dialog");
+    // Should show error badge (API rejects invalid permission enum)
+    await expect(dialog.getByText(/1 error/i)).toBeVisible();
 
-      await yamlImport.close();
-    },
-  );
+    await yamlImport.close();
+  });
 
-  test(
-    "import with missing dependency succeeds",
-    {
-      tag: "@C2611887",
-    },
-    async ({ yamlImport, page }) => {
-      // Per the test case: "当前会成功" — import should succeed even with missing deps
-      const mcName = `test-imp-dep-${Date.now()}`;
-      createdResources.modelCatalogs.push(mcName);
+  test("import with missing dependency succeeds", {
+    tag: "@C2611887",
+  }, async ({ yamlImport, page }) => {
+    // Per the test case: "当前会成功" — import should succeed even with missing deps
+    const mcName = `test-imp-dep-${Date.now()}`;
+    createdResources.modelCatalogs.push(mcName);
 
-      // Import a model catalog that references a non-existent engine version
-      const yaml = `apiVersion: v1
+    // Import a model catalog that references a non-existent engine version
+    const yaml = `apiVersion: v1
 kind: ModelCatalog
 metadata:
   name: ${mcName}
@@ -282,9 +247,9 @@ spec:
     engine: non-existent-engine
     version: v99.99
   resources:
-    cpu: 1
-    memory: 1
-    gpu: 0
+    cpu: "1"
+    memory: "1"
+    gpu: "0"
   replicas:
     num: 1
   deployment_options:
@@ -292,10 +257,9 @@ spec:
       type: roundrobin
   variables: {}`;
 
-      await page.goto("/#/dashboard");
-      await yamlImport.importYaml(yaml);
-      await yamlImport.expectResults({ success: 1 });
-      await yamlImport.close();
-    },
-  );
+    await page.goto("/#/dashboard");
+    await yamlImport.importYaml(yaml);
+    await yamlImport.expectResults({ success: 1 });
+    await yamlImport.close();
+  });
 });


### PR DESCRIPTION
## What

Refresh the Playwright E2E specs so they match the current UI, plus two helper changes:

- **ai-trace helper**: add an `E2E_AITRACE_MODEL` env override for the OpenAI `model` field sent to the gateway (defaults to `"any"`). Served-model names differ per environment, so this makes trace tests portable across endpoints.
- **yaml-import**: quote `cpu` / `memory` / `gpu` resource values so the parsed YAML keeps them as strings.
- **ui-layout**: import `Page` from `@playwright/test` (the base fixture does not re-export it).
- **Spec refresh** across api-keys, clusters, clusters-create, clusters-permissions, endpoints, model-catalogs, roles, user-profiles, workspaces, custom-appearance and yaml-export to align with current UI (usage panel, available-versions, cluster edit fields, permission counts, delete timeouts).

## Notes

- Large diff: the spec refresh is a substantial test-alignment pass against a UI that changed shape. Reviewing with whitespace hidden (`?w=1`) shows ~1.1k lines of real change; the remainder is line-wrapping style.
- `tsc` is clean on the changed files; Biome reports no format fixes on them.

## Test

Individual suites were exercised against a live control plane during development; the trace/model-usage/access data-plane specs were validated against a running endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)