### PR TITLE
fix: correct endpoint GPU model label order

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -301,7 +301,7 @@
   "src/components/ui/calendar.tsx": "dfedaf90a75014faab50dfb32b28c5b2",
   "src/domains/endpoint/lib/vgpu.ts": "7d086eba1576c5e23cfbd524483ef58b",
   "src/domains/endpoint/lib/resource-status.ts": "8bf88a620b262d25091e78061584c14e",
-  "src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx": "a70bee97858c03e2fc4db89d4de7468f",
+  "src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx": "057551fdf73c77c01d5387da87b64c89",
   "src/domains/cluster/lib/resource-status.ts": "9e759f014c4589740efe23ebdaf8bf74",
   "src/foundation/lib/gpu-device-resources.ts": "fddf023743268798b051643a8dd0139a",
   "src/foundation/components/GpuDeviceResourcesView.tsx": "bd15d01f7f41c71b7427a487a72fe429",

--- a/src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx
+++ b/src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import EndpointRuntimeResourcesCard from "./EndpointRuntimeResourcesCard";
 
@@ -124,6 +124,15 @@ describe("EndpointRuntimeResourcesCard", () => {
     expect(screen.getAllByText("8.0 GiB")).toHaveLength(4);
     expect(screen.getAllByText("neutree-gpu-t4-02")).toHaveLength(2);
     expect(screen.getAllByText("neutree-gpu-t4-03")).toHaveLength(2);
+    const summary = screen.getByTestId("runtime-resource-summary");
+    const summaryGpuModelLabel = within(summary).getByText(
+      "common.fields.acceleratorProduct",
+    );
+    const summaryGpuModelValue = within(summary).getByText("Tesla-T4");
+    expect(
+      summaryGpuModelLabel.compareDocumentPosition(summaryGpuModelValue) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
     expect(
       screen.queryByText("GPU-c7907dc0-40f4-47dd-9dbb-6c3b63d60142"),
     ).toBeNull();

--- a/src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx
+++ b/src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx
@@ -143,12 +143,12 @@ export default function EndpointRuntimeResourcesCard({
                   {t("clusters.fields.gpuNumber")}
                 </div>
                 <div className="min-w-0">
-                  <strong className="block truncate text-sm font-semibold leading-5">
-                    {row.product || "-"}
-                  </strong>
                   <span className="block text-xs leading-4 text-muted-foreground">
                     {t("common.fields.acceleratorProduct")}
                   </span>
+                  <strong className="block truncate text-sm font-semibold leading-5">
+                    {row.product || "-"}
+                  </strong>
                 </div>
               </div>
               <ResourceValue


### PR DESCRIPTION
## Summary

Fix the Endpoint detail runtime resource summary so the GPU model field shows its label above the actual GPU model value.

## Issues

NEU-541

## Changes

- Swap the accelerator product label/value order in the endpoint runtime resource summary cell.
- Add a component regression assertion for the DOM order.
- Update the i18n tracker for the modified TSX file.

## Test Plan

### Unit test

- `PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$PATH" yarn test src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx`
- `PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$PATH" yarn typecheck`
- `PATH="$HOME/.nvm/versions/node/v22.22.1/bin:$PATH" ./node_modules/.bin/biome lint src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx src/domains/endpoint/components/EndpointRuntimeResourcesCard.test.tsx`
- Commit hook also passed `depcruise`, `knip`, `lint-staged`, and i18n checks under Node 22.

### DB test

- N/A. This change only adjusts UI rendering order and does not change database schema, migrations, or data access.

### E2E test

- Manual browser verification against the current branch UI at `http://127.0.0.1:5173`, proxied to the E2E Neutree server.
- The available real Endpoint `default/qwen25-0p5b-chat-gpu` had `status.resources=null`, so the environment could not produce a real runtime resource summary for this case.
- To verify the current-branch UI rendering path, Playwright injected `status.resources.summary.products.NVIDIA_Tesla_T4` into that real Endpoint response and opened the Endpoint detail page.
- Verified runtime summary text order: `GPU`, `Accelerator Product`, `NVIDIA_Tesla_T4`, `VRAM`, `15.0 GiB`, `Core`, `-`; label index `1`, value index `2`.
- No default code-backed E2E was added because this scenario depends on runtime resource status data that is not reliably available in the E2E environment.