### PR TITLE
ci: bump nightly build base version to v1.1.1

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -23,6 +23,6 @@ jobs:
       - name: Create Nightly Tag
         run: |
           DATE=$(date +'%Y%m%d')
-          TAG="v1.1.0-nightly-${DATE}"
+          TAG="v1.1.1-nightly-${DATE}"
           git tag "${TAG}" -m "${TAG}"
           git push origin "${TAG}"


### PR DESCRIPTION
## Summary

Bump the UI nightly tag base from v1.1.0 to v1.1.1.

## Changes

- Update the Daily Build tag generation constant only.

## Test Plan

### Unit test
- Not required: GitHub Actions workflow constant only.

### DB test
- Not required: no database surface.

### E2E test
- Local static validation passed (not exercised by PR CI): actionlint, YAML parse, tag assertion, and diff scope check.
- PR CI passed: `test`.
- Scheduled GitHub Actions validation is pending after coordinated merge; no manual workflow dispatch is planned.

## Risk & Rollback

- Merge only as a coordinated set with Neutree #491 and Enterprise #89, then update both `NIGHTLY_CLUSTER_VERSION` repository secrets before the next 00:00 UTC chain. If the window cannot be met, defer all three PRs.
- If a scheduled run has created a tag or dispatched a release, preserve run/tag evidence and do not retag or manually dispatch. Revert all three workflow changes together and restore both secrets to their last recorded values before a controlled recovery.