### PR TITLE
fix: hide static node permissions

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -158,7 +158,7 @@
   "src/domains/role-assignment/components/UserCell.tsx": "ddabf86c8ea0897d69b22f9ac5b73f77",
   "src/domains/role/types.ts": "f1deba5219d3585096cac00c81e20051",
   "src/domains/role/hooks/use-permission-dependencies.ts": "a0ce8deadf5afb2c083b70ab50cf6f2c",
-  "src/domains/role/components/PermissionsTree.tsx": "70d1f5fc23960b83cc1b4939f6052b36",
+  "src/domains/role/components/PermissionsTree.tsx": "423f74beb207490e0b8c3477fd8023af",
   "src/domains/role/components/PermissionsTreeField.tsx": "9771eb340eef413aafd9e1d56ca81da8",
   "src/domains/model-registry/types.ts": "f1af5141f8aee9c147932bdda6f34ca6",
   "src/domains/model-registry/components/ModelRegistryStatus.tsx": "2683d6d752fe80c13efa3583d4e1985f",

--- a/src/domains/role/components/PermissionsTree.test.tsx
+++ b/src/domains/role/components/PermissionsTree.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import PermissionsTree from "./PermissionsTree";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("PermissionsTree", () => {
+  it("hides static node permissions while rendering supported permissions", () => {
+    render(
+      <PermissionsTree
+        permissions={[
+          "workspace:read",
+          "static_node_cluster:read",
+          "static_node:read",
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("workspaces.title")).toBeTruthy();
+    expect(screen.queryByText("static_node_clusters.title")).toBeNull();
+    expect(screen.queryByText("static_nodes.title")).toBeNull();
+  });
+});

--- a/src/domains/role/components/PermissionsTree.tsx
+++ b/src/domains/role/components/PermissionsTree.tsx
@@ -42,11 +42,17 @@ const resourceIcons: Record<string, React.ReactNode> = {
   model_catalog: <BookOpen className="h-5 w-5" />,
 };
 
+const hiddenResources = new Set(["static_node_cluster", "static_node"]);
+
 const parsePermissionsToTree = (permissions: string[]) => {
   const tree: Record<string, string[]> = {};
 
   for (const permission of permissions) {
     const [resource, action] = permission.split(":");
+
+    if (hiddenResources.has(resource)) {
+      continue;
+    }
 
     if (!tree[resource]) {
       tree[resource] = [];


### PR DESCRIPTION
## Issues

NEU-557

## Changes

- Hide `static_node_cluster` and `static_node` permissions from the role detail tree.
- Add a regression test that preserves supported permission rendering.

## Test Plan

### Unit test

- `yarn test src/domains/role` (49 tests)
- `yarn typecheck`
- `yarn dep-check`
- `yarn knip`

### DB test

- Not applicable: UI-only permission display change.

### E2E test

- Not required: Trivial UI-only filtering change is covered by the component regression test; no deployment or E2E environment is needed.