### PR TITLE
fix: match multi-token GPU names

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -323,7 +323,7 @@
   "src/foundation/recipe/compose.ts": "c0cfe4da9024b651f47e4773318641d9",
   "src/foundation/recipe/normalize.ts": "37973e33217df534c07c56a63d07c1ed",
   "src/foundation/recipe/types.ts": "6b11c3319d89fc7158795a4dc2bfe661",
-  "src/foundation/recipe/vram.ts": "7cdf1eda25921556f7991b37ba5d8a16",
+  "src/foundation/recipe/vram.ts": "797c4d86bfcf35b864fb3c0deed5db73",
   "src/domains/model-catalog/components/ModelInfoBadges.tsx": "1608ced09a1c2236d30ee644f974dda2",
   "src/domains/endpoint/components/ComposePreview.tsx": "ab9fb6ee6b9dfed17c774cbf0f6dd823",
   "src/domains/endpoint/components/FeaturePicker.tsx": "899067c0e1879037378ebaf1fd51fb98",

--- a/src/foundation/recipe/vram.test.ts
+++ b/src/foundation/recipe/vram.test.ts
@@ -24,6 +24,19 @@ describe("matchesAcceleratorName", () => {
     ).toBe(true);
   });
 
+  it("does not match complete product names with different SKUs", () => {
+    expect(
+      matchesAcceleratorName("NVIDIA-GeForce-RTX-4090-Ti", [
+        "NVIDIA-GeForce-RTX-4090",
+      ]),
+    ).toBe(false);
+    expect(
+      matchesAcceleratorName("NVIDIA-GeForce-RTX-4090-Laptop-GPU", [
+        "NVIDIA-GeForce-RTX-4090",
+      ]),
+    ).toBe(false);
+  });
+
   it("does not match on partial tokens", () => {
     // "H100" must not match a product whose only similar token is "H1000".
     expect(matchesAcceleratorName("NVIDIA-H1000", ["H100"])).toBe(false);

--- a/src/foundation/recipe/vram.test.ts
+++ b/src/foundation/recipe/vram.test.ts
@@ -16,6 +16,14 @@ describe("matchesAcceleratorName", () => {
     expect(matchesAcceleratorName("nvidia-h100-80gb", [" H100 "])).toBe(true);
   });
 
+  it("matches a complete multi-token product name", () => {
+    expect(
+      matchesAcceleratorName("NVIDIA-GeForce-RTX-4090", [
+        "NVIDIA-GeForce-RTX-4090",
+      ]),
+    ).toBe(true);
+  });
+
   it("does not match on partial tokens", () => {
     // "H100" must not match a product whose only similar token is "H1000".
     expect(matchesAcceleratorName("NVIDIA-H1000", ["H100"])).toBe(false);

--- a/src/foundation/recipe/vram.ts
+++ b/src/foundation/recipe/vram.ts
@@ -31,10 +31,9 @@ const PER_GPU_VRAM_GB: Record<string, number> = {
 
 // Accelerator product strings reported by a cluster are vendor-prefixed and
 // decorated (e.g. "NVIDIA-H100-80GB-HBM3", "Tesla-V100-SXM2-16GB"), while
-// recipe annotations and PER_GPU_VRAM_GB keys use bare model names ("H100",
-// "V100"). matchesAcceleratorName lines the two schemes up by comparing the
-// product's alphanumeric tokens against the bare names — so "H100" matches a
-// product token of "H100" without an exact-string equality that never holds.
+// recipe annotations and PER_GPU_VRAM_GB keys can use either bare model names
+// ("H100", "V100") or complete product names. A match requires every token
+// from the declared name to occur in the product string.
 export function matchesAcceleratorName(
   product: string,
   names: Iterable<string>,
@@ -46,8 +45,14 @@ export function matchesAcceleratorName(
       .filter(Boolean),
   );
   for (const name of names) {
-    const n = name.trim().toUpperCase();
-    if (n && tokens.has(n)) {
+    const nameTokens = name
+      .toUpperCase()
+      .split(/[^A-Z0-9]+/)
+      .filter(Boolean);
+    if (
+      nameTokens.length > 0 &&
+      nameTokens.every((token) => tokens.has(token))
+    ) {
       return true;
     }
   }

--- a/src/foundation/recipe/vram.ts
+++ b/src/foundation/recipe/vram.ts
@@ -32,27 +32,28 @@ const PER_GPU_VRAM_GB: Record<string, number> = {
 // Accelerator product strings reported by a cluster are vendor-prefixed and
 // decorated (e.g. "NVIDIA-H100-80GB-HBM3", "Tesla-V100-SXM2-16GB"), while
 // recipe annotations and PER_GPU_VRAM_GB keys can use either bare model names
-// ("H100", "V100") or complete product names. A match requires every token
-// from the declared name to occur in the product string.
+// ("H100", "V100") or complete product names. Bare names can match a product
+// token; complete product names must match the normalized identifier exactly.
 export function matchesAcceleratorName(
   product: string,
   names: Iterable<string>,
 ): boolean {
-  const tokens = new Set(
-    product
-      .toUpperCase()
-      .split(/[^A-Z0-9]+/)
-      .filter(Boolean),
-  );
+  const productTokens = product
+    .toUpperCase()
+    .split(/[^A-Z0-9]+/)
+    .filter(Boolean);
+  const tokens = new Set(productTokens);
+  const normalizedProduct = productTokens.join("-");
+
   for (const name of names) {
     const nameTokens = name
       .toUpperCase()
       .split(/[^A-Z0-9]+/)
       .filter(Boolean);
-    if (
-      nameTokens.length > 0 &&
-      nameTokens.every((token) => tokens.has(token))
-    ) {
+    if (nameTokens.length === 1 && tokens.has(nameTokens[0])) {
+      return true;
+    }
+    if (nameTokens.length > 1 && nameTokens.join("-") === normalizedProduct) {
       return true;
     }
   }


### PR DESCRIPTION
## Summary
- Match complete validated GPU product names after normalizing their tokens.
- Add RTX 4090 coverage for recipe hardware validation.

## Test Plan
### Unit test
- `vitest run --environment node src/foundation/recipe/vram.test.ts`
- `biome lint src/foundation/recipe/vram.ts src/foundation/recipe/vram.test.ts`
- `yarn build`

### DB test
- Not applicable: this client-only matcher does not access database resources.

### E2E test
- Not run: the shared environment does not yet run this branch's UI build.
- Local proxy smoke check: UI returned HTTP 200 and `/api/v1/clusters` reached the remote environment (HTTP 401 before login).