### PR TITLE
fix: keep accelerator picker visible when no verified GPU matches (NEU-590)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -239,7 +239,7 @@
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "d022c0d909fa184e74a05a17726cb74f",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "75b6677219c8e710ac320214390b4da6",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "9984d0f9bfc803483a1b02a0d63fa1a7",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "7fc5186989f74eb21ecf621ac24e5ee4",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -239,7 +239,7 @@
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "d022c0d909fa184e74a05a17726cb74f",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "d897c22d799fab5ea1005ff8b41a0772",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "75b6677219c8e710ac320214390b4da6",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "7fc5186989f74eb21ecf621ac24e5ee4",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",

--- a/e2e/tests/model-catalogs-recipe-gpu.spec.ts
+++ b/e2e/tests/model-catalogs-recipe-gpu.spec.ts
@@ -156,9 +156,11 @@ test.describe("recipe model catalog: GPU cluster", () => {
     await endpoints.form.selectComboboxOption("spec.cluster", GPU_CLUSTER);
 
     // Intersection is non-empty -> the picker offers the verified product and
-    // the "no validated GPU" notice must NOT appear.
+    // the unvalidated-hardware notice must NOT appear.
     await expect(
-      endpoints.page.getByText(/no validated gpu available/i),
+      endpoints.page.locator(
+        '[data-testid="endpoint-accelerator-unverified-notice"]',
+      ),
     ).toHaveCount(0);
     await endpoints.page
       .locator('[data-testid="field-spec.resources.accelerator"] button')
@@ -172,7 +174,7 @@ test.describe("recipe model catalog: GPU cluster", () => {
     ).toBeVisible();
   });
 
-  test("disjoint verified hardware hides the picker until Show all options", {
+  test("disjoint verified hardware keeps the picker with all accelerators and a notice", {
     tag: "@C2727751",
   }, async ({ endpoints }) => {
     await deployFromCard(endpoints.page, mcFar.name);
@@ -181,17 +183,17 @@ test.describe("recipe model catalog: GPU cluster", () => {
 
     await endpoints.form.selectComboboxOption("spec.cluster", GPU_CLUSTER);
 
-    // No intersection -> picker replaced by the advisory notice with the
-    // variant's VRAM floor.
+    // No intersection -> the picker stays visible (NEU-590) and the
+    // unvalidated-hardware notice states the fallback and the VRAM floor.
     await expect(
-      endpoints.page.getByText(/no validated gpu available/i),
+      endpoints.page.locator(
+        '[data-testid="endpoint-accelerator-unverified-notice"]',
+      ),
     ).toBeVisible();
     await expect(endpoints.page.getByText(/4 GB VRAM/i).first()).toBeVisible();
 
-    // Show all options reveals every cluster accelerator (incl. the real one).
-    await endpoints.page
-      .getByRole("button", { name: /show all options/i })
-      .click();
+    // Without touching "Show all options" the picker already offers every
+    // cluster accelerator (incl. the real one).
     await endpoints.page
       .locator('[data-testid="field-spec.resources.accelerator"] button')
       .first()

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -4186,6 +4186,24 @@ describe("useEndpointForm", () => {
       ).toBeTruthy();
     });
 
+    it("shows no notice on a cluster without accelerators", async () => {
+      setupMocks(
+        [catalogA, recipeCatalogVerified("H100")],
+        [plainKubernetesCluster],
+      );
+      render(<CreateForm />);
+      selectCatalog("recipe-mc");
+      await act(async () => {
+        formInstance?.setValue("spec.cluster", "plain-k8s");
+      });
+
+      // A GPU-less cluster is not a "disjoint verified list" — the notice
+      // must not claim to be showing alternative accelerators.
+      expect(
+        screen.queryByTestId("endpoint-accelerator-unverified-notice"),
+      ).toBeNull();
+    });
+
     it("shows no notice and keeps the verified-only options when the lists intersect", async () => {
       await renderWithVerified("T4");
 

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -4136,6 +4136,69 @@ describe("useEndpointForm", () => {
     });
   });
 
+  // NEU-590: the hardware-verified list is advice, not a gate. When none of
+  // the recipe's validated GPUs exist in the cluster, the accelerator picker
+  // must stay visible and fall back to every available accelerator, with a
+  // notice — not disappear behind "Show all options".
+  describe("unverified accelerator fallback (NEU-590)", () => {
+    const recipeCatalogVerified = (verified: string) => ({
+      ...recipeCatalog,
+      metadata: {
+        name: "recipe-mc",
+        annotations: { "recipe.vllm.ai/hardware-verified": verified },
+      },
+      spec: {
+        ...recipeCatalog.spec,
+        variants: {
+          default: {
+            ...recipeCatalog.spec.variants.default,
+            vram_minimum_gb: 4,
+          },
+        },
+      },
+    });
+
+    async function renderWithVerified(verified: string) {
+      setupMocks(
+        [catalogA, recipeCatalogVerified(verified)],
+        [plainKubernetesClusterWithNodeResources],
+      );
+      render(<CreateForm />);
+      selectCatalog("recipe-mc");
+      await act(async () => {
+        formInstance?.setValue("spec.cluster", "plain-k8s-node-resources");
+      });
+    }
+
+    it("keeps the picker usable with all cluster accelerators when the verified list is disjoint", async () => {
+      await renderWithVerified("H100");
+
+      // The picker is still rendered (not replaced by a notice-only block)...
+      const field = screen.getByTestId("field-spec.resources.accelerator");
+      const trigger = field.querySelector('button[role="combobox"]');
+      expect(trigger).toBeTruthy();
+      // ...and enabled, which proves the fallback options are non-empty (the
+      // combobox is disabled whenever displayedAcceleratorOptions is empty).
+      expect((trigger as HTMLButtonElement).disabled).toBe(false);
+      // The unvalidated-hardware notice is shown alongside it.
+      expect(
+        screen.getByTestId("endpoint-accelerator-unverified-notice"),
+      ).toBeTruthy();
+    });
+
+    it("shows no notice and keeps the verified-only options when the lists intersect", async () => {
+      await renderWithVerified("T4");
+
+      const field = screen.getByTestId("field-spec.resources.accelerator");
+      const trigger = field.querySelector('button[role="combobox"]');
+      expect(trigger).toBeTruthy();
+      expect((trigger as HTMLButtonElement).disabled).toBe(false);
+      expect(
+        screen.queryByTestId("endpoint-accelerator-unverified-notice"),
+      ).toBeNull();
+    });
+  });
+
   // NEU-503: the model-exists check must be driven by an exact-name lookup,
   // not by whatever page the dropdown's search last fetched.
   describe("model existence validation (NEU-503)", () => {

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -1119,18 +1119,22 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   // (verifiedProducts) and present in the selected cluster (acceleratorOptions);
   // "Show all options" reveals every available product.
   const restrictAcceleratorToVerified = !showFull && verifiedProducts.size > 0;
-  const displayedAcceleratorOptions = restrictAcceleratorToVerified
+  const verifiedAcceleratorOptions = restrictAcceleratorToVerified
     ? acceleratorOptions.filter((opt) =>
         matchesAcceleratorName(opt.product, verifiedProducts),
       )
     : acceleratorOptions;
-  // No validated + available GPU in this cluster → hide the product picker and
-  // just surface the required VRAM (the user can still expand "Show all
-  // options" to pick any available accelerator).
+  // No validated GPU in this cluster → the picker must stay usable (NEU-590:
+  // selecting a card is a deploy essential, and the verified list is advice,
+  // not a gate), so fall back to every available accelerator and render an
+  // unvalidated-hardware notice next to the picker instead of hiding it.
   const noVerifiedAcceleratorAvailable =
     restrictAcceleratorToVerified &&
     Boolean(currentCluster) &&
-    displayedAcceleratorOptions.length === 0;
+    verifiedAcceleratorOptions.length === 0;
+  const displayedAcceleratorOptions = noVerifiedAcceleratorAvailable
+    ? acceleratorOptions
+    : verifiedAcceleratorOptions;
 
   const formWithTransformedOnFinish = {
     ...form,
@@ -1779,86 +1783,82 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                       data-testid="endpoint-accelerator-allocator-row"
                       className="contents"
                     >
-                      {noVerifiedAcceleratorAvailable ? (
-                        // No validated GPU exists in this cluster — don't offer
-                        // a product, just state the VRAM requirement.
-                        <div className="col-span-1 min-w-0 space-y-1 sm:col-span-2">
-                          <div className="text-sm font-medium">
-                            {t("endpoints.fields.accelerator")}
-                          </div>
-                          <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
-                            {t(
-                              "endpoints.recipe.noVerifiedAccelerator",
-                              "No validated GPU available in this cluster.",
-                            )}
-                            {activeVariantVram != null && (
-                              <span className="ml-1">
-                                {t(
-                                  "endpoints.recipe.requiredVram",
-                                  "Requires ≥ {{gb}} GB VRAM.",
-                                  { gb: activeVariantVram },
-                                )}
-                              </span>
-                            )}
-                          </div>
-                        </div>
-                      ) : (
-                        <FormFieldGroup
-                          {...form}
-                          name="spec.resources.accelerator"
-                          label={t("endpoints.fields.accelerator")}
-                          className="col-span-1 min-w-0 sm:col-span-2"
+                      <FormFieldGroup
+                        {...form}
+                        name="spec.resources.accelerator"
+                        label={t("endpoints.fields.accelerator")}
+                        className="col-span-1 min-w-0 sm:col-span-2"
+                      >
+                        <FormCombobox
+                          options={displayedAcceleratorOptions.map((opt) => ({
+                            label: opt.label,
+                            value: opt.value,
+                          }))}
+                          value={
+                            selectedAccelerator?.type &&
+                            selectedAccelerator?.product
+                              ? `${selectedAccelerator.type}:${selectedAccelerator.product}`
+                              : ""
+                          }
+                          onChange={(value) => {
+                            // Parse "type:product" format
+                            const selectedOption =
+                              displayedAcceleratorOptions.find(
+                                (opt) => opt.value === value,
+                              );
+                            if (selectedOption) {
+                              const currentVirtualization = form.getValues(
+                                "spec.resources.accelerator.virtualization",
+                              );
+                              form.setValue("spec.resources.accelerator", {
+                                type: selectedOption.type,
+                                product: selectedOption.product,
+                                ...(isSelectedClusterVgpuEnabled
+                                  ? {
+                                      virtualization:
+                                        currentVirtualization || {},
+                                    }
+                                  : {}),
+                              } satisfies ResourceSpec["accelerator"]);
+                            } else {
+                              form.setValue("spec.resources.accelerator", null);
+                            }
+                          }}
+                          placeholder={t(
+                            "endpoints.placeholders.selectAccelerator",
+                          )}
+                          disabled={
+                            !currentCluster ||
+                            displayedAcceleratorOptions.length === 0
+                          }
+                          emptyMessage={t(
+                            "endpoints.messages.noAcceleratorsAvailable",
+                          )}
+                        />
+                      </FormFieldGroup>
+                      {noVerifiedAcceleratorAvailable && (
+                        // The recipe's validated GPU list has no overlap with
+                        // this cluster — the picker above falls back to every
+                        // available accelerator; surface that plus the VRAM
+                        // floor so the fallback is an informed choice.
+                        <div
+                          data-testid="endpoint-accelerator-unverified-notice"
+                          className="col-span-1 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground sm:col-span-2"
                         >
-                          <FormCombobox
-                            options={displayedAcceleratorOptions.map((opt) => ({
-                              label: opt.label,
-                              value: opt.value,
-                            }))}
-                            value={
-                              selectedAccelerator?.type &&
-                              selectedAccelerator?.product
-                                ? `${selectedAccelerator.type}:${selectedAccelerator.product}`
-                                : ""
-                            }
-                            onChange={(value) => {
-                              // Parse "type:product" format
-                              const selectedOption =
-                                displayedAcceleratorOptions.find(
-                                  (opt) => opt.value === value,
-                                );
-                              if (selectedOption) {
-                                const currentVirtualization = form.getValues(
-                                  "spec.resources.accelerator.virtualization",
-                                );
-                                form.setValue("spec.resources.accelerator", {
-                                  type: selectedOption.type,
-                                  product: selectedOption.product,
-                                  ...(isSelectedClusterVgpuEnabled
-                                    ? {
-                                        virtualization:
-                                          currentVirtualization || {},
-                                      }
-                                    : {}),
-                                } satisfies ResourceSpec["accelerator"]);
-                              } else {
-                                form.setValue(
-                                  "spec.resources.accelerator",
-                                  null,
-                                );
-                              }
-                            }}
-                            placeholder={t(
-                              "endpoints.placeholders.selectAccelerator",
-                            )}
-                            disabled={
-                              !currentCluster ||
-                              displayedAcceleratorOptions.length === 0
-                            }
-                            emptyMessage={t(
-                              "endpoints.messages.noAcceleratorsAvailable",
-                            )}
-                          />
-                        </FormFieldGroup>
+                          {t(
+                            "endpoints.recipe.noVerifiedAccelerator",
+                            "This recipe has not been validated on the GPUs in this cluster — showing all available accelerators.",
+                          )}
+                          {activeVariantVram != null && (
+                            <span className="ml-1">
+                              {t(
+                                "endpoints.recipe.requiredVram",
+                                "Requires ≥ {{gb}} GB VRAM.",
+                                { gb: activeVariantVram },
+                              )}
+                            </span>
+                          )}
+                        </div>
                       )}
                     </div>
 

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -1128,9 +1128,13 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   // selecting a card is a deploy essential, and the verified list is advice,
   // not a gate), so fall back to every available accelerator and render an
   // unvalidated-hardware notice next to the picker instead of hiding it.
+  // Requires the cluster to actually offer accelerators — a GPU-less cluster
+  // (or one whose resource info hasn't loaded yet) is not a "disjoint
+  // verified list" and must not claim to be showing alternatives.
   const noVerifiedAcceleratorAvailable =
     restrictAcceleratorToVerified &&
     Boolean(currentCluster) &&
+    acceleratorOptions.length > 0 &&
     verifiedAcceleratorOptions.length === 0;
   const displayedAcceleratorOptions = noVerifiedAcceleratorAvailable
     ? acceleratorOptions

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -839,7 +839,7 @@
 			"resourceEstimate": "Resource estimate",
 			"estimatedVram": "Estimated VRAM",
 			"replicasCount": "{{count}} replica",
-			"noVerifiedAccelerator": "No validated GPU available in this cluster.",
+			"noVerifiedAccelerator": "This recipe has not been validated on the GPUs in this cluster — showing all available accelerators.",
 			"requiredVram": "Requires ≥ {{gb}} GB VRAM.",
 			"vramSufficient": "Sufficient VRAM: {{total}} GB available, {{required}} GB required",
 			"vramInsufficient": "Insufficient VRAM: {{total}} GB available, {{required}} GB required",


### PR DESCRIPTION
## Summary

In simplified recipe deploy, when the recipe's `recipe.vllm.ai/hardware-verified` list had no intersection with the GPU products reported by the selected cluster, the accelerator picker was replaced by a notice-only block ("No validated GPU available in this cluster"). The GPU count input stayed disabled and the only recovery path was the easy-to-miss "Show all options" toggle, leaving users unable to configure an accelerator at all.

Jira: NEU-590

## Changes

- When the verified list matches nothing in the cluster, the accelerator picker now stays visible and falls back to every available cluster accelerator; the verified-only filtering is unchanged when the intersection is non-empty.
- The notice is rendered alongside the picker (with `data-testid="endpoint-accelerator-unverified-notice"`) instead of replacing it, and its copy now explains the fallback: "This recipe has not been validated on the GPUs in this cluster — showing all available accelerators. Requires ≥ X GB VRAM."

## Tests

- Unit: new `unverified accelerator fallback (NEU-590)` cases covering disjoint (picker enabled with fallback options + notice shown) and intersecting (verified-only options, no notice) verified lists.
- E2E: reworked the disjoint-hardware spec to assert the picker offers all cluster accelerators without expanding "Show all options".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EiYUheR1wej3yixz7tPsY