### PR TITLE
feat: expose endpoint monitoring for all engines

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -176,7 +176,7 @@
   "src/domains/endpoint/types.ts": "5caf279683a1f70a559009c4dd53dbd0",
   "src/domains/endpoint/hooks/use-chat-state.ts": "7555e18e5668956e332598e536bdb46a",
   "src/domains/endpoint/hooks/use-endpoint-log-sources.ts": "db5f58fbfdf90e73192f68cd4c29b7da",
-  "src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts": "5980494bc4a8d91c2a7eac8b4ab5cfc3",
+  "src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts": "f81266b161eca80a40cbba56086e81b6",
   "src/domains/endpoint/hooks/use-endpoint-resources.ts": "c1b719ca155f472655bf0644f278e041",
   "src/domains/endpoint/hooks/use-streaming-logs.ts": "f13d3f714694d7cd73b805269b6586ad",
   "src/domains/endpoint/components/ChatPlayground.tsx": "7aa3bbbeeccfe2cb6caeef96b56596fa",

--- a/e2e/tests/endpoints.spec.ts
+++ b/e2e/tests/endpoints.spec.ts
@@ -1,3 +1,4 @@
+import { config } from "../config";
 import { expect, test } from "../fixtures/base";
 import { ApiHelper } from "../helpers/api-helper";
 import { MULTI_USER_TIMEOUT } from "../helpers/constants";
@@ -7,10 +8,12 @@ import { ResourcePage } from "../helpers/resource-page";
 const irName = { value: "" }; // Image registry for cluster dependency
 const clusterName = { value: "" };
 const engineName = { value: "" };
+const nonLlmEngineName = { value: "" };
 const mrName = { value: "" };
 const mcNames = { a: "", b: "" }; // Model catalogs for template selection tests
 const epNames = {
   base: "", // primary endpoint for list/detail/edit
+  nonLlm: "", // endpoint using a non-LLM engine for monitor coverage
   sort: "", // second endpoint for sort ordering
 };
 
@@ -24,8 +27,10 @@ test.describe("endpoints", () => {
     irName.value = `test-ep-ir-${ts}`;
     clusterName.value = `test-ep-cl-${ts}`;
     engineName.value = `test-ep-engine-${ts}`;
+    nonLlmEngineName.value = `test-ep-non-llm-engine-${ts}`;
     mrName.value = `test-ep-mr-${ts}`;
     epNames.base = `test-ep-base-${ts}`;
+    epNames.nonLlm = `test-ep-non-llm-${ts}`;
     epNames.sort = `test-ep-sort-${ts}`;
 
     mcNames.a = `test-ep-mc-a-${ts}`;
@@ -47,6 +52,9 @@ test.describe("endpoints", () => {
         },
       },
     });
+    await api.createEngine(nonLlmEngineName.value, {
+      supportedTasks: ["text-embedding"],
+    });
     await api.createModelRegistry(mrName.value);
     await api.createModelCatalog(mcNames.a, {
       modelVersion: "2.0",
@@ -61,6 +69,13 @@ test.describe("endpoints", () => {
     await api.createEndpoint(epNames.base, {
       cluster: clusterName.value,
       modelRegistry: mrName.value,
+    });
+    await api.createEndpoint(epNames.nonLlm, {
+      cluster: clusterName.value,
+      modelRegistry: mrName.value,
+      engine: nonLlmEngineName.value,
+      engineVersion: "v1.0",
+      modelTask: "text-embedding",
     });
     await api.createEndpoint(epNames.sort, {
       cluster: clusterName.value,
@@ -86,6 +101,7 @@ test.describe("endpoints", () => {
     await Promise.all([
       api.deleteCluster(clusterName.value, { force: true }).catch(() => {}),
       api.deleteEngine(engineName.value, { force: true }).catch(() => {}),
+      api.deleteEngine(nonLlmEngineName.value, { force: true }).catch(() => {}),
       api.deleteModelRegistry(mrName.value, { force: true }).catch(() => {}),
       api.deleteModelCatalog(mcNames.a).catch(() => {}),
       api.deleteModelCatalog(mcNames.b).catch(() => {}),
@@ -296,6 +312,58 @@ test.describe("endpoints", () => {
       ).toBeVisible();
       await expect(
         showPage.getByRole("term").filter({ hasText: /updated at/i }),
+      ).toBeVisible();
+    });
+
+    test("monitor exposes LLM semantic panels", { tag: "@C2737863" }, async ({
+      endpoints,
+    }) => {
+      test.skip(
+        config.engine.name !== "vllm" && config.engine.name !== "sglang",
+        "LLM monitor panel coverage requires a vllm or sglang E2E profile",
+      );
+
+      await endpoints.goToShow(epNames.base);
+
+      const showPage = endpoints.page.locator('[data-testid="show-page"]');
+      const monitorTab = showPage.getByRole("tab", { name: /monitor/i });
+      await expect(monitorTab).toBeVisible();
+      await monitorTab.click();
+
+      const panelSelector = endpoints.page.getByRole("group", {
+        name: /monitor/i,
+      });
+      await expect(panelSelector).toBeVisible();
+      await expect(panelSelector.getByRole("button")).toHaveCount(5);
+      await expect(
+        endpoints.page.getByTitle(
+          /grafana dashboard neutree-endpoint-overview-embed/i,
+        ),
+      ).toBeVisible();
+    });
+
+    test("monitor exposes overview only for non-LLM engines", {
+      tag: "@C2737864",
+    }, async ({ endpoints }) => {
+      await endpoints.goToShow(epNames.nonLlm);
+
+      const nonLlmShowPage = endpoints.page.locator(
+        '[data-testid="show-page"]',
+      );
+      const nonLlmMonitorTab = nonLlmShowPage.getByRole("tab", {
+        name: /monitor/i,
+      });
+      await expect(nonLlmMonitorTab).toBeVisible();
+      await nonLlmMonitorTab.click();
+
+      const panelSelector = endpoints.page.getByRole("group", {
+        name: /monitor/i,
+      });
+      await expect(panelSelector).toBeHidden();
+      await expect(
+        endpoints.page.getByTitle(
+          /grafana dashboard neutree-endpoint-overview-embed/i,
+        ),
       ).toBeVisible();
     });
 

--- a/src/domains/endpoint/hooks/use-endpoint-monitor-panels.test.ts
+++ b/src/domains/endpoint/hooks/use-endpoint-monitor-panels.test.ts
@@ -16,12 +16,14 @@ describe("useEndpointMonitorPanels", () => {
     expect(result.current.showSelector).toBe(false);
   });
 
-  it("should return empty panels without a supported engine", () => {
-    const { result } = renderHook(() => useEndpointMonitorPanels({}));
+  it("should return an overview panel for a non-LLM engine", () => {
+    const { result } = renderHook(() =>
+      useEndpointMonitorPanels({ engineType: "llama-cpp" }),
+    );
 
-    expect(result.current.panels).toEqual([]);
-    expect(result.current.selectedPanel).toBeNull();
-    expect(result.current.showMonitorTab).toBe(false);
+    expect(result.current.panels).toEqual(["overview"]);
+    expect(result.current.selectedPanel).toBe("overview");
+    expect(result.current.showMonitorTab).toBe(true);
     expect(result.current.showSelector).toBe(false);
   });
 
@@ -125,5 +127,25 @@ describe("useEndpointMonitorPanels", () => {
     rerender({ engineType: "vllm" });
 
     expect(result.current.selectedPanel).toBe("cache");
+  });
+
+  it("should fall back to overview when switching to a non-LLM engine", () => {
+    const { result, rerender } = renderHook(
+      ({ engineType }: UseHookArgs) => useEndpointMonitorPanels({ engineType }),
+      {
+        initialProps: { engineType: "vllm" } as UseHookArgs,
+      },
+    );
+
+    act(() => {
+      result.current.setSelectedPanel("queue");
+    });
+
+    rerender({ engineType: "llama-cpp" });
+
+    expect(result.current.panels).toEqual(["overview"]);
+    expect(result.current.selectedPanel).toBe("overview");
+    expect(result.current.showMonitorTab).toBe(true);
+    expect(result.current.showSelector).toBe(false);
   });
 });

--- a/src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts
+++ b/src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts
@@ -18,8 +18,12 @@ export const useEndpointMonitorPanels = ({
   engineType,
 }: UseEndpointMonitorPanelsProps) => {
   const panels = useMemo(() => {
-    if (engineType !== "vllm" && engineType !== "sglang") {
+    if (!engineType) {
       return [];
+    }
+
+    if (engineType !== "vllm" && engineType !== "sglang") {
+      return ["overview"] satisfies EndpointMonitorPanelType[];
     }
 
     return [


### PR DESCRIPTION
## Summary

- Show the Endpoint Monitor tab for every configured engine.
- Keep five LLM panels for vllm and sglang; render Overview only for other engines.
- Add hook coverage and API-seeded Playwright coverage for both panel policies.

## Test Plan

### Unit test

- `yarn test` (102 files, 1165 tests)
- `yarn typecheck`
- `yarn lint:ci` (zero errors; existing warnings remain)
- `yarn build`

### DB test

- Not applicable: no backend, API, or database changes.

### E2E test

- Passed: `vllm` Endpoint Monitor displays Overview, Latency, Throughput, Queue, and Cache. Verified with paused `qwen3.5-4b-1` (`vllm:v0.24.0`).
- Passed: non-LLM Endpoint Monitor displays Overview only with no panel selector. Verified with `asr-k8s` (`flex:v0.1.1`).