### PR TITLE
ci: bump nightly base version to v1.2.0

### DIFF
--- a/.github/workflows/daily-build.yaml
+++ b/.github/workflows/daily-build.yaml
@@ -23,6 +23,6 @@ jobs:
       - name: Create Nightly Tag
         run: |
           DATE=$(date +'%Y%m%d')
-          TAG="v1.1.1-nightly-${DATE}"
+          TAG="v1.2.0-nightly-${DATE}"
           git tag "${TAG}" -m "${TAG}"
           git push origin "${TAG}"


### PR DESCRIPTION
## Issues

n/a

## Changes

- Generate UI nightly tags as v1.2.0-nightly-YYYYMMDD.

## Test

### Unit test

- N/A: CI workflow configuration only.
- `git diff --check` and Ruby YAML parsing passed.

### DB test

- N/A: no database changes.

### E2E test

- N/A: no runtime behavior changed; manual testing is not required.

## Risk & Rollback

Low code risk. Merge the UI, Neutree, and enterprise PRs before the next 00:00 UTC UI nightly window so all same-day dependency tags use v1.2.0. If the coordinated cutover is missed, avoid the enterprise nightly until the matching UI and community tags exist, or manually dispatch the upstream workflows first. Revert the workflow base version before the next nightly run to restore v1.1.1 tags.

_Trivial CI configuration change; docs MR and TestRail are not applicable._