### PR TITLE
feat: filter the access log by any status code (NEU-581)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -290,8 +290,8 @@
   "src/domains/external-endpoint/components/TestConnectivityButton.tsx": "c4c97cc62ad41f004d08238c569e0054",
   "src/domains/external-endpoint/hooks/use-test-connectivity.ts": "71fed924f6125ed6cfbbc8891b96c282",
   "src/domains/external-endpoint/hooks/use-model-mapping-rows.ts": "8acf1e3078e104a09eaa7ce60bb41b56",
-  "src/pages/ai-traces/list.tsx": "9010fcb000a396cfbfbb35f7b273c13b",
-  "src/pages/ai-traces/components/TraceDetailDrawer.tsx": "c1b0f27279fabc6712be1106a499a501",
+  "src/pages/ai-traces/list.tsx": "92a19df13bb9bc96db3eee9535d46202",
+  "src/pages/ai-traces/components/TraceDetailDrawer.tsx": "036f00b452cfcdc0a0fd01687b621e85",
   "src/pages/ai-traces/components/TraceStatsChart.tsx": "a7d1563a26479dc5d39dfe7f2b25d2f6",
   "src/foundation/lib/api/ai-traces.ts": "bcc854067422a7e98d439ba1fcd7f36f",
   "src/foundation/components/DateRangePicker.tsx": "7db897cba5bece0433e75fcd91d305b1",
@@ -336,5 +336,7 @@
   "src/foundation/lib/token-quota.ts": "dee58b27c987d8ba96b05ac695044ebc",
   "src/domains/api-key/components/TokenQuotaField.tsx": "a7c98aedb46387b79bc766104feb9217",
   "src/domains/endpoint/components/ParameterSlider.tsx": "f9fd46610b6416c4164158bd71302930",
-  "src/foundation/lib/device-resource-utils.ts": "7be0c31919e517221667a491023cf5a1"
+  "src/foundation/lib/device-resource-utils.ts": "7be0c31919e517221667a491023cf5a1",
+  "src/pages/ai-traces/status.tsx": "8db808b9824fbec7e25a1f8226078e14",
+  "src/pages/ai-traces/components/StatusCodeFilter.tsx": "9f36fc145c432c079c278378ba8cf882"
 }

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -337,6 +337,6 @@
   "src/domains/api-key/components/TokenQuotaField.tsx": "a7c98aedb46387b79bc766104feb9217",
   "src/domains/endpoint/components/ParameterSlider.tsx": "f9fd46610b6416c4164158bd71302930",
   "src/foundation/lib/device-resource-utils.ts": "7be0c31919e517221667a491023cf5a1",
-  "src/pages/ai-traces/status.tsx": "8db808b9824fbec7e25a1f8226078e14",
+  "src/pages/ai-traces/status.tsx": "115ed148e0cb242ef1a5bc53c0408097",
   "src/pages/ai-traces/components/StatusCodeFilter.tsx": "9f36fc145c432c079c278378ba8cf882"
 }

--- a/e2e/tests/ai-traces-ui.spec.ts
+++ b/e2e/tests/ai-traces-ui.spec.ts
@@ -2,8 +2,9 @@ import { expect, test } from "../fixtures/base";
 import { aiTraceEnv, chatCompletion } from "../helpers/ai-trace";
 
 // TestRail suite 2420, Access Log section — frontend UI cases
-// (列表 / 活动柱状图 / 详情抽屉). The ai-traces UI has no data-testids, so
-// selectors rely on the i18n labels. Opt-in via E2E_AITRACE_ENDPOINT.
+// (list / activity chart / detail drawer). The ai-traces UI is almost free of
+// data-testids, so selectors mostly rely on the i18n labels.
+// Opt-in via E2E_AITRACE_ENDPOINT.
 
 const env = aiTraceEnv();
 const e = env as NonNullable<typeof env>;
@@ -102,6 +103,32 @@ test.describe("access log — UI", () => {
     await page
       .getByPlaceholder("Endpoint name")
       .fill(`no-such-endpoint-${Date.now()}`);
+    await expect(
+      page.getByText("No access logs in the selected window."),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("status filter accepts both suggested and free-typed codes", async ({
+    page,
+  }) => {
+    await openFiltered(page);
+    const rows = page.locator("tbody tr");
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+
+    const trigger = page.getByTestId("status-filter");
+    const options = page.locator('[data-state="open"][role="dialog"]');
+
+    // A suggested code — the seeded traces all succeeded.
+    await trigger.click();
+    await options.getByRole("option", { name: /^200/ }).click();
+    await expect(trigger).toHaveText("200");
+    await expect(rows.first()).toBeVisible({ timeout: 15_000 });
+
+    // A code that is not in the suggestion list is still selectable.
+    await trigger.click();
+    await options.getByPlaceholder("Type or pick a status code").fill("418");
+    await options.getByRole("option", { name: /^418/ }).click();
+    await expect(trigger).toHaveText("418");
     await expect(
       page.getByText("No access logs in the selected window."),
     ).toBeVisible({ timeout: 15_000 });

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1503,6 +1503,7 @@
 			"finishReason": "Finish"
 		},
 		"status": {
+			"classInfo": "Informational — the server acknowledged the request and is still processing it.",
 			"classSuccess": "Success — the request completed normally.",
 			"classRedirect": "Redirect.",
 			"classClient": "Client error — the request was rejected.",
@@ -1522,6 +1523,7 @@
 				"503": "Service unavailable — no healthy upstream was available to serve the request.",
 				"504": "Gateway timeout — the upstream did not respond within the time limit."
 			},
+			"shortInfo": "Informational",
 			"shortSuccess": "Success",
 			"shortRedirect": "Redirect",
 			"shortClient": "Client error",

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1481,6 +1481,8 @@
 			"allTypes": "All types",
 			"status": "Status",
 			"allStatuses": "All statuses",
+			"statusSearch": "Type or pick a status code",
+			"statusHint": "Enter a 3-digit status code (100–599).",
 			"model": "Model",
 			"apiKey": "API key",
 			"allApiKeys": "All API keys",
@@ -1507,6 +1509,7 @@
 			"classServer": "Server error — the gateway or upstream failed.",
 			"unknown": "Unknown status.",
 			"description": {
+				"200": "OK — the request completed successfully.",
 				"400": "Bad request — the request was malformed or rejected by the gateway.",
 				"401": "Unauthorized — the API key is missing or invalid.",
 				"403": "Forbidden — the API key is not allowed to access this resource.",
@@ -1518,6 +1521,24 @@
 				"502": "Bad gateway — the upstream returned an invalid response.",
 				"503": "Service unavailable — no healthy upstream was available to serve the request.",
 				"504": "Gateway timeout — the upstream did not respond within the time limit."
+			},
+			"shortSuccess": "Success",
+			"shortRedirect": "Redirect",
+			"shortClient": "Client error",
+			"shortServer": "Server error",
+			"short": {
+				"200": "OK",
+				"400": "Bad request",
+				"401": "Unauthorized",
+				"403": "Forbidden",
+				"404": "Not found",
+				"408": "Request timeout",
+				"429": "Too many requests",
+				"499": "Client closed request",
+				"500": "Internal server error",
+				"502": "Bad gateway",
+				"503": "Service unavailable",
+				"504": "Gateway timeout"
 			}
 		},
 		"detail": {

--- a/src/pages/ai-traces/components/StatusCodeFilter.test.tsx
+++ b/src/pages/ai-traces/components/StatusCodeFilter.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/foundation/lib/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { StatusCodeFilter } from "./StatusCodeFilter";
+
+// cmdk observes and scrolls its list; jsdom implements neither.
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+Element.prototype.scrollIntoView = vi.fn();
+
+function openFilter(value = "") {
+  const onChange = vi.fn();
+  render(<StatusCodeFilter value={value} onChange={onChange} />);
+  fireEvent.click(screen.getByTestId("status-filter"));
+  return {
+    onChange,
+    search: screen.getByPlaceholderText("ai_traces.filters.statusSearch"),
+  };
+}
+
+const codesInList = () =>
+  screen
+    .queryAllByRole("option")
+    .map((el) => el.getAttribute("data-value"))
+    .filter((v) => v !== "all");
+
+/** Clicks an option in the popover (the trigger can show the same text). */
+const clickOption = (name: string) =>
+  fireEvent.click(within(screen.getByRole("listbox")).getByText(name));
+
+describe("StatusCodeFilter", () => {
+  it("suggests the well-known codes, including 499", () => {
+    openFilter();
+
+    expect(codesInList()).toEqual([
+      "200",
+      "400",
+      "401",
+      "403",
+      "404",
+      "408",
+      "429",
+      "499",
+      "500",
+      "502",
+      "503",
+      "504",
+    ]);
+  });
+
+  it("selects a suggested code", () => {
+    const { onChange } = openFilter();
+
+    clickOption("499");
+
+    expect(onChange).toHaveBeenCalledWith("499");
+  });
+
+  it("offers an unlisted code that the user types", () => {
+    const { onChange, search } = openFilter();
+
+    fireEvent.change(search, { target: { value: "418" } });
+    expect(codesInList()).toEqual(["418"]);
+
+    clickOption("418");
+    expect(onChange).toHaveBeenCalledWith("418");
+  });
+
+  it("does not duplicate a typed code that is already suggested", () => {
+    const { search } = openFilter();
+
+    fireEvent.change(search, { target: { value: "429" } });
+
+    expect(codesInList()).toEqual(["429"]);
+  });
+
+  it("shows a hint instead of an option for implausible input", () => {
+    const { search } = openFilter();
+
+    fireEvent.change(search, { target: { value: "12" } });
+
+    expect(codesInList()).toEqual([]);
+    expect(screen.getByText("ai_traces.filters.statusHint")).toBeTruthy();
+  });
+
+  it("keeps a previously picked unlisted code in the list", () => {
+    openFilter("418");
+
+    expect(screen.getByTestId("status-filter").textContent).toContain("418");
+    // Sorted into place between 408 and 429 rather than appended.
+    expect(codesInList()).toContain("418");
+    expect(codesInList().indexOf("418")).toBe(codesInList().indexOf("408") + 1);
+  });
+
+  it("clears the filter when the selected code is picked again", () => {
+    const { onChange } = openFilter("429");
+
+    clickOption("429");
+
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("selects all statuses", () => {
+    const { onChange } = openFilter("429");
+
+    clickOption("ai_traces.filters.allStatuses");
+
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+});

--- a/src/pages/ai-traces/components/StatusCodeFilter.tsx
+++ b/src/pages/ai-traces/components/StatusCodeFilter.tsx
@@ -1,0 +1,148 @@
+import { Check, ChevronsUpDown } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useTranslation } from "@/foundation/lib/i18n";
+import { cn } from "@/foundation/lib/utils";
+import {
+  DESCRIBED_STATUS_CODES,
+  parseStatusCode,
+  statusShortLabel,
+} from "../status";
+
+type Props = {
+  /** Selected status code as a string; "" means "all statuses". */
+  value: string;
+  onChange: (value: string) => void;
+};
+
+/**
+ * Status-code filter for the access log.
+ *
+ * The gateway can return any status code, so the well-known codes are only
+ * suggestions — typing a code that is not listed (e.g. 418) offers it as a
+ * selectable option instead of leaving it unfilterable.
+ */
+export const StatusCodeFilter = ({ value, onChange }: Props) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  // Keep a selected-but-unlisted code (from a previous free-typed pick) in the
+  // list so it renders as checked rather than silently missing.
+  const selected = parseStatusCode(value);
+  const codes = [...DESCRIBED_STATUS_CODES];
+  if (selected !== null && !codes.includes(selected)) {
+    codes.push(selected);
+    codes.sort((a, b) => a - b);
+  }
+
+  const typed = parseStatusCode(search);
+  const showCustom = typed !== null && !codes.includes(typed);
+
+  const select = (next: string) => {
+    onChange(next === value ? "" : next);
+    setOpen(false);
+    setSearch("");
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setSearch("");
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          data-testid="status-filter"
+          className={cn(
+            "w-[150px] flex justify-between font-normal",
+            !value && "text-muted-foreground",
+          )}
+        >
+          {value || t("ai_traces.filters.allStatuses")}
+          <ChevronsUpDown className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-0" align="start">
+        <Command shouldFilter>
+          <CommandInput
+            placeholder={t("ai_traces.filters.statusSearch")}
+            className="h-9"
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            <CommandEmpty>{t("ai_traces.filters.statusHint")}</CommandEmpty>
+            <CommandGroup>
+              {!search && (
+                <CommandItem value="all" onSelect={() => select("")}>
+                  {t("ai_traces.filters.allStatuses")}
+                  <Check
+                    className={cn(
+                      "ml-auto shrink-0",
+                      value ? "opacity-0" : "opacity-100",
+                    )}
+                  />
+                </CommandItem>
+              )}
+              {showCustom && (
+                <CommandItem
+                  value={String(typed)}
+                  onSelect={() => select(String(typed))}
+                >
+                  <span className="font-mono">{typed}</span>
+                  <span className="ml-2 truncate text-xs text-muted-foreground">
+                    {statusShortLabel(typed, t)}
+                  </span>
+                  <Check
+                    className={cn(
+                      "ml-auto shrink-0",
+                      value === String(typed) ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                </CommandItem>
+              )}
+              {codes.map((code) => (
+                <CommandItem
+                  key={code}
+                  value={String(code)}
+                  onSelect={() => select(String(code))}
+                >
+                  <span className="font-mono">{code}</span>
+                  <span className="ml-2 truncate text-xs text-muted-foreground">
+                    {statusShortLabel(code, t)}
+                  </span>
+                  <Check
+                    className={cn(
+                      "ml-auto shrink-0",
+                      value === String(code) ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/pages/ai-traces/components/TraceDetailDrawer.tsx
+++ b/src/pages/ai-traces/components/TraceDetailDrawer.tsx
@@ -32,6 +32,7 @@ import Timestamp from "@/foundation/components/Timestamp";
 import { type AITrace, fetchAITrace } from "@/foundation/lib/api/ai-traces";
 import { useTranslation } from "@/foundation/lib/i18n";
 import { cn } from "@/foundation/lib/utils";
+import { StatusBadge } from "../status";
 
 type Props = {
   trace: AITrace | null;
@@ -115,17 +116,7 @@ const MetaGrid = ({ trace }: { trace: AITrace }) => {
         <Timestamp timestamp={trace.time} format="YYYY-MM-DD HH:mm:ss" />
       </MetaRow>
       <MetaRow label={t("ai_traces.detail.status")}>
-        <Badge
-          variant={
-            trace.response_status >= 200 && trace.response_status < 300
-              ? "default"
-              : trace.response_status >= 400 && trace.response_status < 500
-                ? "outline"
-                : "destructive"
-          }
-        >
-          {trace.response_status || "-"}
-        </Badge>
+        <StatusBadge status={trace.response_status} />
       </MetaRow>
       <MetaRow label={t("ai_traces.detail.endpoint")}>
         <EndpointLink

--- a/src/pages/ai-traces/list.tsx
+++ b/src/pages/ai-traces/list.tsx
@@ -3,7 +3,6 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import dayjs from "dayjs";
 import { RefreshCw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -22,11 +21,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   type DateRange,
   DateRangePicker,
   trailingRange,
@@ -39,8 +33,10 @@ import { type AITrace, fetchAITraces } from "@/foundation/lib/api/ai-traces";
 import { useTranslation } from "@/foundation/lib/i18n";
 import { formatTokens } from "@/foundation/lib/unit";
 import { cn } from "@/foundation/lib/utils";
+import { StatusCodeFilter } from "./components/StatusCodeFilter";
 import { TraceDetailDrawer } from "./components/TraceDetailDrawer";
 import { TraceStatsChart } from "./components/TraceStatsChart";
+import { StatusBadge } from "./status";
 
 const LIMIT = 50;
 
@@ -187,25 +183,7 @@ export const AITracesList = () => {
             <SelectItem value="external-endpoint">external-endpoint</SelectItem>
           </SelectContent>
         </Select>
-        <Select
-          value={status || "all"}
-          onValueChange={(v) => setStatus(v === "all" ? "" : v)}
-        >
-          <SelectTrigger className="w-[150px]">
-            <SelectValue placeholder={t("ai_traces.filters.status")} />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="all">
-              {t("ai_traces.filters.allStatuses")}
-            </SelectItem>
-            <SelectItem value="200">200</SelectItem>
-            <SelectItem value="400">400</SelectItem>
-            <SelectItem value="401">401</SelectItem>
-            <SelectItem value="429">429</SelectItem>
-            <SelectItem value="500">500</SelectItem>
-            <SelectItem value="502">502</SelectItem>
-          </SelectContent>
-        </Select>
+        <StatusCodeFilter value={status} onChange={setStatus} />
         <Input
           className="w-[200px]"
           placeholder={t("ai_traces.filters.model")}
@@ -423,43 +401,4 @@ function formatDuration(durationMs?: number): React.ReactNode {
     return <span className="text-muted-foreground">-</span>;
   }
   return `${(durationMs / 1000).toFixed(2)} s`;
-}
-
-// Status codes with a maintained, gateway-accurate description (includes the
-// non-standard 499 "client closed request" and 504 "gateway timeout" seen from
-// the Kong layer). Codes outside this set fall back to a status-class hint.
-const DESCRIBED_STATUS_CODES = new Set([
-  400, 401, 403, 404, 408, 429, 499, 500, 502, 503, 504,
-]);
-
-const StatusBadge = ({ status }: { status: number }) => {
-  const { t } = useTranslation();
-  const variant =
-    status >= 200 && status < 300
-      ? "default"
-      : status >= 400 && status < 500
-        ? "outline"
-        : "destructive";
-  const description = statusDescription(status, t);
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Badge variant={variant} className="cursor-help">
-          {status || "-"}
-        </Badge>
-      </TooltipTrigger>
-      <TooltipContent className="max-w-[260px]">{description}</TooltipContent>
-    </Tooltip>
-  );
-};
-
-function statusDescription(status: number, t: (key: string) => string): string {
-  if (DESCRIBED_STATUS_CODES.has(status)) {
-    return t(`ai_traces.status.description.${status}`);
-  }
-  if (status >= 200 && status < 300) return t("ai_traces.status.classSuccess");
-  if (status >= 300 && status < 400) return t("ai_traces.status.classRedirect");
-  if (status >= 400 && status < 500) return t("ai_traces.status.classClient");
-  if (status >= 500) return t("ai_traces.status.classServer");
-  return t("ai_traces.status.unknown");
 }

--- a/src/pages/ai-traces/status.test.ts
+++ b/src/pages/ai-traces/status.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseStatusCode,
+  statusBadgeVariant,
+  statusDescription,
+  statusShortLabel,
+} from "./status";
+
+const t = (key: string) => key;
+
+describe("parseStatusCode", () => {
+  it("accepts three-digit codes in the 1xx–5xx range", () => {
+    expect(parseStatusCode("200")).toBe(200);
+    expect(parseStatusCode("499")).toBe(499);
+    expect(parseStatusCode("100")).toBe(100);
+    expect(parseStatusCode("599")).toBe(599);
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseStatusCode("  418 ")).toBe(418);
+  });
+
+  it("rejects codes outside the plausible range", () => {
+    expect(parseStatusCode("099")).toBeNull();
+    expect(parseStatusCode("600")).toBeNull();
+    expect(parseStatusCode("999")).toBeNull();
+  });
+
+  it("rejects anything that is not exactly three digits", () => {
+    expect(parseStatusCode("")).toBeNull();
+    expect(parseStatusCode("4")).toBeNull();
+    expect(parseStatusCode("40")).toBeNull();
+    expect(parseStatusCode("4000")).toBeNull();
+    expect(parseStatusCode("4xx")).toBeNull();
+    expect(parseStatusCode("+404")).toBeNull();
+    expect(parseStatusCode("40.4")).toBeNull();
+  });
+});
+
+describe("statusBadgeVariant", () => {
+  it("maps 2xx to default, 4xx to outline and everything else to destructive", () => {
+    expect(statusBadgeVariant(200)).toBe("default");
+    expect(statusBadgeVariant(204)).toBe("default");
+    expect(statusBadgeVariant(404)).toBe("outline");
+    // 499 is a 4xx code — a client disconnect, not a server failure.
+    expect(statusBadgeVariant(499)).toBe("outline");
+    expect(statusBadgeVariant(302)).toBe("destructive");
+    expect(statusBadgeVariant(503)).toBe("destructive");
+  });
+});
+
+describe("statusDescription", () => {
+  it("uses the per-code description for known codes", () => {
+    expect(statusDescription(429, t)).toBe("ai_traces.status.description.429");
+    expect(statusDescription(499, t)).toBe("ai_traces.status.description.499");
+    expect(statusDescription(200, t)).toBe("ai_traces.status.description.200");
+  });
+
+  it("falls back to a status-class hint for unlisted codes", () => {
+    expect(statusDescription(204, t)).toBe("ai_traces.status.classSuccess");
+    expect(statusDescription(302, t)).toBe("ai_traces.status.classRedirect");
+    expect(statusDescription(418, t)).toBe("ai_traces.status.classClient");
+    expect(statusDescription(507, t)).toBe("ai_traces.status.classServer");
+    expect(statusDescription(0, t)).toBe("ai_traces.status.unknown");
+  });
+});
+
+describe("statusShortLabel", () => {
+  it("uses the per-code short label for known codes", () => {
+    expect(statusShortLabel(499, t)).toBe("ai_traces.status.short.499");
+  });
+
+  it("falls back to a class label for unlisted codes", () => {
+    expect(statusShortLabel(204, t)).toBe("ai_traces.status.shortSuccess");
+    expect(statusShortLabel(302, t)).toBe("ai_traces.status.shortRedirect");
+    expect(statusShortLabel(418, t)).toBe("ai_traces.status.shortClient");
+    expect(statusShortLabel(507, t)).toBe("ai_traces.status.shortServer");
+    expect(statusShortLabel(0, t)).toBe("ai_traces.status.unknown");
+  });
+});

--- a/src/pages/ai-traces/status.test.ts
+++ b/src/pages/ai-traces/status.test.ts
@@ -57,6 +57,8 @@ describe("statusDescription", () => {
   });
 
   it("falls back to a status-class hint for unlisted codes", () => {
+    // Every code parseStatusCode accepts gets a class hint, 1xx included.
+    expect(statusDescription(100, t)).toBe("ai_traces.status.classInfo");
     expect(statusDescription(204, t)).toBe("ai_traces.status.classSuccess");
     expect(statusDescription(302, t)).toBe("ai_traces.status.classRedirect");
     expect(statusDescription(418, t)).toBe("ai_traces.status.classClient");
@@ -71,6 +73,7 @@ describe("statusShortLabel", () => {
   });
 
   it("falls back to a class label for unlisted codes", () => {
+    expect(statusShortLabel(100, t)).toBe("ai_traces.status.shortInfo");
     expect(statusShortLabel(204, t)).toBe("ai_traces.status.shortSuccess");
     expect(statusShortLabel(302, t)).toBe("ai_traces.status.shortRedirect");
     expect(statusShortLabel(418, t)).toBe("ai_traces.status.shortClient");

--- a/src/pages/ai-traces/status.tsx
+++ b/src/pages/ai-traces/status.tsx
@@ -1,0 +1,85 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useTranslation } from "@/foundation/lib/i18n";
+
+// Status codes with a maintained, gateway-accurate description (includes the
+// non-standard 499 "client closed request" and 504 "gateway timeout" seen from
+// the Kong layer). Codes outside this set fall back to a status-class hint.
+// This is also the suggestion list of the status filter — the gateway can emit
+// any code, so the filter accepts arbitrary ones on top of these.
+export const DESCRIBED_STATUS_CODES = [
+  200, 400, 401, 403, 404, 408, 429, 499, 500, 502, 503, 504,
+];
+
+const DESCRIBED = new Set(DESCRIBED_STATUS_CODES);
+
+/**
+ * Parses free-typed filter input into an HTTP status code.
+ * Returns null when the input is not a plausible code (three digits, 1xx–5xx).
+ */
+export function parseStatusCode(input: string): number | null {
+  const trimmed = input.trim();
+  if (!/^\d{3}$/.test(trimmed)) return null;
+  const code = Number(trimmed);
+  return code >= 100 && code <= 599 ? code : null;
+}
+
+export function statusBadgeVariant(
+  status: number,
+): "default" | "outline" | "destructive" {
+  if (status >= 200 && status < 300) return "default";
+  if (status >= 400 && status < 500) return "outline";
+  return "destructive";
+}
+
+export function statusDescription(
+  status: number,
+  t: (key: string) => string,
+): string {
+  if (DESCRIBED.has(status)) {
+    return t(`ai_traces.status.description.${status}`);
+  }
+  if (status >= 200 && status < 300) return t("ai_traces.status.classSuccess");
+  if (status >= 300 && status < 400) return t("ai_traces.status.classRedirect");
+  if (status >= 400 && status < 500) return t("ai_traces.status.classClient");
+  if (status >= 500) return t("ai_traces.status.classServer");
+  return t("ai_traces.status.unknown");
+}
+
+/**
+ * Short label for a status code — a couple of words, for lists where the full
+ * sentence from `statusDescription` would be truncated.
+ */
+export function statusShortLabel(
+  status: number,
+  t: (key: string) => string,
+): string {
+  if (DESCRIBED.has(status)) {
+    return t(`ai_traces.status.short.${status}`);
+  }
+  if (status >= 200 && status < 300) return t("ai_traces.status.shortSuccess");
+  if (status >= 300 && status < 400) return t("ai_traces.status.shortRedirect");
+  if (status >= 400 && status < 500) return t("ai_traces.status.shortClient");
+  if (status >= 500) return t("ai_traces.status.shortServer");
+  return t("ai_traces.status.unknown");
+}
+
+export const StatusBadge = ({ status }: { status: number }) => {
+  const { t } = useTranslation();
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge variant={statusBadgeVariant(status)} className="cursor-help">
+          {status || "-"}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-[260px]">
+        {statusDescription(status, t)}
+      </TooltipContent>
+    </Tooltip>
+  );
+};

--- a/src/pages/ai-traces/status.tsx
+++ b/src/pages/ai-traces/status.tsx
@@ -43,6 +43,7 @@ export function statusDescription(
   if (DESCRIBED.has(status)) {
     return t(`ai_traces.status.description.${status}`);
   }
+  if (status >= 100 && status < 200) return t("ai_traces.status.classInfo");
   if (status >= 200 && status < 300) return t("ai_traces.status.classSuccess");
   if (status >= 300 && status < 400) return t("ai_traces.status.classRedirect");
   if (status >= 400 && status < 500) return t("ai_traces.status.classClient");
@@ -61,6 +62,7 @@ export function statusShortLabel(
   if (DESCRIBED.has(status)) {
     return t(`ai_traces.status.short.${status}`);
   }
+  if (status >= 100 && status < 200) return t("ai_traces.status.shortInfo");
   if (status >= 200 && status < 300) return t("ai_traces.status.shortSuccess");
   if (status >= 300 && status < 400) return t("ai_traces.status.shortRedirect");
   if (status >= 400 && status < 500) return t("ai_traces.status.shortClient");


### PR DESCRIPTION
## What

The Access Log status filter offered six hardcoded codes (200/400/401/429/500/502). Codes the gateway actually returns — 499 among them, which already has its own badge description — could not be filtered on at all.

The filter is now a combobox: the well-known codes are suggestions, and typing any plausible three-digit code (100–599) offers it as a selectable option.

- A selected-but-unlisted code stays in the list, sorted into place, so it renders as checked.
- Picking the selected code again clears the filter.
- Suggestions carry a short label (`Client closed request`, `Too many requests`, …).

## Refactor

The code list existed in three drifting copies. `src/pages/ai-traces/status.tsx` is now the single source: `DESCRIBED_STATUS_CODES`, `parseStatusCode`, `statusDescription`, `statusShortLabel`, `statusBadgeVariant`, `StatusBadge`. The list table and the detail drawer both use `StatusBadge` — the drawer gains the description tooltip it was missing.

No backend change: the wire shape is still a flat `?status=<code>` exact match.

## Tests

- `src/pages/ai-traces/status.test.ts` — 9 cases over the parsing/description/variant helpers.
- `src/pages/ai-traces/components/StatusCodeFilter.test.tsx` — 8 cases: suggestion list, free-typed code, no duplicate for an already-suggested code, hint on unmatched input, selected-unlisted code retained, clear-on-reselect.
- `e2e/tests/ai-traces-ui.spec.ts` — one case covering both the suggested and free-typed paths. Gated behind `E2E_AITRACE_ENDPOINT`; not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3edETcwjrzraVcTwR6diN