### PR TITLE
fix: sync document lang with the active locale (NEU-598)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -97,7 +97,7 @@
   "src/foundation/lib/column-visibility-storage.ts": "1c01bd1a7acbeac08880f87e23fbfb51",
   "src/foundation/lib/constant.ts": "9065e6a19b4fe8499eae6b7ec59f495c",
   "src/foundation/lib/grafana-dashboard-configs.ts": "38cde7d922d8dfafbef218542b22f698",
-  "src/foundation/lib/i18n.ts": "7b321c9625deff3063bf3b7554a24f88",
+  "src/foundation/lib/i18n.ts": "7ca93a505420fdfee78bb9d88ffcc272",
   "src/foundation/lib/plural.ts": "5d10922518b7de7bf6db90ce2e078f5f",
   "src/foundation/lib/unit.ts": "17809cc71da9ff806c3a931de23155d5",
   "src/foundation/lib/utils.ts": "618d00bf4537ce84f9ba62c5b215fb30",

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-US">
 
 <head>
   <meta charset="utf-8" />

--- a/src/foundation/lib/i18n.test.ts
+++ b/src/foundation/lib/i18n.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  AVAILABLE_LOCALES,
+  i18n,
+  resolveSupportedLocale,
+  syncDocumentLanguage,
+} from "./i18n";
+
+describe("resolveSupportedLocale", () => {
+  it("keeps a locale that this build ships", () => {
+    expect(resolveSupportedLocale("en-US")).toBe("en-US");
+  });
+
+  it("falls back for a locale the detector returns but we do not ship", () => {
+    expect(resolveSupportedLocale("fr")).toBe("en-US");
+  });
+
+  it("falls back when the locale is missing", () => {
+    expect(resolveSupportedLocale(undefined)).toBe("en-US");
+  });
+});
+
+describe("syncDocumentLanguage", () => {
+  beforeEach(() => {
+    document.documentElement.lang = "en";
+  });
+
+  it("writes the resolved locale onto the root element", () => {
+    syncDocumentLanguage("en-US");
+    expect(document.documentElement.lang).toBe("en-US");
+  });
+
+  it("never writes an unsupported detector value", () => {
+    syncDocumentLanguage("xx-YY");
+    expect(AVAILABLE_LOCALES).toContain(document.documentElement.lang);
+  });
+});
+
+describe("i18n language changes", () => {
+  it("syncs the root element on init", () => {
+    expect(document.documentElement.lang).toBe(
+      i18n.resolvedLanguage ?? "en-US",
+    );
+  });
+
+  it("syncs the root element on every switch", async () => {
+    document.documentElement.lang = "en";
+
+    await i18n.changeLanguage("en-US");
+    expect(document.documentElement.lang).toBe("en-US");
+
+    // A locale that is not bundled must not leak into the root element.
+    await i18n.changeLanguage("zh-CN");
+    expect(AVAILABLE_LOCALES).toContain(document.documentElement.lang);
+
+    await i18n.changeLanguage("en-US");
+    expect(document.documentElement.lang).toBe("en-US");
+  });
+});

--- a/src/foundation/lib/i18n.ts
+++ b/src/foundation/lib/i18n.ts
@@ -39,12 +39,33 @@ export const LOCALE_LABELS = AVAILABLE_LOCALES.reduce(
   {} as Record<string, string>,
 );
 
+const FALLBACK_LOCALE = "en-US";
+
+// The detector may return a locale this build does not ship (e.g. "fr" from the
+// browser, or a stale value in localStorage). Only ever write a locale we have
+// resources for, so document.documentElement.lang matches the rendered text.
+export function resolveSupportedLocale(locale?: string): string {
+  if (locale && AVAILABLE_LOCALES.includes(locale)) {
+    return locale;
+  }
+  return AVAILABLE_LOCALES.includes(FALLBACK_LOCALE)
+    ? FALLBACK_LOCALE
+    : (AVAILABLE_LOCALES[0] ?? FALLBACK_LOCALE);
+}
+
+export function syncDocumentLanguage(locale?: string) {
+  if (typeof document === "undefined") {
+    return;
+  }
+  document.documentElement.lang = resolveSupportedLocale(locale);
+}
+
 i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources,
-    fallbackLng: "en-US",
+    fallbackLng: FALLBACK_LOCALE,
     debug: false,
     interpolation: {
       escapeValue: false,
@@ -53,5 +74,13 @@ i18n
       useSuspense: false,
     },
   });
+
+// index.html ships a static lang="en"; keep it in sync with the resolved
+// language on boot and on every switch so screen readers and browser
+// translation tools see the language the page is actually rendered in.
+syncDocumentLanguage(i18n.resolvedLanguage ?? i18n.language);
+i18n.on("languageChanged", (locale) =>
+  syncDocumentLanguage(i18n.resolvedLanguage ?? locale),
+);
 
 export { I18nextProvider, i18n, useTranslation };


### PR DESCRIPTION
The root element kept the static `lang="en"` from `index.html` after switching to another locale. Visible text and the accessible tree were translated, but screen readers, browser translation and spell check still saw the page as English.

- `syncDocumentLanguage()` writes `document.documentElement.lang` from the resolved i18next language, once after init and again on every `languageChanged` event.
- `resolveSupportedLocale()` guards that write, so a browser-detected or stale `localStorage` value the build has no resources for falls back to `en-US` instead of leaking into the root element. The handler reads `i18n.resolvedLanguage`, so a request like `zh` that i18next resolves to `zh-CN` writes the language actually rendered.
- `index.html` now ships `lang="en-US"`, matching `fallbackLng`, so the value is consistent from first paint.

Unit tests cover locale resolution, the initial detector state, and an `en-US -> zh-CN -> en-US` switch. This repo only ships `en-US.json`, so the switch test asserts the root element always holds a bundled locale rather than hardcoding `zh-CN`; it holds for both this build and enterprise builds that add more locale files.
