### PR TITLE
fix: start a new range on the first calendar click (NEU-612)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -294,7 +294,7 @@
   "src/pages/ai-traces/components/TraceDetailDrawer.tsx": "036f00b452cfcdc0a0fd01687b621e85",
   "src/pages/ai-traces/components/TraceStatsChart.tsx": "a7d1563a26479dc5d39dfe7f2b25d2f6",
   "src/foundation/lib/api/ai-traces.ts": "bcc854067422a7e98d439ba1fcd7f36f",
-  "src/foundation/components/DateRangePicker.tsx": "92270575b1e1f69bf49cb0d1ae26c862",
+  "src/foundation/components/DateRangePicker.tsx": "e700bd01704468c415f7fda9118f6df5",
   "src/pages/model-usage/list.tsx": "37ba9e5ad7b29a3a27f77c8084f100ba",
   "src/domains/api-key/hooks/use-usage-by-dimension.ts": "b7e55f4a3573c6f2f2e51d8171cbf393",
   "src/domains/api-key/hooks/use-workspace-usage.ts": "5f008c9efecb5f75398ae4fb67414d69",

--- a/src/foundation/components/DateRangePicker.test.tsx
+++ b/src/foundation/components/DateRangePicker.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/foundation/lib/i18n", () => ({
@@ -7,20 +8,54 @@ vi.mock("@/foundation/lib/i18n", () => ({
   }),
 }));
 
-import { DateRangePicker, trailingRange } from "./DateRangePicker";
+import {
+  type DateRange,
+  DateRangePicker,
+  trailingRange,
+} from "./DateRangePicker";
 
-function openPicker(presets?: number[]) {
+// Renders the picker with its parent state wired up the way the real pages do
+// it, then opens the popover. The default window is fixed so day clicks map to
+// known dates; the trigger is always the first button on the page.
+function openPicker({
+  presets,
+  value = { start: "2026-07-24", end: "2026-07-30" },
+}: {
+  presets?: number[];
+  value?: DateRange;
+} = {}) {
   const onChange = vi.fn();
-  render(
-    <DateRangePicker
-      value={trailingRange(7)}
-      onChange={onChange}
-      presets={presets}
-    />,
-  );
-  fireEvent.click(screen.getByRole("button"));
+  function Host() {
+    const [range, setRange] = useState(value);
+    return (
+      <DateRangePicker
+        value={range}
+        presets={presets}
+        onChange={(next) => {
+          onChange(next);
+          setRange(next);
+        }}
+      />
+    );
+  }
+  render(<Host />);
+  fireEvent.click(screen.getAllByRole("button")[0]);
   return onChange;
 }
+
+const reopenPicker = () => {
+  fireEvent.click(screen.getAllByRole("button")[0]);
+  fireEvent.click(screen.getAllByRole("button")[0]);
+};
+
+// Day cells are matched by their accessible label so that the leading/trailing
+// days of the adjacent months don't collide with the July ones.
+const clickDay = (day: number) =>
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: new RegExp(`July ${day}\\w{2}, 2026`),
+    }),
+  );
 
 const presetLabels = () =>
   screen
@@ -40,7 +75,7 @@ describe("DateRangePicker", () => {
   });
 
   it("only offers the quick picks the caller asks for", () => {
-    openPicker([7, 30]);
+    openPicker({ presets: [7, 30] });
 
     expect(presetLabels()).toEqual([
       "common.dateRange.lastDays:7",
@@ -49,10 +84,58 @@ describe("DateRangePicker", () => {
   });
 
   it("reports the trailing window when a quick pick is clicked", () => {
-    const onChange = openPicker([7, 30]);
+    const onChange = openPicker({ presets: [7, 30] });
 
     fireEvent.click(screen.getByText("common.dateRange.lastDays:30"));
 
     expect(onChange).toHaveBeenCalledWith(trailingRange(30));
+  });
+
+  // Two clicks always define the whole range: the first only anchors a start,
+  // so the committed window is never extended from the previous one.
+  it.each([
+    {
+      name: "starts a new range instead of extending the current one",
+      clicks: [25, 28],
+      committed: { start: "2026-07-25", end: "2026-07-28" },
+    },
+    {
+      name: "normalises a backwards selection",
+      clicks: [28, 25],
+      committed: { start: "2026-07-25", end: "2026-07-28" },
+    },
+    {
+      name: "selects a single day when the same day is picked twice",
+      clicks: [26, 26],
+      committed: { start: "2026-07-26", end: "2026-07-26" },
+    },
+  ])("$name", ({ clicks: [first, second], committed }) => {
+    const onChange = openPicker();
+
+    clickDay(first);
+    expect(onChange).not.toHaveBeenCalled();
+
+    clickDay(second);
+    expect(onChange).toHaveBeenCalledWith(committed);
+  });
+
+  it("discards a half-finished range when the popover is reopened", () => {
+    const onChange = openPicker();
+
+    clickDay(25);
+    reopenPicker();
+    clickDay(28);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("drops a half-finished range when a quick pick is used", () => {
+    const onChange = openPicker();
+
+    clickDay(25);
+    fireEvent.click(screen.getByText("common.dateRange.lastDays:7"));
+
+    expect(onChange).toHaveBeenCalledWith(trailingRange(7));
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/foundation/components/DateRangePicker.tsx
+++ b/src/foundation/components/DateRangePicker.tsx
@@ -1,5 +1,6 @@
 import dayjs from "dayjs";
 import { CalendarDays } from "lucide-react";
+import { useState } from "react";
 import type { DateRange as RdpRange } from "react-day-picker";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
@@ -45,14 +46,35 @@ export function DateRangePicker({
   presets?: number[];
 }) {
   const { t } = useTranslation();
+  // The first calendar click only anchors a new start; the committed `value`
+  // stays untouched until a second click closes the range. Without this draft,
+  // react-day-picker extends the existing range instead of starting a new one,
+  // so re-picking a narrower window inside the current one keeps the old start.
+  const [draftStart, setDraftStart] = useState<string | null>(null);
   const label = `${dayjs(value.start).format("MMM D")} – ${dayjs(value.end).format("MMM D")}`;
-  const selected: RdpRange = {
-    from: dayjs(value.start).toDate(),
-    to: dayjs(value.end).toDate(),
+  const selected: RdpRange = draftStart
+    ? { from: dayjs(draftStart).toDate(), to: undefined }
+    : { from: dayjs(value.start).toDate(), to: dayjs(value.end).toDate() };
+
+  const pickDay = (day: Date) => {
+    const picked = dayjs(day).format("YYYY-MM-DD");
+    if (!draftStart) {
+      setDraftStart(picked);
+      return;
+    }
+    setDraftStart(null);
+    // Backwards selections are normalised so the earlier day always wins.
+    onChange(
+      picked < draftStart
+        ? { start: picked, end: draftStart }
+        : { start: draftStart, end: picked },
+    );
   };
 
   return (
-    <Popover>
+    // A half-finished draft is discarded whenever the popover opens or closes,
+    // so every visit starts from the committed range.
+    <Popover onOpenChange={() => setDraftStart(null)}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -71,7 +93,10 @@ export function DateRangePicker({
               variant="ghost"
               size="sm"
               className="h-7 px-2 text-xs"
-              onClick={() => onChange(trailingRange(d))}
+              onClick={() => {
+                setDraftStart(null);
+                onChange(trailingRange(d));
+              }}
             >
               {t("common.dateRange.lastDays", { days: d })}
             </Button>
@@ -81,14 +106,9 @@ export function DateRangePicker({
           mode="range"
           defaultMonth={selected.from}
           selected={selected}
-          onSelect={(r: RdpRange | undefined) => {
-            if (r?.from) {
-              onChange({
-                start: dayjs(r.from).format("YYYY-MM-DD"),
-                end: dayjs(r.to ?? r.from).format("YYYY-MM-DD"),
-              });
-            }
-          }}
+          // The range react-day-picker computes is ignored; only the clicked day
+          // matters, since the draft above decides what it means.
+          onSelect={(_r: RdpRange | undefined, day: Date) => pickDay(day)}
         />
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
Re-picking a narrower window inside the current one kept the old start: selecting Jul 25 then Jul 28 inside Jul 24 – Jul 30 committed Jul 24 – Jul 28, so the label and the list/stats queries covered an extra day. Access Log and Model Usage both share the picker.

`DateRangePicker` passed the committed range to react-day-picker as its controlled selection, and RDP treats a click on a complete range as "extend it" rather than "start over" — the half-range was written back to the parent immediately, and the second click could only grow from the old start.

The picker now holds the first click as an uncommitted draft anchor and calls `onChange` only once the second click closes the range, normalising backwards selections. The draft is dropped when the popover opens or closes and when a quick pick is used, so a half-selection never leaks into the committed value. Consumers are unchanged — they only ever see a completed range, and their day-boundary conversion was already correct.