### PR TITLE
fix(dev): forward the proxy target's Host and allow opt-in preview hostnames

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -1,5 +1,5 @@
 {
-  "vite.config.ts": "a2ebabd7035347e83eb48536602b2fe1",
+  "vite.config.ts": "2f4ea227a08df0d1587921fe627a10e3",
   "src/App.tsx": "fde81ee0bd7da1cc39c7ed969abed825",
   "src/Root.tsx": "dd7ccc8e83bb3cb7f8c8fb879e4aa203",
   "src/index.tsx": "6eaed6f7788c9ba4ace41044c3cbc5a8",

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The dev server proxies `/api/v1` to `http://localhost`. Point it at another
 backend with `NODE_IP`, which may include a port:
 
 ```bash
-NODE_IP=192.168.1.10:3000 yarn dev
+NODE_IP=my-backend.example.com:3000 yarn dev
 ```
 
 When the dev server is reached through a hostname other than `localhost` — a

--- a/README.md
+++ b/README.md
@@ -16,6 +16,25 @@ Start the development server:
 yarn dev
 ```
 
+The dev server proxies `/api/v1` to `http://localhost`. Point it at another
+backend with `NODE_IP`, which may include a port:
+
+```bash
+NODE_IP=192.168.1.10:3000 yarn dev
+```
+
+When the dev server is reached through a hostname other than `localhost` — a
+tunnel, a cloud sandbox, or a LAN hostname — Vite's DNS-rebinding protection
+answers `403 Forbidden`. List those hostnames in `VITE_ALLOWED_HOSTS` (comma
+separated) to allow them:
+
+```bash
+VITE_ALLOWED_HOSTS=my-preview.example.dev yarn dev --host 0.0.0.0
+```
+
+Leave `VITE_ALLOWED_HOSTS` unset for local development; the protection stays on
+by default.
+
 ### Building
 
 Build the project for production:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,16 @@ import { defineConfig } from "vite";
 const NODE_IP = process.env.NODE_IP || "localhost";
 const analyze = process.env.ANALYZE === "true";
 
+// Vite >= 4.5.6 rejects dev-server requests whose Host header it does not
+// recognise, which guards against DNS-rebinding attacks. That check also blocks
+// remote preview setups (tunnels, cloud sandboxes, LAN hostnames), where the
+// browser reaches the dev server under a hostname Vite cannot infer. Opt those
+// hostnames in explicitly, e.g. VITE_ALLOWED_HOSTS="my-preview.example.dev".
+// Leaving the variable unset keeps Vite's default, strict behaviour.
+const allowedHosts = process.env.VITE_ALLOWED_HOSTS?.split(",")
+  .map((host) => host.trim())
+  .filter(Boolean);
+
 export default defineConfig({
   plugins: [
     react(),
@@ -21,9 +31,13 @@ export default defineConfig({
     },
   },
   server: {
+    allowedHosts,
     proxy: {
       "/api/v1": {
         target: `http://${NODE_IP}`,
+        // Send the target's own Host header instead of the dev server's, so
+        // NODE_IP can point at a backend that routes by virtual host.
+        changeOrigin: true,
       },
     },
   },


### PR DESCRIPTION
## Problem

The dev server proxied `/api/v1` with a bare `{ target }`:

```ts
proxy: { "/api/v1": { target: `http://${NODE_IP}` } }
```

Two gaps follow from that.

**1. The forwarded `Host` is the dev server's own.** Without `changeOrigin`, a request to `http://localhost:5173/api/v1/...` reaches the backend still carrying `Host: localhost:5173`. `NODE_IP` exists precisely so the dev server can point at a remote backend, but a backend that routes by virtual host cannot match a request announcing the dev server's hostname.

**2. A remote hostname cannot reach the dev server at all.** The lockfile pins Vite `4.5.14`, which carries the DNS-rebinding protection added in 4.5.6: requests whose `Host` the server does not recognise are refused with `403 Forbidden`. That blocks every remote preview setup — tunnels, cloud sandboxes, LAN hostnames — with no supported way to opt a hostname in.

## Change

Dev-server only; `server.proxy` and `server.allowedHosts` do not exist in the production build.

- `changeOrigin: true` on the `/api/v1` proxy, unconditionally, so the target's own `Host` is sent.
- `allowedHosts` populated from a new `VITE_ALLOWED_HOSTS` env var (comma separated, trimmed). Unset leaves the value `undefined`, i.e. Vite's default strict behaviour — the protection is opted out of per hostname, never disabled wholesale.
- `README.md` documents `NODE_IP` (including that it may carry a port) and `VITE_ALLOWED_HOSTS`, with the `403` it resolves.

`host: true` is deliberately not set; `--host 0.0.0.0` on the command line already covers it.

## Verification

Backend: an existing internal deployment, read-only (login attempts and GETs only). Measured through the dev-server proxy with `curl`, before and after the change.

`allowedHosts` — the reproduced failure:

| request | before | after, unset | after, host listed |
| --- | --- | --- | --- |
| `/` via `localhost:5173` | 200 | 200 | 200 |
| `/` via a remote preview hostname | **403** | **403** | **200** |
| `/` via a hostname *not* in the list | 403 | 403 | **403** |

So the default is unchanged and an unlisted host is still refused; only the listed hostname is admitted.

`changeOrigin` — honest result: **the 502 this was expected to fix did not reproduce on this backend.** With `NODE_IP` pointing at that backend's API port, proxied requests behaved identically before and after:

| request | before | after |
| --- | --- | --- |
| `POST /api/v1/auth/token?grant_type=password` | 400 `invalid_credentials` | 400 `invalid_credentials` |
| `GET /api/v1/workspaces` | 401 | 401 |

Both codes are the backend answering on its merits, so the request arrived intact with either `Host`. Sending `Host: localhost:5173` directly to that origin returns the same 400, confirming this deployment does not route on `Host`. Pointing `NODE_IP` at port 80 (Kong) instead returns `404 no Route matched with those values`, again identically with and without `changeOrigin` — a path-routing mismatch, not a `Host` one.

`changeOrigin` is kept because it is the semantically correct behaviour for a proxy whose target is configurable, and it is what makes `NODE_IP` usable against a vhost-routed backend. This PR does not claim to fix an observed 502.

Browser login was deliberately skipped: the single admin account on that host signed in the same day, and resetting its password to obtain a session would lock out the person using it. The status codes above already show requests reaching GoTrue and PostgREST.

Full checks pass on the branch: `typecheck`, `lint:ci`, `dep-check`, `knip`, `build`.

