### PR TITLE
docs(i18n): describe what the i18n CI gate actually checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,13 @@ Follow the unit testing guide: [contributing/unit-test.md](contributing/unit-tes
 ## E2E Tests
 
 Follow the E2E guide: [contributing/e2e.md](contributing/e2e.md)
+
+## I18n
+
+Follow the i18n guide: [contributing/i18n-guide.md](contributing/i18n-guide.md)
+
+Note the CI gate before editing anything: `tools/i18n-tracker.cjs` hashes every `.ts` and `.tsx`
+file in the repository — build configs such as `vite.config.ts` included — and fails when a file's
+content differs from `.i18n-tracker.lock`. Editing any TypeScript file therefore requires
+`node tools/i18n-tracker.cjs update <path>` and committing the updated lock, whether or not the
+change involves user-facing text.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,21 @@ Lint your code:
 ```bash
 yarn lint
 ```
+
+### Before you commit
+
+The `pre-commit` hook and the `Test` CI workflow run the same checks: lint, typecheck, layer
+boundaries, unused exports, unit tests, and two i18n gates.
+
+One of the i18n gates fires on changes that have nothing to do with copy, so it is worth knowing
+about up front. `tools/i18n-tracker.cjs` hashes **every `.ts` and `.tsx` file in the repository —
+build configs such as `vite.config.ts` included** — and fails whenever a file's content differs
+from `.i18n-tracker.lock`. After editing any TypeScript file, record its new hash and commit the
+lock with it:
+
+```bash
+node tools/i18n-tracker.cjs update vite.config.ts
+git add vite.config.ts .i18n-tracker.lock
+```
+
+Full rules, exclusions, and failure recipes: [contributing/i18n-guide.md](contributing/i18n-guide.md).

--- a/contributing/i18n-guide.md
+++ b/contributing/i18n-guide.md
@@ -6,9 +6,62 @@ This document explains how to work with the i18n (internationalization) system i
 
 This project uses `react-i18next` for internationalization. All user-facing text must be translated to support multiple languages.
 
-## CI/CD Integration
+## The CI gate (read this first)
 
-A GitHub Actions workflow automatically checks all PRs to ensure that modified files have been processed for i18n translations. If unprocessed files are detected, the CI will fail.
+Two steps in [`.github/workflows/test.yml`](../.github/workflows/test.yml) enforce i18n on every
+pull request to `main`. The `pre-commit` hook runs the same two scripts, so they block the commit
+before they block the PR.
+
+| CI step | Script | Fails when |
+| --- | --- | --- |
+| Check i18n translations | `tools/i18n-tracker.cjs` | a tracked file's content no longer matches the hash recorded in `.i18n-tracker.lock` |
+| Check i18n key references | `tools/check-i18n-keys.cjs` | a `t("…")` call under `src/` names a key that is missing from `src/locales/en-US.json` |
+
+### What the tracker actually tracks
+
+The tracker is a **content-hash ledger, not a text scanner**. It never inspects what you wrote: it
+takes an md5 of each tracked file (line endings normalised to LF) and fails on any difference from
+`.i18n-tracker.lock`. That has consequences worth knowing before they surprise you:
+
+- **Every `.ts` and `.tsx` file is tracked, wherever it lives** — including the root build configs
+  `vite.config.ts`, `vitest.config.ts` and `playwright.config.ts`. Editing one of those fails the
+  gate even though it contains no user-facing string.
+- **Any content change counts.** A new comment, a reordered import, a whitespace-only reformat —
+  all trip it. So does adding a new `.ts`/`.tsx` file, and so does renaming one, because the new
+  path has no entry yet.
+- **Non-TypeScript files are invisible to it.** A change confined to `.md`, `.json`, `.css`, or to
+  the locale files themselves, never trips it.
+- **CI scans the whole tree, not your diff.** The CI step runs the scan with no `--git` flag, so it
+  re-hashes every tracked file in the checkout.
+
+Excluded from tracking: `*.d.ts`, any path containing `.test.`, everything under `e2e/`,
+`node_modules/`, and any dot-directory.
+
+### Making it pass
+
+If you changed a TypeScript file with no user-facing text — a build config, a type-only module, a
+pure utility — the whole obligation is to record its new hash and commit the lock:
+
+```bash
+node tools/i18n-tracker.cjs update vite.config.ts
+git add vite.config.ts .i18n-tracker.lock
+```
+
+If the file does render text, review it first: every user-facing string must go through `t()`, with
+the key present in `src/locales/en-US.json`. Then record the hash the same way. Marking a file
+reviewed asserts that you looked at it — the tool cannot check that for you.
+
+### Local-only gotchas
+
+These bite on your machine and in the `pre-commit` hook, but not in CI, which always runs on a
+clean checkout:
+
+- **The scan walks the filesystem, not git.** Untracked and even *gitignored* `.ts` files in your
+  working tree count — a scratch file at the repo root, or a stale `dist/` holding TypeScript, will
+  fail the scan. Delete them rather than adding them to the lock.
+- **Scan mode writes to the lock.** It garbage-collects entries whose file no longer exists. Delete
+  a `.ts` file, run the scan, and `.i18n-tracker.lock` comes back modified; commit that alongside
+  the deletion.
 
 ## Usage in Components
 
@@ -79,6 +132,22 @@ node tools/i18n-tracker.cjs update <file-path>
 node tools/i18n-tracker.cjs update src/pages/users/list.tsx
 ```
 
+Paths outside the tracked set are accepted but ignored — `update README.md` and
+`update src/foundation/lib/i18n.test.ts` both print a "skipping" line and exit 0.
+
+#### Mark several files at once
+
+```bash
+# Mark only files touched by the last N commits
+node tools/i18n-tracker.cjs update-all --git 3
+
+# Mark every pending file in the tree
+node tools/i18n-tracker.cjs update-all
+```
+
+Bare `update-all` rubber-stamps *every* pending file, including ones you never opened. Prefer
+`update <path>` per file, or scope it with `--git <n>`.
+
 ## Workflow for Adding I18n to a File
 
 1. **Modify your component** to use `t()` for all user-facing strings
@@ -126,18 +195,30 @@ Follow these conventions for consistency:
 
 ## CI Check Failure - How to Fix
 
-If your PR fails the i18n check:
+### "Check i18n translations" failed
 
-1. **Check the CI output** to see which files need processing
+The step prints every file whose hash does not match the lock. Reproduce it locally with
+`node tools/i18n-tracker.cjs`, then for each listed file:
 
-2. **Review each file** and add i18n translations where needed
+1. **Review it** for user-facing strings, and route any you find through `t()` with keys added to
+   `src/locales/en-US.json`. For a file that renders no text — a build config, say — there is
+   nothing to change.
 
-3. **Update the tracker** for each processed file:
+2. **Record the hash**:
    ```bash
    node tools/i18n-tracker.cjs update <file-path>
    ```
 
-4. **Commit and push** the changes including `.i18n-tracker.lock`
+3. **Commit and push** `.i18n-tracker.lock` together with the file itself.
+
+If a listed file is one you never touched, check it exists in the branch at all: a rename shows up
+as a pending new path, and a deletion shows up as a lock rewrite.
+
+### "Check i18n key references" failed
+
+The step lists each `t("key")` whose key is absent from `src/locales/en-US.json`. Add the missing
+keys there. It only reads `src/`, and it skips dynamic keys — anything containing `${` or `{{` — so
+a key assembled at runtime is not verified by this gate.
 
 ## Advanced: Using Variables in Translations
 


### PR DESCRIPTION
## Why

The i18n gate blocks pull requests that have nothing to do with copy, and no document said so.

In #360 the only source change was `vite.config.ts` (plus `README.md`). CI failed on **Check i18n
translations**, and it took an extra commit doing nothing but bumping one hash in
`.i18n-tracker.lock` to get green. Nothing in the repository would have predicted that:
`contributing/i18n-guide.md` described the check as verifying that "modified files have been
processed for i18n translations", which reads as a scan for untranslated strings in files you
edited *for copy reasons*. A build config is neither.

Meanwhile `README.md` and `CLAUDE.md` — the two places someone starts from when changing a build
config — did not mention i18n at all.

## What the gate actually does

Verified by running `tools/i18n-tracker.cjs` against a working tree, not inferred from a CI log:

| Probe | Result |
| --- | --- |
| clean tree | pass |
| comment appended to `vite.config.ts` | **fail** — lists `vite.config.ts` |
| change confined to `README.md` | pass |
| new untracked `src/*.ts` | **fail** — new paths have no lock entry |
| new `*.test.ts` / `*.d.ts` / `e2e/*.ts` | pass — excluded |
| rename a tracked file | **fail** — the new path is pending |
| delete a tracked file | pass, but the scan **rewrites** `.i18n-tracker.lock` (gc) |
| gitignored `dist/scratch.ts` present locally | **fail** — the scan walks the filesystem, not git |

The load-bearing facts, none of which were written down:

- It is a **content-hash ledger, not a text scanner**. md5 per file against `.i18n-tracker.lock`;
  the file's contents are never inspected for strings.
- The tracked set is **every `.ts`/`.tsx` in the repo**, which today includes `vite.config.ts`,
  `vitest.config.ts` and `playwright.config.ts` — 344 entries. Exclusions: `*.d.ts`, `.test.`,
  `e2e/`, `node_modules/`, dot-directories.
- CI runs the scan with **no `--git` flag**, so it re-hashes the whole tree rather than the diff.
- The same two scripts run in `.husky/pre-commit`, so they block the commit before the PR.
- `tools/check-i18n-keys.cjs`, the second i18n CI step, had **no documentation at all**.

## What changed

Documentation only — no change to the gate, the scripts, the workflow, or the lock.

- `contributing/i18n-guide.md` — replaces the three-line "CI/CD Integration" section with an
  accurate description of both CI steps, the tracked set and its exclusions, how to make the gate
  pass for a file with no user-facing text, and the local-only gotchas. Documents `update-all` and
  rewrites the failure recipes per failing step.
- `README.md` — a "Before you commit" section stating inline that the tracker covers build configs.
- `CLAUDE.md` — an I18n entry alongside the existing architecture / unit-test / e2e links.

The surprising part is stated inline in both entry points rather than left behind a link named
"i18n guide": someone changing `vite.config.ts` has no reason to click that link.

## Gate design concerns (documented, deliberately not fixed)

Out of scope for this PR, but worth a decision:

1. **Build configs are tracked.** `vite.config.ts` and friends contain no user-facing strings, so
   the hash bump is a ritual rather than a review. An exclusion list would remove the friction
   without weakening the gate.
2. **CI scans the whole tree, not the diff.** A PR can in principle be blocked by files it never
   touched. `--git` mode exists and is unused in CI.
3. **Any content change trips it**, including a formatter-only reflow, so a `biome` sweep across
   `src/` forces a mass rubber-stamp.
4. **`update-all` with no arguments** marks every pending file reviewed, including files nobody
   opened — the cheapest escape from 1–3, and the one that most erodes the gate's meaning.
5. **Scan mode is not read-only.** It garbage-collects entries for deleted files and rewrites the
   lock, contradicting the script's own header comment ("Scan mode never writes hashes").

## Verification

`node tools/i18n-tracker.cjs` and `node tools/check-i18n-keys.cjs` both pass, and
`.i18n-tracker.lock` is untouched — which is this change demonstrating its own claim that a
markdown-only diff is invisible to the tracker. The remaining CI steps (biome, typecheck,
dep-check, knip, vitest) do not process markdown; CI confirms.