### PR TITLE
fix: prevent cluster version downgrade

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -275,7 +275,7 @@
   "src/domains/external-endpoint/lib/find-overlapping-model-keys.ts": "c95ecffb5e8e3e0a45983f6e1f5d2ea4",
   "src/pages/auth/lib/validate-password-match.ts": "c113f0c5136ce533297e38cc20bf698f",
   "src/domains/endpoint/lib/pause-action.ts": "3efa178458d6906c0cc81dad7c41e675",
-  "src/domains/cluster/components/ClusterUpgradeAction.tsx": "b54d3549e3b8dfdb01636ee6a00ee5d3",
+  "src/domains/cluster/components/ClusterUpgradeAction.tsx": "69bbf15ed8d1b0e68a235ada096065e9",
   "src/foundation/components/OemFavicon.tsx": "bb7648f90f369cb8a26439963f1966d1",
   "src/domains/external-endpoint/lib/get-endpoint-type.ts": "a5fec42612881e3206ee2e19ca3c820f",
   "src/domains/endpoint/hooks/use-document-list.ts": "7dc70792a61cc83271e61844abc90ec8",
@@ -358,5 +358,6 @@
   "src/domains/model-registry/components/ModelInfoFields.tsx": "4de75c3f06118f24d2b1538af84786e8",
   "src/domains/model-registry/components/ModelRegistryStats.tsx": "207d63a6478d660945c1e7c3a9fdc52a",
   "src/domains/model-registry/components/RegistryModelsTable.tsx": "3fbf89f317de15c16ed5515f4e34d9cc",
-"src/domains/engine/lib/resolve-capabilities.ts": "9a444cc413dae9066a7983c28c1d0fba"
+  "src/domains/engine/lib/resolve-capabilities.ts": "9a444cc413dae9066a7983c28c1d0fba",
+  "src/domains/cluster/lib/upgrade-versions.ts": "0b8da429b7f5a4c73d1ee2cada4556ae"
 }

--- a/e2e/tests/clusters-upgrade.spec.ts
+++ b/e2e/tests/clusters-upgrade.spec.ts
@@ -6,6 +6,7 @@ const irName = { value: "" };
 const clNames = {
   ssh: "",
   k8s: "",
+  upgrade: "",
 };
 
 test.describe("clusters - upgrade", () => {
@@ -18,6 +19,7 @@ test.describe("clusters - upgrade", () => {
     irName.value = `test-upg-ir-${ts}`;
     clNames.ssh = `test-upg-ssh-${ts}`;
     clNames.k8s = `test-upg-k8s-${ts}`;
+    clNames.upgrade = `test-upg-guard-${ts}`;
 
     await api.createImageRegistry(irName.value);
     await api.createCluster(clNames.ssh, {
@@ -27,6 +29,11 @@ test.describe("clusters - upgrade", () => {
     await api.createCluster(clNames.k8s, {
       type: "kubernetes",
       imageRegistry: irName.value,
+    });
+    await api.createCluster(clNames.upgrade, {
+      type: "ssh",
+      imageRegistry: irName.value,
+      version: "v1.1.0",
     });
 
     await context.close();
@@ -119,6 +126,75 @@ test.describe("clusters - upgrade", () => {
       const cancelBtn = dialog.getByRole("button", { name: /cancel/i });
       await expect(cancelBtn).toBeVisible();
       await cancelBtn.click();
+    });
+
+    test("only submits a strictly newer version from an unsorted response", async ({
+      clusters,
+    }) => {
+      await clusters.page.route(
+        "**/api/v1/clusters/available_versions?**",
+        async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            body: JSON.stringify({
+              available_versions: ["v1.2.0", "v1.0.2", "v1.1.0", "v1.0.1"],
+            }),
+          });
+        },
+      );
+      await clusters.page.route("**/api/v1/clusters?**", async (route) => {
+        if (route.request().method() !== "PATCH") {
+          await route.continue();
+          return;
+        }
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          headers: { "content-range": "0-0/1" },
+          body: JSON.stringify([{}]),
+        });
+      });
+
+      await clusters.goToList();
+      await clusters.table.waitForLoaded();
+
+      const row = clusters.table.rowWithText(clNames.upgrade);
+      await row.locator('[data-testid="row-actions-trigger"]').click();
+      await clusters.page.getByRole("menuitem", { name: /upgrade/i }).click();
+
+      const dialog = clusters.page.getByRole("dialog");
+      const targetVersion = dialog.locator('button[role="combobox"]');
+      await expect(targetVersion).toHaveText("v1.2.0");
+      await targetVersion.click();
+      await expect(
+        clusters.page.getByRole("option", { name: "v1.2.0" }),
+      ).toBeVisible();
+      await expect(
+        clusters.page.getByRole("option", { name: "v1.1.0" }),
+      ).toHaveCount(0);
+      await expect(
+        clusters.page.getByRole("option", { name: "v1.0.2" }),
+      ).toHaveCount(0);
+      await expect(
+        clusters.page.getByRole("option", { name: "v1.0.1" }),
+      ).toHaveCount(0);
+      await clusters.page.keyboard.press("Escape");
+
+      const updateRequest = clusters.page.waitForRequest(
+        (request) =>
+          request.url().includes("/api/v1/clusters?") &&
+          request.method() === "PATCH",
+      );
+      await dialog
+        .getByRole("button", { name: "Upgrade", exact: true })
+        .click();
+      const request = await updateRequest;
+
+      expect(JSON.parse(request.postData() ?? "{}").spec?.version).toBe(
+        "v1.2.0",
+      );
+      await expect(dialog).not.toBeVisible();
     });
 
     test("K8s cluster upgrade dialog shows rolling update message", async ({

--- a/src/domains/cluster/components/ClusterUpgradeAction.test.tsx
+++ b/src/domains/cluster/components/ClusterUpgradeAction.test.tsx
@@ -1,0 +1,173 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Cluster } from "@/domains/cluster/types";
+
+const mocks = vi.hoisted(() => ({
+  availableVersions: [] as string[],
+  invalidate: vi.fn(),
+  mutateAsync: vi.fn(),
+}));
+
+vi.mock("@refinedev/core", () => ({
+  useCustom: () => ({
+    data: { data: { available_versions: mocks.availableVersions } },
+    isLoading: false,
+  }),
+  useInvalidate: () => mocks.invalidate,
+  useUpdate: () => ({ mutateAsync: mocks.mutateAsync, isLoading: false }),
+}));
+
+vi.mock("@/foundation/lib/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/components/ui/alert", () => ({
+  Alert: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDescription: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/combobox", () => ({
+  Combobox: ({
+    onChange,
+    options,
+    value,
+  }: {
+    onChange: (value: string) => void;
+    options: { label: string; value: string }[];
+    value: string;
+  }) => (
+    <select
+      aria-label="target-version"
+      onChange={(event) => onChange(event.target.value)}
+      value={value}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: ReactNode;
+    onSelect: () => void;
+  }) => (
+    <button type="button" onClick={onSelect}>
+      {children}
+    </button>
+  ),
+}));
+
+import {
+  ClusterUpgradeAction,
+  ClusterUpgradeProvider,
+} from "./ClusterUpgradeAction";
+
+const cluster = {
+  api_version: "v1",
+  id: 1,
+  kind: "Cluster",
+  metadata: { name: "cluster-a", workspace: "default" },
+  spec: {
+    config: {},
+    image_registry: "registry-a",
+    type: "ssh",
+    version: "v1.1.0",
+  },
+  status: null,
+} as Cluster;
+
+function renderUpgradeAction() {
+  return render(
+    <ClusterUpgradeProvider>
+      <ClusterUpgradeAction cluster={cluster} />
+    </ClusterUpgradeProvider>,
+  );
+}
+
+describe("ClusterUpgradeAction", () => {
+  beforeEach(() => {
+    mocks.availableVersions = [];
+    mocks.invalidate.mockReset().mockResolvedValue(undefined);
+    mocks.mutateAsync.mockReset().mockResolvedValue({});
+  });
+
+  it("only offers newer versions and selects the highest result", async () => {
+    mocks.availableVersions = ["v1.2.0", "v1.0.2", "v1.1.0"];
+    renderUpgradeAction();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "clusters.actions.upgrade" }),
+    );
+
+    const targetVersion = await screen.findByLabelText("target-version");
+    expect((targetVersion as HTMLSelectElement).value).toBe("v1.2.0");
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+    expect(screen.getByRole("option", { name: "v1.2.0" })).toBeTruthy();
+  });
+
+  it("submits the selected newer version and refreshes cluster data", async () => {
+    mocks.availableVersions = ["v1.2.0", "v1.0.2", "v1.1.0"];
+    renderUpgradeAction();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "clusters.actions.upgrade" }),
+    );
+    await screen.findByLabelText("target-version");
+    fireEvent.click(
+      screen.getAllByRole("button", { name: "clusters.actions.upgrade" })[1],
+    );
+
+    await waitFor(() => {
+      expect(mocks.mutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          values: expect.objectContaining({
+            spec: expect.objectContaining({ version: "v1.2.0" }),
+          }),
+        }),
+      );
+    });
+    expect(mocks.invalidate).toHaveBeenCalledWith({
+      id: "cluster-a",
+      invalidates: ["list", "detail"],
+      resource: "clusters",
+    });
+  });
+});

--- a/src/domains/cluster/components/ClusterUpgradeAction.tsx
+++ b/src/domains/cluster/components/ClusterUpgradeAction.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from "react";
 import { toast } from "sonner";
@@ -19,6 +20,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import {
+  getUpgradeVersions,
+  isUpgradeVersion,
+} from "@/domains/cluster/lib/upgrade-versions";
 import type { Cluster } from "@/domains/cluster/types";
 import { useTranslation } from "@/foundation/lib/i18n";
 
@@ -122,27 +127,33 @@ function UpgradeDialog({
       },
     });
 
-  const excludeVersions = new Set(
-    [cluster.spec.version, cluster.status?.version].filter(Boolean),
-  );
-  const availableVersions = (data?.data?.available_versions ?? []).filter(
-    (v) => !excludeVersions.has(v),
+  const availableVersions = useMemo(
+    () =>
+      getUpgradeVersions(
+        data?.data?.available_versions ?? [],
+        cluster.spec.version,
+      ),
+    [cluster.spec.version, data?.data?.available_versions],
   );
   const currentVersion = cluster.status?.version ?? "-";
 
   useEffect(() => {
-    if (availableVersions.length > 0 && !targetVersion) {
-      setTargetVersion(availableVersions[availableVersions.length - 1]);
+    if (!open) {
+      setTargetVersion("");
+      return;
     }
-  }, [availableVersions, targetVersion]);
 
-  // Reset when dialog opens
-  useEffect(() => {
-    if (open) setTargetVersion("");
-  }, [open]);
+    setTargetVersion((currentTarget) =>
+      availableVersions.includes(currentTarget)
+        ? currentTarget
+        : (availableVersions.at(-1) ?? ""),
+    );
+  }, [availableVersions, open]);
 
   const handleUpgrade = async () => {
-    if (!targetVersion || isUpdating) return;
+    if (!isUpgradeVersion(targetVersion, cluster.spec.version) || isUpdating) {
+      return;
+    }
     try {
       await mutateAsync({
         resource: "clusters",

--- a/src/domains/cluster/lib/upgrade-versions.test.ts
+++ b/src/domains/cluster/lib/upgrade-versions.test.ts
@@ -20,6 +20,27 @@ describe("getUpgradeVersions", () => {
     ).toEqual(["v1.2.0-rc.1", "v1.2.0"]);
   });
 
+  it("orders nightly, rc, and stable releases while rejecting prerelease downgrades", () => {
+    expect(
+      getUpgradeVersions(
+        ["v1.2.0", "v1.2.0-rc.1", "v1.2.0-nightly.1", "v1.1.0"],
+        "v1.1.0",
+      ),
+    ).toEqual(["v1.2.0-nightly.1", "v1.2.0-rc.1", "v1.2.0"]);
+    expect(
+      getUpgradeVersions(
+        ["v1.2.0", "v1.2.0-rc.1", "v1.2.0-nightly.1"],
+        "v1.2.0-rc.1",
+      ),
+    ).toEqual(["v1.2.0"]);
+  });
+
+  it("accepts a prerelease from a higher minor version", () => {
+    expect(
+      getUpgradeVersions(["v1.2.0-rc.1", "v1.2.0-nightly.1"], "v1.1.0"),
+    ).toEqual(["v1.2.0-nightly.1", "v1.2.0-rc.1"]);
+  });
+
   it("drops invalid candidate versions", () => {
     expect(
       getUpgradeVersions(["v1.2.0", "not-a-version", "v1.0.1"], "v1.0.1"),

--- a/src/domains/cluster/lib/upgrade-versions.test.ts
+++ b/src/domains/cluster/lib/upgrade-versions.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { getUpgradeVersions, isUpgradeVersion } from "./upgrade-versions";
+
+describe("getUpgradeVersions", () => {
+  it("keeps only strictly newer versions than the current spec version", () => {
+    expect(
+      getUpgradeVersions(["v1.0.1", "v1.0.2", "v1.1.0", "v1.2.0"], "v1.1.0"),
+    ).toEqual(["v1.2.0"]);
+  });
+
+  it("sorts valid versions and removes duplicates", () => {
+    expect(
+      getUpgradeVersions(["v1.2.0", "v1.1.2", "v1.2.0", "v1.1.1"], "v1.0.1"),
+    ).toEqual(["v1.1.1", "v1.1.2", "v1.2.0"]);
+  });
+
+  it("orders prereleases before their matching stable version", () => {
+    expect(
+      getUpgradeVersions(["v1.2.0", "v1.2.0-rc.1", "v1.1.0"], "v1.1.0"),
+    ).toEqual(["v1.2.0-rc.1", "v1.2.0"]);
+  });
+
+  it("drops invalid candidate versions", () => {
+    expect(
+      getUpgradeVersions(["v1.2.0", "not-a-version", "v1.0.1"], "v1.0.1"),
+    ).toEqual(["v1.2.0"]);
+  });
+
+  it("keeps every valid candidate when the current spec version is missing or invalid", () => {
+    expect(getUpgradeVersions(["v1.2.0", "v1.0.2", "bad"], undefined)).toEqual([
+      "v1.0.2",
+      "v1.2.0",
+    ]);
+    expect(getUpgradeVersions(["v1.2.0", "v1.0.2", "bad"], "unknown")).toEqual([
+      "v1.0.2",
+      "v1.2.0",
+    ]);
+  });
+});
+
+describe("isUpgradeVersion", () => {
+  it("rejects equal, lower, invalid, and missing targets", () => {
+    expect(isUpgradeVersion("v1.2.0", "v1.1.0")).toBe(true);
+    expect(isUpgradeVersion("v1.1.0", "v1.1.0")).toBe(false);
+    expect(isUpgradeVersion("v1.0.2", "v1.1.0")).toBe(false);
+    expect(isUpgradeVersion("invalid", "v1.1.0")).toBe(false);
+    expect(isUpgradeVersion(undefined, "v1.1.0")).toBe(false);
+    expect(isUpgradeVersion("v1.2.0", undefined)).toBe(true);
+    expect(isUpgradeVersion("v1.2.0", "unknown")).toBe(true);
+  });
+});

--- a/src/domains/cluster/lib/upgrade-versions.ts
+++ b/src/domains/cluster/lib/upgrade-versions.ts
@@ -1,0 +1,31 @@
+import { compareVersions, validate } from "compare-versions";
+
+export function isUpgradeVersion(
+  candidate: string | null | undefined,
+  currentSpecVersion: string | null | undefined,
+): boolean {
+  if (typeof candidate !== "string" || !validate(candidate)) return false;
+
+  return (
+    typeof currentSpecVersion !== "string" ||
+    !validate(currentSpecVersion) ||
+    compareVersions(candidate, currentSpecVersion) > 0
+  );
+}
+
+export function getUpgradeVersions(
+  candidates: readonly string[],
+  currentSpecVersion: string | null | undefined,
+): string[] {
+  const validCandidates = [...new Set(candidates.filter(validate))].sort(
+    compareVersions,
+  );
+
+  if (typeof currentSpecVersion !== "string" || !validate(currentSpecVersion)) {
+    return validCandidates;
+  }
+
+  return validCandidates.filter((candidate) =>
+    isUpgradeVersion(candidate, currentSpecVersion),
+  );
+}


### PR DESCRIPTION
## Summary
- Jira: NEU-524
- filter cluster upgrade candidates to valid semantic versions strictly newer than `spec.version`
- default the dialog to the highest valid upgrade and reject stale downgrade submissions
- add unit coverage and a deterministic upgrade request E2E case

## Test Plan

### Unit test
- `npx --yes node@22 node_modules/vitest/vitest.mjs run` (117 files, 1271 tests)
- `npx --yes node@22 node_modules/vitest/vitest.mjs run --coverage src/domains/cluster/lib/upgrade-versions.test.ts src/domains/cluster/components/ClusterUpgradeAction.test.tsx` (`ClusterUpgradeAction.tsx`: 91.11% line coverage)
- `yarn typecheck`
- `npx --yes node@22 node_modules/@biomejs/biome/bin/biome ci .`
- `npx --yes node@22 node_modules/dependency-cruiser/bin/dependency-cruise.mjs src --config .dependency-cruiser.cjs`
- `yarn build`

### DB test
- Not applicable: no API, database, or migration changes.

### E2E test
- Added deterministic `clusters-upgrade.spec.ts` coverage for mixed unsorted candidates and PATCH payload `spec.version=v1.2.0`.
- Execution is blocked in this workspace because the local UI proxy has no reachable backend/auth profile; manual testing is required until a valid E2E environment is available.