### PR TITLE
fix: lock endpoint cluster on edit

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -239,7 +239,7 @@
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "d022c0d909fa184e74a05a17726cb74f",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "4cc027fbab8e693d19612c4fc1fa9008",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "660a23da3772a16db5017db30453e49b",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "7fc5186989f74eb21ecf621ac24e5ee4",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",

--- a/e2e/tests/endpoints.spec.ts
+++ b/e2e/tests/endpoints.spec.ts
@@ -7,6 +7,7 @@ import { ResourcePage } from "../helpers/resource-page";
 // ── Shared test data created once in beforeAll ──
 const irName = { value: "" }; // Image registry for cluster dependency
 const clusterName = { value: "" };
+const alternateClusterName = { value: "" };
 const engineName = { value: "" };
 const nonLlmEngineName = { value: "" };
 const mrName = { value: "" };
@@ -26,6 +27,7 @@ test.describe("endpoints", () => {
     const ts = Date.now();
     irName.value = `test-ep-ir-${ts}`;
     clusterName.value = `test-ep-cl-${ts}`;
+    alternateClusterName.value = `test-ep-alt-cl-${ts}`;
     engineName.value = `test-ep-engine-${ts}`;
     nonLlmEngineName.value = `test-ep-non-llm-engine-${ts}`;
     mrName.value = `test-ep-mr-${ts}`;
@@ -39,6 +41,10 @@ test.describe("endpoints", () => {
     // Create dependency resources first
     await api.createImageRegistry(irName.value);
     await api.createCluster(clusterName.value, {
+      type: "ssh",
+      imageRegistry: irName.value,
+    });
+    await api.createCluster(alternateClusterName.value, {
       type: "ssh",
       imageRegistry: irName.value,
     });
@@ -100,6 +106,9 @@ test.describe("endpoints", () => {
     // Then dependencies in parallel (cluster + model registry + model catalog)
     await Promise.all([
       api.deleteCluster(clusterName.value, { force: true }).catch(() => {}),
+      api
+        .deleteCluster(alternateClusterName.value, { force: true })
+        .catch(() => {}),
       api.deleteEngine(engineName.value, { force: true }).catch(() => {}),
       api.deleteEngine(nonLlmEngineName.value, { force: true }).catch(() => {}),
       api.deleteModelRegistry(mrName.value, { force: true }).catch(() => {}),
@@ -1093,25 +1102,44 @@ test.describe("endpoints", () => {
       await expect(endpoints.form.field("-model-catalog")).toBeHidden();
     });
 
-    test("edit: cluster and registry editable", { tag: "@C2613287" }, async ({
-      endpoints,
-    }) => {
+    test("edit: cluster immutable and registry editable", {
+      tag: "@C2613287",
+    }, async ({ endpoints, apiHelper }) => {
       await endpoints.goToEdit(epNames.base);
       await expect(
         endpoints.page.locator('[data-testid="form-submit"]'),
       ).toBeEnabled();
 
-      // Cluster combobox should be enabled
+      // Existing endpoints keep their deployment cluster.
       const clusterButton = endpoints.form
         .field("spec.cluster")
-        .locator("button");
-      await expect(clusterButton).toBeEnabled();
+        .locator('button[role="combobox"]');
+      await expect(clusterButton).toBeDisabled();
 
       // Model registry combobox should be enabled
       const registryButton = endpoints.form
         .field("spec.model.registry")
         .locator("button");
       await expect(registryButton).toBeEnabled();
+
+      const patch = await apiHelper.request<{ code: string }>(
+        "PATCH",
+        `/endpoints?metadata->>name=eq.${epNames.base}&metadata->>workspace=eq.default`,
+        { spec: { cluster: alternateClusterName.value } },
+        { probe: true },
+      );
+      expect(patch.status).toBe(400);
+      expect(patch.body).toMatchObject({ code: "10225" });
+
+      const endpoint = await apiHelper.request<
+        Array<{ spec: { cluster: string } }>
+      >(
+        "GET",
+        `/endpoints?metadata->>name=eq.${epNames.base}&metadata->>workspace=eq.default`,
+      );
+      expect(endpoint.ok).toBe(true);
+      expect(endpoint.body).toHaveLength(1);
+      expect(endpoint.body[0]?.spec.cluster).toBe(clusterName.value);
     });
 
     test("edit: model registry visible in configuration details", {

--- a/e2e/tests/endpoints.spec.ts
+++ b/e2e/tests/endpoints.spec.ts
@@ -7,7 +7,6 @@ import { ResourcePage } from "../helpers/resource-page";
 // ── Shared test data created once in beforeAll ──
 const irName = { value: "" }; // Image registry for cluster dependency
 const clusterName = { value: "" };
-const alternateClusterName = { value: "" };
 const engineName = { value: "" };
 const nonLlmEngineName = { value: "" };
 const mrName = { value: "" };
@@ -27,7 +26,6 @@ test.describe("endpoints", () => {
     const ts = Date.now();
     irName.value = `test-ep-ir-${ts}`;
     clusterName.value = `test-ep-cl-${ts}`;
-    alternateClusterName.value = `test-ep-alt-cl-${ts}`;
     engineName.value = `test-ep-engine-${ts}`;
     nonLlmEngineName.value = `test-ep-non-llm-engine-${ts}`;
     mrName.value = `test-ep-mr-${ts}`;
@@ -41,10 +39,6 @@ test.describe("endpoints", () => {
     // Create dependency resources first
     await api.createImageRegistry(irName.value);
     await api.createCluster(clusterName.value, {
-      type: "ssh",
-      imageRegistry: irName.value,
-    });
-    await api.createCluster(alternateClusterName.value, {
       type: "ssh",
       imageRegistry: irName.value,
     });
@@ -106,9 +100,6 @@ test.describe("endpoints", () => {
     // Then dependencies in parallel (cluster + model registry + model catalog)
     await Promise.all([
       api.deleteCluster(clusterName.value, { force: true }).catch(() => {}),
-      api
-        .deleteCluster(alternateClusterName.value, { force: true })
-        .catch(() => {}),
       api.deleteEngine(engineName.value, { force: true }).catch(() => {}),
       api.deleteEngine(nonLlmEngineName.value, { force: true }).catch(() => {}),
       api.deleteModelRegistry(mrName.value, { force: true }).catch(() => {}),
@@ -1104,7 +1095,7 @@ test.describe("endpoints", () => {
 
     test("edit: cluster immutable and registry editable", {
       tag: "@C2613287",
-    }, async ({ endpoints, apiHelper }) => {
+    }, async ({ endpoints }) => {
       await endpoints.goToEdit(epNames.base);
       await expect(
         endpoints.page.locator('[data-testid="form-submit"]'),
@@ -1121,25 +1112,6 @@ test.describe("endpoints", () => {
         .field("spec.model.registry")
         .locator("button");
       await expect(registryButton).toBeEnabled();
-
-      const patch = await apiHelper.request<{ code: string }>(
-        "PATCH",
-        `/endpoints?metadata->>name=eq.${epNames.base}&metadata->>workspace=eq.default`,
-        { spec: { cluster: alternateClusterName.value } },
-        { probe: true },
-      );
-      expect(patch.status).toBe(400);
-      expect(patch.body).toMatchObject({ code: "10225" });
-
-      const endpoint = await apiHelper.request<
-        Array<{ spec: { cluster: string } }>
-      >(
-        "GET",
-        `/endpoints?metadata->>name=eq.${epNames.base}&metadata->>workspace=eq.default`,
-      );
-      expect(endpoint.ok).toBe(true);
-      expect(endpoint.body).toHaveLength(1);
-      expect(endpoint.body[0]?.spec.cluster).toBe(clusterName.value);
     });
 
     test("edit: model registry visible in configuration details", {

--- a/e2e/tests/endpoints.spec.ts
+++ b/e2e/tests/endpoints.spec.ts
@@ -1093,9 +1093,7 @@ test.describe("endpoints", () => {
       await expect(endpoints.form.field("-model-catalog")).toBeHidden();
     });
 
-    test("edit: cluster immutable and registry editable", {
-      tag: "@C2613287",
-    }, async ({ endpoints }) => {
+    test("edit: cluster immutable and registry editable", async ({ endpoints }) => {
       await endpoints.goToEdit(epNames.base);
       await expect(
         endpoints.page.locator('[data-testid="form-submit"]'),

--- a/e2e/tests/endpoints.spec.ts
+++ b/e2e/tests/endpoints.spec.ts
@@ -92,7 +92,7 @@ test.describe("endpoints", () => {
   });
 
   test.afterAll(async ({ browser }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(120_000);
     const context = await browser.newContext();
     const page = await context.newPage();
     const api = new ApiHelper(page);

--- a/e2e/tests/endpoints.spec.ts
+++ b/e2e/tests/endpoints.spec.ts
@@ -1093,7 +1093,9 @@ test.describe("endpoints", () => {
       await expect(endpoints.form.field("-model-catalog")).toBeHidden();
     });
 
-    test("edit: cluster immutable and registry editable", async ({ endpoints }) => {
+    test("edit: cluster immutable and registry editable", async ({
+      endpoints,
+    }) => {
       await endpoints.goToEdit(epNames.base);
       await expect(
         endpoints.page.locator('[data-testid="form-submit"]'),

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -971,6 +971,39 @@ describe("useEndpointForm", () => {
     formInstance = null;
   });
 
+  it("locks the cluster when editing but keeps it selectable when creating", async () => {
+    setupMocks([catalogA, catalogB], [virtualizedKubernetesClusterWithDevices]);
+    const editRender = render(<EditForm />);
+
+    const editClusterButton = await within(
+      await screen.findByTestId("field-spec.cluster"),
+    ).findByRole("combobox");
+    expect(editClusterButton.hasAttribute("disabled")).toBe(true);
+
+    editRender.unmount();
+    render(<CreateForm />);
+
+    const createClusterButton = await within(
+      await screen.findByTestId("field-spec.cluster"),
+    ).findByRole("combobox");
+    expect(createClusterButton.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("keeps an edit cluster visible when it is absent from cluster options", async () => {
+    setupMocks([catalogA, catalogB], [virtualizedKubernetesClusterWithDevices]);
+    render(<EditForm />);
+
+    await waitFor(() => expect(formInstance).not.toBeNull());
+    act(() => {
+      formInstance?.setValue("spec.cluster", "unlisted-existing-cluster");
+    });
+
+    const clusterButton = await within(
+      screen.getByTestId("field-spec.cluster"),
+    ).findByRole("combobox");
+    expect(clusterButton.textContent).toContain("unlisted-existing-cluster");
+  });
+
   it("places cluster-only scheduling target inside resource selection", async () => {
     setupMocks([catalogA, catalogB], [virtualizedKubernetesClusterWithDevices]);
     const { container } = render(<CreateForm />);

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -299,6 +299,23 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   const isEdit = action === "edit";
   const sectionVariant = "section";
 
+  const clusterOptions = useMemo(() => {
+    const options = (clusters.query?.data?.data || []).map((cluster) => ({
+      label: cluster.metadata.name,
+      value: cluster.metadata.name,
+    }));
+
+    if (
+      !isEdit ||
+      !currentCluster ||
+      options.some((option) => option.value === currentCluster)
+    ) {
+      return options;
+    }
+
+    return [{ label: currentCluster, value: currentCluster }, ...options];
+  }, [clusters.query?.data?.data, currentCluster, isEdit]);
+
   const selectedVirtualization = selectedAccelerator?.virtualization;
   const isSelectedClusterVgpuEnabled =
     selectedCluster?.spec.type === "kubernetes" &&
@@ -1664,14 +1681,9 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                   className="w-full max-w-[280px]"
                 >
                   <FormCombobox
-                    disabled={clusters.query.isLoading}
+                    disabled={isEdit || clusters.query.isLoading}
                     placeholder={t("endpoints.placeholders.selectCluster")}
-                    options={(clusters.query?.data?.data || []).map((e) => {
-                      return {
-                        label: e.metadata.name,
-                        value: e.metadata.name,
-                      };
-                    })}
+                    options={clusterOptions}
                   />
                 </FormFieldGroup>
                 <div


### PR DESCRIPTION
## Issue

NEU-635

## Summary

Keep an endpoint cluster visible but immutable in the edit form, while preserving create behavior and model registry editing.

## Changes

- Disable the endpoint cluster selector only in edit mode.
- Retain a persisted cluster value when it is absent from current options.
- Keep the endpoint edit browser test UI-only: it checks the disabled cluster selector and enabled model registry selector, with no direct endpoint API assertion or TestRail tag.

## Test Plan

### Unit test

- `yarn test`: 115 files and 1263 tests passed under Node 22.22.1.
- `yarn typecheck` and CI `yarn lint:ci` passed for head `41021c7`.

### DB test

- Not affected.

### E2E test

- The endpoint edit UI-only browser test passed: cluster selector disabled and model registry selector enabled.
- Manual testing is not required; the required edit-flow behavior is covered by the browser E2E test.

## Risk & Rollback

No API or schema change in this repository. Revert this PR to restore the former edit selector behavior.