### PR TITLE
test: use maintained vllm versions in e2e

### DIFF
--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -138,7 +138,7 @@ function buildConfig(raw: Record<string, any>): E2eConfig {
     },
     engine: {
       name: eng.name ?? "vllm",
-      version: eng.version ?? "v0.8.5",
+      version: eng.version ?? "v0.24.0",
     },
     model: {
       name: model.name ?? "test-model",

--- a/e2e/profiles/default.yaml
+++ b/e2e/profiles/default.yaml
@@ -29,7 +29,7 @@ kubernetes:
 
 engine:
   name: "vllm"
-  version: "v0.8.5"
+  version: "v0.24.0"
 
 model:
   name: "test-model"

--- a/e2e/profiles/k8s-cpu.yaml.example
+++ b/e2e/profiles/k8s-cpu.yaml.example
@@ -12,7 +12,7 @@ k8sCluster:
 
 engine:
   name: "vllm"
-  version: "v0.8.5"
+  version: "v0.24.0"
 
 model:
   name: "TinyLlama/TinyLlama-1.1B-Chat-v1.0"

--- a/e2e/tests/engines.spec.ts
+++ b/e2e/tests/engines.spec.ts
@@ -97,6 +97,7 @@ test.describe("engines list", () => {
 
     // vLLM exposes maintained versions in the builtin support window.
     const row = engines.table.rowWithText(ENGINE_VLLM);
+    await expect(row.getByText("v0.17.1")).toBeVisible();
     await expect(row.getByText("v0.24.0")).toBeVisible();
   });
 

--- a/e2e/tests/engines.spec.ts
+++ b/e2e/tests/engines.spec.ts
@@ -95,9 +95,9 @@ test.describe("engines list", () => {
     await engines.table.waitForLoaded();
     await expect(engines.table.headerCell(/versions/i)).toBeVisible();
 
-    // vllm has multiple versions
+    // vLLM exposes maintained versions in the builtin support window.
     const row = engines.table.rowWithText(ENGINE_VLLM);
-    await expect(row.getByText("v0.8.5")).toBeVisible();
+    await expect(row.getByText("v0.24.0")).toBeVisible();
   });
 
   test("can sort by updated time", {
@@ -205,7 +205,7 @@ test.describe("engines detail", () => {
   test("can switch version in detail page", {
     tag: "@C2613211",
   }, async ({ engines }) => {
-    // vllm has multiple versions (v0.8.5, v0.11.2)
+    // vLLM has multiple maintained versions (v0.17.1, v0.24.0).
     await engines.goToShow(ENGINE_VLLM);
 
     const showPage = engines.page.locator('[data-testid="show-page"]');

--- a/e2e/tests/model-catalogs-recipe-gpu.spec.ts
+++ b/e2e/tests/model-catalogs-recipe-gpu.spec.ts
@@ -52,7 +52,7 @@ async function pickAccelerator(page: Page): Promise<void> {
  * cover the three VRAM-check outcomes on a ~15 GB card. */
 function hwRecipeSpec(registry: string): Record<string, unknown> {
   return {
-    engine: { engine: "vllm", version: "v0.8.5" },
+    engine: { engine: "vllm", version: "v0.24.0" },
     base: { engine_args: { enable_prefix_caching: true, dtype: "half" } },
     variants: {
       default: {

--- a/e2e/tests/model-catalogs-recipe.spec.ts
+++ b/e2e/tests/model-catalogs-recipe.spec.ts
@@ -85,7 +85,7 @@ async function closeMcImportDialog(page: Page) {
 // create form resolves the variant's model against it. ──
 function recipeSpec(registry = "huggingface"): Record<string, unknown> {
   return {
-    engine: { engine: "vllm", version: "v0.8.5" },
+    engine: { engine: "vllm", version: "v0.24.0" },
     base: { engine_args: { enable_prefix_caching: true } },
     variants: {
       default: {
@@ -221,7 +221,7 @@ metadata:
   annotations:
     recipe.vllm.ai/hardware-verified: "L20"
 spec:
-  engine: { engine: vllm, version: v0.8.5 }
+  engine: { engine: vllm, version: v0.24.0 }
   base: { engine_args: { enable_prefix_caching: true } }
   variants:
     default:
@@ -289,7 +289,7 @@ spec:
 kind: ModelCatalog
 metadata: { name: ${name}, workspace: default }
 spec:
-  engine: { engine: vllm, version: v0.8.5 }
+  engine: { engine: vllm, version: v0.24.0 }
   model: { registry: huggingface, name: top-level-model, task: text-generation }
   variants:
     default:
@@ -315,7 +315,7 @@ spec:
 kind: ModelCatalog
 metadata: { name: ${name}, workspace: default }
 spec:
-  engine: { engine: vllm, version: v0.8.5 }
+  engine: { engine: vllm, version: v0.24.0 }
   variants:
     default:
       model: { registry: huggingface, name: Neutree/Test-27B, task: text-generation }
@@ -344,7 +344,7 @@ spec:
 kind: ModelCatalog
 metadata: { name: ${name}, workspace: default }
 spec:
-  engine: { engine: vllm, version: v0.8.5 }
+  engine: { engine: vllm, version: v0.24.0 }
   variants:
     default:
       model: { registry: huggingface, name: Neutree/Test-27B, task: text-generation }
@@ -370,7 +370,7 @@ spec:
 kind: ModelCatalog
 metadata: { name: ${name}, workspace: default }
 spec:
-  engine: { engine: vllm, version: v0.8.5 }
+  engine: { engine: vllm, version: v0.24.0 }
   variants:
     default:
       model: { registry: huggingface, name: Neutree/Test-27B, task: text-generation }
@@ -759,7 +759,7 @@ test.describe("recipe model catalog: import permissions", () => {
 kind: ModelCatalog
 metadata: { name: ${name}, workspace: default }
 spec:
-  engine: { engine: vllm, version: v0.8.5 }
+  engine: { engine: vllm, version: v0.24.0 }
   variants:
     default:
       model: { registry: huggingface, name: Neutree/Test-27B, task: text-generation }`);

--- a/e2e/tests/yaml-import.spec.ts
+++ b/e2e/tests/yaml-import.spec.ts
@@ -29,7 +29,7 @@ spec:
     file: model.safetensors
   engine:
     engine: vllm
-    version: v0.8.5
+    version: v0.24.0
   resources:
     cpu: 1
     memory: 1


### PR DESCRIPTION
## Summary

- replace retired vLLM versions in UI E2E defaults and fixtures
- assert the Engines list uses vLLM v0.24.0

## Test Plan

### Unit test

- N/A: E2E fixture-only change.

### DB test

- N/A: no database change.

### E2E test

- Pending provisioned browser environment. The isolated worktree has no Playwright binary.