### PR TITLE
test: cover cluster credential rotation inputs

### DIFF
--- a/e2e/tests/clusters.spec.ts
+++ b/e2e/tests/clusters.spec.ts
@@ -392,7 +392,7 @@ test.describe("clusters", () => {
       await expect(irButton).toBeDisabled();
     });
 
-    test("SSH edit: provider, auth, and cache fields disabled", {
+    test("SSH edit: immutable fields and caches disabled; worker IPs and private key can update", {
       tag: "@C2612829",
     }, async ({ clusters }) => {
       await clusters.goToEdit(clNames.ssh);
@@ -405,12 +405,10 @@ test.describe("clusters", () => {
         clusters.page.getByPlaceholder("e.g 192.168.1.1"),
       ).toBeDisabled();
 
-      // Provider: Worker IP "Add" section should be hidden (disabled hides it)
+      // Provider: Worker IP controls remain available for node changes.
       await expect(
-        clusters.page.getByRole("button", { name: /add/i }).filter({
-          has: clusters.page.locator("svg"),
-        }),
-      ).toBeHidden();
+        clusters.page.getByPlaceholder("Add New Worker Node IP"),
+      ).toBeEnabled();
 
       // Auth: ssh_user disabled
       const sshUserInput = clusters.form
@@ -418,24 +416,34 @@ test.describe("clusters", () => {
         .locator("input");
       await expect(sshUserInput).toBeDisabled();
 
-      // Auth: ssh_private_key disabled
+      // Auth: ssh_private_key is blank and editable for rotation.
       const sshKeyTextarea = clusters.form
         .field("spec.config.ssh_config.auth.ssh_private_key")
         .locator("textarea");
-      await expect(sshKeyTextarea).toBeDisabled();
+      await expect(sshKeyTextarea).toBeEnabled();
+      await expect(sshKeyTextarea).toHaveValue("");
 
       // Auth: "Leave empty to keep" message
       await expect(
         clusters.page.getByText(/leave empty to keep/i).first(),
       ).toBeVisible();
 
-      // Cache: "Add Model Cache" button should not be visible when disabled
+      // Existing model cache fields are disabled in SSH edit mode.
+      await clusters.goToEdit(clNames.sshWithCache);
+      await expect(
+        clusters.form.field("spec.config.model_caches.0.name").locator("input"),
+      ).toBeDisabled();
+      await expect(
+        clusters.form
+          .field("spec.config.model_caches.0.host_path.path")
+          .locator("input"),
+      ).toBeDisabled();
       await expect(
         clusters.page.getByRole("button", { name: /add model cache/i }),
       ).toBeHidden();
     });
 
-    test("K8s edit: name, workspace, type disabled; kubeconfig disabled", {
+    test("K8s edit: name, workspace, type disabled; kubeconfig can rotate", {
       tag: "@C2613080",
     }, async ({ clusters }) => {
       await clusters.goToEdit(clNames.k8s);
@@ -459,11 +467,12 @@ test.describe("clusters", () => {
         .locator('button[role="combobox"]');
       await expect(typeButton).toBeDisabled();
 
-      // Kubeconfig disabled
+      // Kubeconfig is blank and editable for rotation.
       const kubeconfigTextarea = clusters.form
         .field("spec.config.kubernetes_config.kubeconfig")
         .locator("textarea");
-      await expect(kubeconfigTextarea).toBeDisabled();
+      await expect(kubeconfigTextarea).toBeEnabled();
+      await expect(kubeconfigTextarea).toHaveValue("");
 
       // "Leave empty to keep" message
       await expect(


### PR DESCRIPTION
## Issue

NEU-388

## Summary

Align Cluster edit Playwright contracts with the existing UI behavior for editable, empty credential fields and immutable infrastructure fields.

## Changes

- Verify that Kubernetes kubeconfig and SSH private key inputs remain editable and empty in edit mode.
- Retain disabled assertions for image registry, immutable identity fields, and existing model cache controls.
- Keep test fixtures and TestRail tags intact without entering or exposing secrets.

## Test Plan

### Unit test

- `node tools/i18n-tracker.cjs`
- `biome check e2e/tests/clusters.spec.ts`
- `tsc -b --pretty false`

### DB test

- Not affected: E2E test-contract change only.

### E2E test

- Pending Step 5 controlled browser validation against a matching API/UI environment.
- Test discovery covers the Kubernetes kubeconfig and SSH private-key edit cases.

## Risk & Rollback

No production UI behavior changes. Revert this test-only commit to restore the previous assertions.