### PR TITLE
feat(endpoints): gate the Playground on the engine's declared capability (NEU-599)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -33,7 +33,7 @@
   "src/pages/endpoints/create.tsx": "80007cdbc2f2ecd902d6485b6774cf2b",
   "src/pages/endpoints/edit.tsx": "f985a843fe494b31594f2291e8bcfee8",
   "src/pages/endpoints/list.tsx": "aa1f159a45560783cd05531e54829a02",
-  "src/pages/endpoints/show.tsx": "aac23e165a08c9c5a16cc1f14c37e57b",
+  "src/pages/endpoints/show.tsx": "3361cccbba6f2909fb6ab83721b4c7b3",
   "src/pages/dashboard/Dashboard.tsx": "5c949e1cfe926f6538294445610940ce",
   "src/pages/clusters/create.tsx": "fd2b1c7affa795305445f8e307dea099",
   "src/pages/clusters/edit.tsx": "d636f55fd8591fabd56759bf0f46963e",
@@ -167,7 +167,7 @@
   "src/domains/model-catalog/components/ModelCatalogStatus.tsx": "05b5724d20089c977c76c3ee2ddf1e22",
   "src/domains/image-registry/types.ts": "d63ecb27f4dd788187d49224d2ac2e0d",
   "src/domains/image-registry/components/ImageRegistryStatus.tsx": "177d04944d9cf0fd39c063698ac1fd46",
-  "src/domains/engine/types.ts": "3d7707317a940caec7f051551b6b9408",
+  "src/domains/engine/types.ts": "522162d43e3b3cfbb22d763412912325",
   "src/domains/engine/components/EngineStatus.tsx": "5bf9e785a7f7476a56b9c87c36ba3f18",
   "src/domains/engine/components/EngineVariablesCard.tsx": "bcb8238f540bf70deddf5296723f31e9",
   "src/domains/engine/components/EngineVersions.tsx": "46eb6987394db5f7c5cf8fed3204e074",
@@ -357,5 +357,6 @@
   "src/domains/model-registry/components/ModelEditDialog.tsx": "c9af4f5b1b5cae132240a0669762769a",
   "src/domains/model-registry/components/ModelInfoFields.tsx": "4de75c3f06118f24d2b1538af84786e8",
   "src/domains/model-registry/components/ModelRegistryStats.tsx": "207d63a6478d660945c1e7c3a9fdc52a",
-  "src/domains/model-registry/components/RegistryModelsTable.tsx": "3fbf89f317de15c16ed5515f4e34d9cc"
+  "src/domains/model-registry/components/RegistryModelsTable.tsx": "3fbf89f317de15c16ed5515f4e34d9cc",
+"src/domains/engine/lib/resolve-capabilities.ts": "9a444cc413dae9066a7983c28c1d0fba"
 }

--- a/src/domains/engine/lib/resolve-capabilities.test.ts
+++ b/src/domains/engine/lib/resolve-capabilities.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type {
+  EngineCapabilities,
+  EngineVersion,
+  PlaygroundMode,
+} from "@/domains/engine/types";
+import { resolvePlayground } from "./resolve-capabilities";
+
+function makeVersion(capabilities?: EngineCapabilities | null): EngineVersion {
+  return {
+    version: "v1",
+    values_schema: {},
+    capabilities,
+  };
+}
+
+function playgroundVersion(
+  enabled: boolean,
+  modes?: PlaygroundMode[],
+): EngineVersion {
+  return makeVersion({ playground: { enabled, modes } });
+}
+
+describe("resolvePlayground", () => {
+  describe("undeclared falls back to the pre-protocol behaviour", () => {
+    // These are the cases that matter on upgrade: engines registered before the
+    // capability protocol carry no declaration and must keep working.
+    const undeclared: [string, EngineVersion | undefined][] = [
+      ["engine version not resolved yet", undefined],
+      ["no capabilities at all", makeVersion()],
+      ["null capabilities", makeVersion(null)],
+      ["capabilities present but playground undeclared", makeVersion({})],
+      [
+        "another capability declared, playground undeclared",
+        makeVersion({ metrics_export: { enabled: false } }),
+      ],
+    ];
+
+    it.each(undeclared)("%s: shows the tab", (_name, version) => {
+      expect(resolvePlayground(version, "text-generation").enabled).toBe(true);
+    });
+
+    it.each(undeclared)(
+      "%s: derives the surface from the task",
+      (_name, version) => {
+        expect(resolvePlayground(version, "text-embedding").mode).toBe(
+          "embedding",
+        );
+        expect(resolvePlayground(version, "text-rerank").mode).toBe("rerank");
+        expect(resolvePlayground(version, "text-generation").mode).toBe("chat");
+        expect(resolvePlayground(version, undefined).mode).toBe("chat");
+      },
+    );
+  });
+
+  it("hides the tab when the engine declares it unsupported", () => {
+    expect(
+      resolvePlayground(playgroundVersion(false), "text-generation"),
+    ).toEqual({ enabled: false, mode: null });
+  });
+
+  it("ignores declared modes when disabled", () => {
+    expect(
+      resolvePlayground(playgroundVersion(false, ["chat"]), "text-generation"),
+    ).toEqual({ enabled: false, mode: null });
+  });
+
+  it("treats an empty mode list as no narrowing", () => {
+    expect(
+      resolvePlayground(playgroundVersion(true, []), "text-rerank"),
+    ).toEqual({
+      enabled: true,
+      mode: "rerank",
+    });
+  });
+
+  it("uses the task's surface when the engine declares it", () => {
+    expect(
+      resolvePlayground(
+        playgroundVersion(true, ["chat", "embedding"]),
+        "text-embedding",
+      ),
+    ).toEqual({ enabled: true, mode: "embedding" });
+  });
+
+  it("prefers the declaration over the task when they disagree", () => {
+    // A document-extraction engine (the MinerU case) serves a chat playground
+    // while its task is nothing the console knows about. The declaration wins.
+    expect(
+      resolvePlayground(
+        playgroundVersion(true, ["chat"]),
+        "document-extraction",
+      ),
+    ).toEqual({ enabled: true, mode: "chat" });
+
+    // Same rule when the task maps to a surface the engine did not declare:
+    // showing the rerank playground for an engine that cannot rerank would be
+    // worse than showing the one it says it has.
+    expect(
+      resolvePlayground(playgroundVersion(true, ["embedding"]), "text-rerank"),
+    ).toEqual({ enabled: true, mode: "embedding" });
+  });
+});

--- a/src/domains/engine/lib/resolve-capabilities.ts
+++ b/src/domains/engine/lib/resolve-capabilities.ts
@@ -1,0 +1,79 @@
+import type { EngineVersion, PlaygroundMode } from "@/domains/engine/types";
+
+/**
+ * Playground state resolved for a specific endpoint, with the
+ * undeclared-means-legacy fallback already applied.
+ */
+type ResolvedPlayground = {
+  /** Whether the Playground tab should be offered at all. */
+  enabled: boolean;
+  /**
+   * Which Playground component to render. Null only when `enabled` is false.
+   */
+  mode: PlaygroundMode | null;
+};
+
+/**
+ * Maps an endpoint's model task to the interaction surface the console used
+ * before engines could declare capabilities: embedding and rerank tasks each
+ * had their own Playground, everything else fell through to chat.
+ */
+function modeFromTask(task: string | undefined): PlaygroundMode {
+  switch (task) {
+    case "text-embedding":
+      return "embedding";
+    case "text-rerank":
+      return "rerank";
+    default:
+      return "chat";
+  }
+}
+
+/**
+ * Resolves whether to show the Playground for an endpoint, and which one.
+ *
+ * The fallback rules mirror `EngineVersion.ResolvePlayground` on the server
+ * (api/v1/engine_types.go). They matter more than the happy path: an engine
+ * version with no declaration — every engine registered before the capability
+ * protocol, including externally registered ones in already-deployed
+ * environments — must behave exactly as it did before, which means the tab
+ * stays visible and the surface comes from the model task.
+ *
+ * @param engineVersion the endpoint's engine version, or undefined while the
+ *   engine query is still loading or the version is no longer registered
+ * @param task the endpoint's `spec.model.task`
+ */
+export function resolvePlayground(
+  engineVersion: EngineVersion | undefined,
+  task: string | undefined,
+): ResolvedPlayground {
+  const declared = engineVersion?.capabilities?.playground;
+
+  // Undeclared, or the engine version could not be resolved at all: keep the
+  // pre-protocol behaviour rather than hiding a Playground that works today.
+  if (!declared) {
+    return { enabled: true, mode: modeFromTask(task) };
+  }
+
+  if (!declared.enabled) {
+    return { enabled: false, mode: null };
+  }
+
+  const modes = declared.modes ?? [];
+
+  // Enabled without narrowing the surface down: same as undeclared.
+  if (modes.length === 0) {
+    return { enabled: true, mode: modeFromTask(task) };
+  }
+
+  const preferred = modeFromTask(task);
+
+  if (modes.includes(preferred)) {
+    return { enabled: true, mode: preferred };
+  }
+
+  // The engine declares surfaces, but not the one this task implies. Trust the
+  // declaration over the task — that is the whole point of the protocol — and
+  // render the first surface it does declare.
+  return { enabled: true, mode: modes[0] };
+}

--- a/src/domains/engine/types.ts
+++ b/src/domains/engine/types.ts
@@ -14,9 +14,48 @@ export type EngineSpec = {
   supported_tasks: string[];
 };
 
+/**
+ * Interaction surfaces the Playground can render. This is a separate vocabulary
+ * from the model task: an engine can serve a chat-shaped playground without
+ * advertising `text-generation` (document extraction engines such as MinerU),
+ * which is why the tab must not be derived from the task alone.
+ */
+export type PlaygroundMode = "chat" | "embedding" | "rerank";
+
+export type PlaygroundCapability = {
+  enabled: boolean;
+  /**
+   * Interaction surfaces this engine version can serve. Absent or empty means
+   * the engine does not narrow it down, and the surface is inferred from the
+   * endpoint's model task as it was before engines could declare capabilities.
+   */
+  modes?: PlaygroundMode[];
+};
+
+export type MetricsExportCapability = {
+  enabled: boolean;
+  port?: number;
+  path?: string;
+};
+
+/**
+ * What an engine version declares it can do.
+ *
+ * Every field is optional, and an absent field means "undeclared", not
+ * "unsupported". Engines registered before the capability protocol carry no
+ * declaration at all and must keep working as they did, so never read these
+ * fields directly — go through `resolvePlayground` in
+ * `@/domains/engine/lib/resolve-capabilities`, which applies that fallback.
+ */
+export type EngineCapabilities = {
+  metrics_export?: MetricsExportCapability;
+  playground?: PlaygroundCapability;
+};
+
 export type EngineVersion = {
   version: string;
   values_schema: Record<string, string | number | boolean>;
+  capabilities?: EngineCapabilities | null;
 };
 
 export type EngineStatus = BaseStatus<EnginePhase>;

--- a/src/pages/endpoints/show.tsx
+++ b/src/pages/endpoints/show.tsx
@@ -20,6 +20,7 @@ import ResourcesCard from "@/domains/endpoint/components/ResourcesCard";
 import { useEndpointMonitorPanels } from "@/domains/endpoint/hooks/use-endpoint-monitor-panels";
 import type { Endpoint } from "@/domains/endpoint/types";
 import EngineVariablesCard from "@/domains/engine/components/EngineVariablesCard";
+import { resolvePlayground } from "@/domains/engine/lib/resolve-capabilities";
 import type { Engine } from "@/domains/engine/types";
 import GrafanaDashboard from "@/foundation/components/GrafanaDashboard";
 import { Loader } from "@/foundation/components/Loader";
@@ -153,9 +154,11 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
     return <div>{t("pages.error.notFound")}</div>;
   }
 
-  const engineVersionSchema = engineData?.data?.spec.versions.find(
+  const engineVersion = engineData?.data?.spec.versions.find(
     (v) => v.version === record.spec.engine.version,
-  )?.values_schema;
+  );
+  const engineVersionSchema = engineVersion?.values_schema;
+  const playground = resolvePlayground(engineVersion, record.spec.model.task);
 
   return (
     <ShowPage
@@ -210,9 +213,14 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
           <TabsTrigger value="logs" className={detailTabTriggerClassName}>
             {t("common.tabs.logs")}
           </TabsTrigger>
-          <TabsTrigger value="playground" className={detailTabTriggerClassName}>
-            {t("endpoints.tabs.playground")}
-          </TabsTrigger>
+          {playground.enabled && (
+            <TabsTrigger
+              value="playground"
+              className={detailTabTriggerClassName}
+            >
+              {t("endpoints.tabs.playground")}
+            </TabsTrigger>
+          )}
         </TabsList>
         <TabsContent
           value="basic"
@@ -389,19 +397,24 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
             <EndpointLogTabs endpoint={record} />
           </Suspense>
         </TabsContent>
-        <TabsContent value="playground" className="mt-0 flex-1 overflow-hidden">
-          <Suspense
-            fallback={<Loader className="w-16 text-muted-foreground" />}
+        {playground.enabled && (
+          <TabsContent
+            value="playground"
+            className="mt-0 flex-1 overflow-hidden"
           >
-            {record.spec.model.task === "text-embedding" ? (
-              <EmbeddingPlayground endpoint={record} />
-            ) : record.spec.model.task === "text-rerank" ? (
-              <RerankPlayground endpoint={record} />
-            ) : (
-              <ChatPlayground endpoint={record} />
-            )}
-          </Suspense>
-        </TabsContent>
+            <Suspense
+              fallback={<Loader className="w-16 text-muted-foreground" />}
+            >
+              {playground.mode === "embedding" ? (
+                <EmbeddingPlayground endpoint={record} />
+              ) : playground.mode === "rerank" ? (
+                <RerankPlayground endpoint={record} />
+              ) : (
+                <ChatPlayground endpoint={record} />
+              )}
+            </Suspense>
+          </TabsContent>
+        )}
       </Tabs>
     </ShowPage>
   );


### PR DESCRIPTION
## Issue

NEU-599

## Summary

The endpoint detail page shows the Playground tab unconditionally and picks which Playground to render from `spec.model.task` alone. NEU-599 concluded that neither "is it an LLM engine" nor the task is a sound basis for that decision — some flex engines are not LLM engines but still serve a usable Playground (MinerU), while other engines have no interactive surface at all.

This reads the engine's declared capability instead. Depends on **neutree-ai/neutree#544**, which adds `capabilities` to `EngineVersion`; until that ships, every engine resolves as undeclared and the page behaves exactly as it does today.

## Changes

- **`src/domains/engine/types.ts`** — `EngineCapabilities` on `EngineVersion`, with `playground` (enabled + modes) and `metrics_export`. Every field optional: absent means *undeclared*, not *unsupported*.
- **`src/domains/engine/lib/resolve-capabilities.ts`** (new) — `resolvePlayground(engineVersion, task)` applies the same fallback rules as `EngineVersion.ResolvePlayground` on the server.
- **`src/pages/endpoints/show.tsx`** — the tab trigger and its content render only when the resolved capability is enabled; the surface comes from the resolved mode rather than from the task directly.

No new user-facing strings — the tab label already goes through `t()`.

## Design notes

**Why a resolver function rather than reading the field inline.** `capabilities?.playground?.enabled` is `undefined` for every engine registered before the protocol, and `undefined` is falsy — so the inline version would hide the Playground for every existing deployment on upgrade. The resolver makes "undeclared" an explicit branch that returns the pre-protocol behaviour: tab visible, surface inferred from the task. Note this is the opposite of NEU-599's literal wording ("hide when undeclared or unsupported"); the inversion is deliberate and matches the compatibility rule agreed for the protocol in neutree#544.

**When modes disagree with the task, the declaration wins.** An engine declaring `modes: ["chat"]` gets the chat Playground even if its task is something the console does not recognise — that is exactly the MinerU case the ticket calls out. If the task maps to a surface the engine did not declare, we render the first surface it did declare rather than one it never claimed to support.

## Test Plan

- [x] Unit: `npm run test` — 116 files, 1276 tests pass. `resolve-capabilities.test.ts` covers the fallback matrix (undeclared / null / empty capabilities / another capability declared), explicit disable, empty mode list, task-matches-declaration, and both disagreement cases.
- [x] `npm run typecheck` clean; `yarn dep-check` and `yarn knip` clean.
- [x] `npm run lint:ci`: 3 errors / 50 warnings — **identical to the counts on a clean tree**, verified by stashing. No new lint issues introduced.
- [ ] Manual: **not done.** Wants a running console with an engine declaring `playground.enabled: false` to confirm the tab disappears, and an undeclared engine to confirm it does not. Needs neutree#544 deployed first.
- [ ] E2E: not affected — no existing spec asserts on the Playground tab.

## Risk & Rollback

Contained to one tab on one page. Rollback is reverting the commit.

The risk worth naming is the fallback: if `resolvePlayground` were wrong about the undeclared case, every existing endpoint would lose its Playground with no error anywhere — a silent regression. That path is the most heavily covered part of the test file for exactly this reason.

Secondary: the page hides the tab while the engine query is still in flight — `engineVersion` is `undefined` then, which resolves to *enabled*, so the tab stays visible during loading and does not flicker.
