### PR TITLE
fix(roles): model:push auto-selects and locks model:read (NEU-674)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -157,9 +157,9 @@
   "src/domains/role-assignment/types.ts": "ef54639c9b39af1db44d8956f4fc1759",
   "src/domains/role-assignment/components/UserCell.tsx": "9e9d51d5c0092c6a09c3d5bc41f18ac0",
   "src/domains/role/types.ts": "f1deba5219d3585096cac00c81e20051",
-  "src/domains/role/hooks/use-permission-dependencies.ts": "a0ce8deadf5afb2c083b70ab50cf6f2c",
-  "src/domains/role/components/PermissionsTree.tsx": "4b0fdb1357674f14988b7b23f80e4185",
-  "src/domains/role/components/PermissionsTreeField.tsx": "9771eb340eef413aafd9e1d56ca81da8",
+  "src/domains/role/hooks/use-permission-dependencies.ts": "febea7795d55ad4d539fe58665eedd24",
+  "src/domains/role/components/PermissionsTree.tsx": "10389743bd5a6c0269d6a5199fd88715",
+  "src/domains/role/components/PermissionsTreeField.tsx": "36e4bfeaa54682f3cf53812813843e2a",
   "src/domains/model-registry/types.ts": "c66adc9129353fb8c1478f1f71c37dd0",
   "src/domains/model-registry/components/ModelRegistryStatus.tsx": "74e59bea4562ddc782a0043ec1865be8",
   "src/domains/model-registry/components/ModelRegistryType.tsx": "7fc4fbd98b503e3a5cfc795cbe847193",
@@ -372,5 +372,6 @@
   "src/domains/model-registry/lib/capabilities.ts": "b544757b2e8cddba755eca02c8ab5cde",
   "src/domains/model-registry/lib/model-card.ts": "6614d0a004271fa9e0524e8d0e656e97",
   "src/foundation/lib/api/model-registries.ts": "63aabfb75c7df819933df76333e6f67b",
-  "src/foundation/lib/model-registry-visibility.ts": "24550d054dd3e6365f09c526b829302a"
+  "src/foundation/lib/model-registry-visibility.ts": "24550d054dd3e6365f09c526b829302a",
+  "src/domains/role/lib/format-permission.ts": "9f2b7f7a698e51dc6ba8188a808db44b"
 }

--- a/src/domains/role/components/PermissionsTree.tsx
+++ b/src/domains/role/components/PermissionsTree.tsx
@@ -20,6 +20,7 @@ import type React from "react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
+import { formatPermission } from "@/domains/role/lib/format-permission";
 import type { Role } from "@/domains/role/types";
 import { getResourcePlural } from "@/foundation/lib/plural";
 
@@ -160,10 +161,7 @@ const ActionNode = ({
 
   const actionIcon = actionIcons[action] || <Eye className="h-4 w-4" />;
 
-  const plural = getResourcePlural(resource);
-  const fullPermission = ["system"].includes(resource)
-    ? t(`permissions.${resource}_${action}`)
-    : `${t(`${plural}.title`)}:${t(`permissions.${action}`)}`;
+  const fullPermission = formatPermission(t, `${resource}:${action}`);
 
   return (
     <div className="flex items-center p-2 rounded bg-card border border-border text-card-foreground">

--- a/src/domains/role/components/PermissionsTreeField.test.tsx
+++ b/src/domains/role/components/PermissionsTreeField.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { useState } from "react";
+import { StrictMode, useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import PermissionsTreeField from "./PermissionsTreeField";
@@ -12,11 +12,23 @@ vi.mock("react-i18next", () => ({
 }));
 
 /** Mirrors how the role form drives the field: value comes back as state. */
-const ControlledField = ({ initialValue }: { initialValue: string[] }) => {
+const ControlledField = ({
+  initialValue,
+  onChange,
+}: {
+  initialValue: string[];
+  onChange?: (value: string[]) => void;
+}) => {
   const [value, setValue] = useState(initialValue);
   return (
     <TooltipProvider>
-      <PermissionsTreeField value={value} onChange={setValue} />
+      <PermissionsTreeField
+        value={value}
+        onChange={(next) => {
+          onChange?.(next);
+          setValue(next);
+        }}
+      />
       <div data-testid="value">{[...value].sort().join(",")}</div>
     </TooltipProvider>
   );
@@ -45,5 +57,28 @@ describe("PermissionsTreeField", () => {
       "model:push,model:read,model_registry:read",
     );
     expect(screen.queryByTestId("permission-backfill-notice")).toBeNull();
+  });
+
+  it("backfills idempotently under StrictMode double-invoked effects", () => {
+    const onChange = vi.fn();
+    render(
+      <StrictMode>
+        <ControlledField initialValue={["model:push"]} onChange={onChange} />
+      </StrictMode>,
+    );
+
+    // A repeated effect run closes over the same value, so it can only produce
+    // the same set again — and once value settles the effect stops firing.
+    for (const [next] of onChange.mock.calls) {
+      expect([...next].sort()).toEqual([
+        "model:push",
+        "model:read",
+        "model_registry:read",
+      ]);
+    }
+    expect(onChange.mock.calls.length).toBeLessThanOrEqual(2);
+    expect(screen.getByTestId("value").textContent).toBe(
+      "model:push,model:read,model_registry:read",
+    );
   });
 });

--- a/src/domains/role/components/PermissionsTreeField.test.tsx
+++ b/src/domains/role/components/PermissionsTreeField.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import PermissionsTreeField from "./PermissionsTreeField";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) =>
+      options?.actions ? `${key}:${options.actions}` : key,
+  }),
+}));
+
+/** Mirrors how the role form drives the field: value comes back as state. */
+const ControlledField = ({ initialValue }: { initialValue: string[] }) => {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <TooltipProvider>
+      <PermissionsTreeField value={value} onChange={setValue} />
+      <div data-testid="value">{[...value].sort().join(",")}</div>
+    </TooltipProvider>
+  );
+};
+
+describe("PermissionsTreeField", () => {
+  it("NEU-674: backfills missing dependencies of a push-only role and reports them", () => {
+    render(<ControlledField initialValue={["model:push"]} />);
+
+    expect(screen.getByTestId("value").textContent).toBe(
+      "model:push,model:read,model_registry:read",
+    );
+    expect(
+      screen.getByTestId("permission-backfill-notice").textContent,
+    ).toContain("models.title:permissions.read");
+  });
+
+  it("leaves a complete permission set untouched and shows no notice", () => {
+    render(
+      <ControlledField
+        initialValue={["model:push", "model:read", "model_registry:read"]}
+      />,
+    );
+
+    expect(screen.getByTestId("value").textContent).toBe(
+      "model:push,model:read,model_registry:read",
+    );
+    expect(screen.queryByTestId("permission-backfill-notice")).toBeNull();
+  });
+});

--- a/src/domains/role/components/PermissionsTreeField.tsx
+++ b/src/domains/role/components/PermissionsTreeField.tsx
@@ -25,8 +25,9 @@ import {
   Upload,
   Users,
 } from "lucide-react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import {
   Tooltip,
@@ -34,6 +35,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { usePermissionDependencies } from "@/domains/role/hooks/use-permission-dependencies";
+import { formatPermission } from "@/domains/role/lib/format-permission";
 import { getResourcePlural } from "@/foundation/lib/plural";
 import { cn } from "@/foundation/lib/utils";
 
@@ -75,9 +77,11 @@ const PermissionsTreeField = React.forwardRef<
   HTMLDivElement,
   PermissionsTreeFieldProps
 >(({ value = [], onChange, disabled = false, className }, ref) => {
+  const { t } = useTranslation();
   const {
     permissionTree,
     sortedResources,
+    missingDependencies,
     togglePermission,
     toggleAllResourcePermissions,
     getActionDependents,
@@ -86,8 +90,33 @@ const PermissionsTreeField = React.forwardRef<
     onChange,
   });
 
+  // A role saved before a dependency rule existed (e.g. a push-only role from
+  // before NEU-674) loads with unmet dependencies — backfill them and tell the
+  // user what was added, so saving cannot produce an invalid combination.
+  const [backfilled, setBackfilled] = useState<string[]>([]);
+  useEffect(() => {
+    if (disabled || !onChange || missingDependencies.length === 0) return;
+    setBackfilled(missingDependencies);
+    onChange([...value, ...missingDependencies]);
+  }, [disabled, onChange, value, missingDependencies]);
+
   return (
     <div className={cn("w-full max-w-3xl mx-auto", className)} ref={ref}>
+      {backfilled.length > 0 && (
+        <Alert
+          variant="info"
+          className="mb-2"
+          data-testid="permission-backfill-notice"
+        >
+          <AlertDescription>
+            {t("permissions.dependenciesAdded", {
+              actions: backfilled
+                .map((permission) => formatPermission(t, permission))
+                .join(", "),
+            })}
+          </AlertDescription>
+        </Alert>
+      )}
       <div className="space-y-2">
         {sortedResources.map((resource) => (
           <ResourceNode
@@ -230,10 +259,7 @@ const ActionNode = ({
 
   const actionIcon = actionIcons[action] || <Eye className="h-4 w-4" />;
 
-  const plural = getResourcePlural(resource);
-  const fullPermission = ["system"].includes(resource)
-    ? t(`permissions.${resource}_${action}`)
-    : `${t(`${plural}.title`)}:${t(`permissions.${action}`)}`;
+  const fullPermission = formatPermission(t, `${resource}:${action}`);
 
   const locked = dependents.length > 0;
   const isDisabled = disabled || (locked && isSelected);
@@ -271,11 +297,7 @@ const ActionNode = ({
         >
           {t("permissions.requiredBy", {
             actions: dependents
-              .map((perm) => {
-                const [res, act] = perm.split(":");
-                const p = getResourcePlural(res);
-                return `${t(`${p}.title`)}:${t(`permissions.${act}`)}`;
-              })
+              .map((perm) => formatPermission(t, perm))
               .join(", "),
           })}
         </TooltipContent>

--- a/src/domains/role/hooks/use-permission-dependencies.test.ts
+++ b/src/domains/role/hooks/use-permission-dependencies.test.ts
@@ -634,7 +634,7 @@ describe("usePermissionDependencies", () => {
       expect(called).not.toContain("model:read");
     });
 
-    it("NEU-396: model:push should not auto-select model:read", () => {
+    it("NEU-674: model:push should auto-select model:read and model_registry:read", () => {
       const onChange = vi.fn();
       const { result } = renderHook(() =>
         usePermissionDependencies({
@@ -650,8 +650,73 @@ describe("usePermissionDependencies", () => {
 
       const called = onChange.mock.calls[0][0] as string[];
       expect(called).toContain("model:push");
+      expect(called).toContain("model:read");
       expect(called).toContain("model_registry:read");
-      expect(called).not.toContain("model:read");
+    });
+
+    it("NEU-674: model:read should be locked while model:push is selected", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        usePermissionDependencies({
+          value: ["model:push", "model:read", "model_registry:read"],
+          allPermissions: TEST_PERMISSIONS,
+          onChange,
+        }),
+      );
+
+      expect(result.current.getActionDependents("model", "read")).toEqual([
+        "model:push",
+      ]);
+
+      act(() => {
+        result.current.togglePermission("model", "read");
+      });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("NEU-674: unselecting model:push releases model:read", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        usePermissionDependencies({
+          value: ["model:push", "model:read", "model_registry:read"],
+          allPermissions: TEST_PERMISSIONS,
+          onChange,
+        }),
+      );
+
+      act(() => {
+        result.current.togglePermission("model", "push");
+      });
+
+      const called = onChange.mock.calls[0][0] as string[];
+      expect(called).not.toContain("model:push");
+      expect(called).toContain("model:read");
+    });
+
+    it("NEU-674: reports model:read as missing for a push-only role", () => {
+      const { result } = renderHook(() =>
+        usePermissionDependencies({
+          value: ["model:push"],
+          allPermissions: TEST_PERMISSIONS,
+        }),
+      );
+
+      expect(result.current.missingDependencies).toContain("model:read");
+      expect(result.current.missingDependencies).toContain(
+        "model_registry:read",
+      );
+    });
+
+    it("NEU-674: reports no missing dependencies for a complete permission set", () => {
+      const { result } = renderHook(() =>
+        usePermissionDependencies({
+          value: ["model:push", "model:read", "model_registry:read"],
+          allPermissions: TEST_PERMISSIONS,
+        }),
+      );
+
+      expect(result.current.missingDependencies).toEqual([]);
     });
 
     it("NEU-396: model:pull should not auto-select model:read", () => {

--- a/src/domains/role/hooks/use-permission-dependencies.ts
+++ b/src/domains/role/hooks/use-permission-dependencies.ts
@@ -24,9 +24,13 @@ const ALL_RULES: PermissionDependencyRule[] = [
   { action: "create", deps: ["read"] },
   { action: "update", deps: ["read"] },
   { action: "delete", deps: ["read"] },
-  // model:delete/push/pull depend on model_registry:read, NOT model:read
+  // model:delete/pull depend on model_registry:read, NOT model:read
   { action: "model:delete", deps: ["model_registry:read"] },
-  { action: "model:push", deps: ["model_registry:read"] },
+  // NEU-674: pushing a model updates its alias, which is only visible under
+  // model_aliases RLS when the identity can also read models. Without
+  // model:read the UPDATE silently affects 0 rows, so model:push must
+  // auto-select and lock model:read.
+  { action: "model:push", deps: ["model_registry:read", "model:read"] },
   { action: "model:pull", deps: ["model_registry:read"] },
   // model:read depends on model_registry:read
   { action: "model:read", deps: ["model_registry:read"] },
@@ -141,6 +145,39 @@ function getDepsForAction(
 }
 
 /**
+ * Collect every dependency (transitively) required by `selectedPermissions`
+ * but not present in it. Only permissions that actually exist are returned.
+ */
+function findMissingDeps(
+  selectedPermissions: string[],
+  rules: PermissionDependencyRule[],
+  allPermissionsSet: Set<string>,
+  workspacedResources: Set<string> = WORKSPACED_RESOURCES,
+): string[] {
+  const known = new Set(selectedPermissions);
+  const missing: string[] = [];
+  // The queue only grows, so an index cursor also visits deps appended below.
+  const queue = [...selectedPermissions];
+
+  for (let i = 0; i < queue.length; i++) {
+    const [resource, action] = queue[i].split(":");
+    for (const dep of getDepsForAction(
+      resource,
+      action,
+      rules,
+      workspacedResources,
+    )) {
+      if (known.has(dep) || !allPermissionsSet.has(dep)) continue;
+      known.add(dep);
+      missing.push(dep);
+      queue.push(dep);
+    }
+  }
+
+  return missing;
+}
+
+/**
  * Find all selected permissions that depend on resource:action.
  * Returns full permission strings, e.g. ["endpoint:create"].
  */
@@ -212,6 +249,17 @@ export function usePermissionDependencies(options: {
     [permissionTree],
   );
 
+  /** Commit a selection together with everything it transitively requires. */
+  const commitWithDeps = useCallback(
+    (permissions: string[]) => {
+      onChange?.([
+        ...permissions,
+        ...findMissingDeps(permissions, rules, allPermissionsSet),
+      ]);
+    },
+    [allPermissionsSet, rules, onChange],
+  );
+
   const togglePermission = useCallback(
     (resource: string, action: string) => {
       const perm = `${resource}:${action}`;
@@ -223,18 +271,10 @@ export function usePermissionDependencies(options: {
         }
         onChange?.(value.filter((p) => p !== perm));
       } else {
-        const deps = getDepsForAction(resource, action, rules);
-        const newPerms = new Set(value);
-        for (const dep of deps) {
-          if (allPermissionsSet.has(dep)) {
-            newPerms.add(dep);
-          }
-        }
-        newPerms.add(perm);
-        onChange?.([...newPerms]);
+        commitWithDeps([...value, perm]);
       }
     },
-    [value, allPermissionsSet, rules, onChange],
+    [value, rules, onChange, commitWithDeps],
   );
 
   const toggleAllResourcePermissions = useCallback(
@@ -243,17 +283,12 @@ export function usePermissionDependencies(options: {
       if (!resourceData) return;
 
       if (selectAll) {
-        const newPerms = new Set(value);
-        for (const action of resourceData.actions) {
-          newPerms.add(`${resource}:${action}`);
-          // Also add cross-resource deps for each action
-          for (const dep of getDepsForAction(resource, action, rules)) {
-            if (allPermissionsSet.has(dep)) {
-              newPerms.add(dep);
-            }
-          }
-        }
-        onChange?.([...newPerms]);
+        commitWithDeps([
+          ...new Set([
+            ...value,
+            ...resourceData.actions.map((a) => `${resource}:${a}`),
+          ]),
+        ]);
       } else {
         // Remove all this resource's permissions first, then check which
         // are still needed by OTHER resources' selected permissions.
@@ -276,7 +311,7 @@ export function usePermissionDependencies(options: {
         onChange?.([...valueWithoutResource, ...lockedPerms]);
       }
     },
-    [permissionTree, value, allPermissionsSet, rules, onChange],
+    [permissionTree, value, rules, onChange, commitWithDeps],
   );
 
   const getActionDependents = useCallback(
@@ -286,9 +321,18 @@ export function usePermissionDependencies(options: {
     [value, rules],
   );
 
+  /** Dependencies required by `value` but missing from it — non-empty only for
+   *  permission sets built outside this hook, e.g. an existing role loaded into
+   *  the edit form before a new dependency rule was introduced (NEU-674). */
+  const missingDependencies = useMemo(
+    () => findMissingDeps(value, rules, allPermissionsSet),
+    [value, rules, allPermissionsSet],
+  );
+
   return {
     permissionTree,
     sortedResources,
+    missingDependencies,
     togglePermission,
     toggleAllResourcePermissions,
     getActionDependents,

--- a/src/domains/role/lib/format-permission.ts
+++ b/src/domains/role/lib/format-permission.ts
@@ -1,0 +1,13 @@
+import type { useTranslation } from "react-i18next";
+import { getResourcePlural } from "@/foundation/lib/plural";
+
+type Translate = ReturnType<typeof useTranslation>["t"];
+
+/** "model:push" → "Models:Push" (system permissions have their own labels) */
+export const formatPermission = (t: Translate, permission: string) => {
+  const [resource, action] = permission.split(":");
+  if (resource === "system") {
+    return t(`permissions.${resource}_${action}`);
+  }
+  return `${t(`${getResourcePlural(resource)}.title`)}:${t(`permissions.${action}`)}`;
+};

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1732,7 +1732,8 @@
 		"read-credentials": "Read Credentials",
 		"trace-read": "Access Log Read",
 		"usage-read": "Usage Read",
-		"requiredBy": "Required by: {{actions}}"
+		"requiredBy": "Required by: {{actions}}",
+		"dependenciesAdded": "Added required permissions: {{actions}}"
 	},
 	"systems": {
 		"title": "Systems"


### PR DESCRIPTION
## Problem

The role editor allowed a custom role with `model:push` but without `model:read`. Under `model_aliases` RLS that identity's alias UPDATE matches no rows, so pushing a model silently no-ops — no write error, zero rows changed.

## Changes

- `model:push` now depends on `model:read` in addition to `model_registry:read`: checking Push auto-selects Read and locks it (existing lock/tooltip mechanism) until Push is unchecked. Unchecking Push leaves Read selected, and Read stays locked while any other permission still requires it.
- Dependency resolution walks the transitive closure instead of one level, replacing the duplicated dep-adding loops in `togglePermission` and `toggleAllResourcePermissions`.
- Roles saved before this rule (e.g. push-only) are backfilled when loaded into the form: the missing dependencies are selected and an info alert lists what was added, so the form cannot be saved with an invalid combination.
- Permission label formatting moved to `src/domains/role/lib/format-permission.ts` and shared by the editable and read-only permission trees.

Scope note: this is the UI checkbox linkage only. Constructing a push-only role directly through the Role API / PostgREST remains outside this change.

## Tests

`use-permission-dependencies.test.ts` covers the new rule, the lock, and the missing-dependency report; new `PermissionsTreeField.test.tsx` covers the backfill of a push-only role and the no-op case.