### PR TITLE
feat(ui): add API key project workflows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -442,7 +442,6 @@ const resources: ResourceProps[] = [
     meta: {
       icon: <Key />,
       workspaced: true,
-      idColumnName: "metadata->name",
       parent: "access_control",
     },
   },

--- a/src/domains/api-key/components/ApiKeyLimitsCard.tsx
+++ b/src/domains/api-key/components/ApiKeyLimitsCard.tsx
@@ -1,5 +1,6 @@
+import { useCustomMutation, useInvalidate } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
-import { MoreHorizontal } from "lucide-react";
+import { MoreHorizontal, Power, PowerOff } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import type { FieldValues } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -14,9 +15,11 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Form } from "@/components/ui/form";
 import { ApiKeyPolicyFields } from "@/domains/api-key/components/ApiKeyPolicyFields";
+import { ProjectPicker } from "@/domains/api-key/components/ProjectPicker";
 import {
   type ApiKeyPolicyFormValues,
   apiKeyPolicyDefaults,
+  buildApiKeyLimits,
   limitsToForm,
   QUOTA_PERIODS,
   type QuotaPeriod,
@@ -24,6 +27,7 @@ import {
   useApiKeyLimits,
 } from "@/domains/api-key/hooks/use-api-key-policy";
 import type { ApiKeyLimits } from "@/domains/api-key/types";
+import { FormFieldGroup } from "@/foundation/components/FormFieldGroup";
 import { formatTokenQuota } from "@/foundation/lib/token-quota";
 import { cn } from "@/foundation/lib/utils";
 
@@ -34,17 +38,21 @@ import { cn } from "@/foundation/lib/utils";
 export const ApiKeyLimitsCard = ({
   apiKeyId,
   workspace,
+  projectId,
 }: {
   apiKeyId: string;
   workspace: string;
+  projectId: string;
 }) => {
   const { t } = useTranslation();
-  const { load, save } = useApiKeyLimits();
+  const { load } = useApiKeyLimits();
   const { disable, enable } = useApiKeyDisable();
+  const { mutateAsync } = useCustomMutation();
+  const invalidate = useInvalidate();
   const [limits, setLimits] = useState<ApiKeyLimits>({});
-  const form = useForm<ApiKeyPolicyFormValues>({
+  const form = useForm<ApiKeyPolicyFormValues & { project_id: string }>({
     mode: "all",
-    defaultValues: apiKeyPolicyDefaults(),
+    defaultValues: { ...apiKeyPolicyDefaults(), project_id: projectId },
   });
 
   // Load (and re-load after save) the key's current limits. Keyed only on
@@ -55,8 +63,8 @@ export const ApiKeyLimitsCard = ({
   const refresh = useCallback(async () => {
     const next = await load(apiKeyId);
     setLimits(next);
-    form.reset(limitsToForm(next));
-  }, [apiKeyId]);
+    form.reset({ ...limitsToForm(next), project_id: projectId });
+  }, [apiKeyId, projectId]);
 
   useEffect(() => {
     // Load failures (network/auth) just leave the default empty state; swallow
@@ -68,7 +76,21 @@ export const ApiKeyLimitsCard = ({
   const [toggling, setToggling] = useState(false);
 
   const onSave = async (values: FieldValues) => {
-    await save(apiKeyId, values as ApiKeyPolicyFormValues, { disabled });
+    await mutateAsync({
+      url: "/rpc/update_api_key_configuration",
+      method: "post",
+      values: {
+        p_api_key_id: apiKeyId,
+        p_project_id: values.project_id,
+        p_limits: buildApiKeyLimits(values as ApiKeyPolicyFormValues, {
+          disabled,
+        }),
+      },
+    });
+    await invalidate({
+      resource: "api_keys",
+      invalidates: ["list", "detail"],
+    });
     await refresh();
   };
 
@@ -105,91 +127,117 @@ export const ApiKeyLimitsCard = ({
   const warn = !over && ratio >= 0.8;
 
   return (
-    <Card className="mt-4">
-      <CardHeader className="pb-2">
-        <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-xl font-semibold">
-            {t("api_keys.limits.sectionTitle")}
-          </CardTitle>
-          <div className="flex items-center gap-2">
-            {disabled ? (
-              <Badge variant="destructive">
-                {t("api_keys.limits.statusDisabled")}
-              </Badge>
-            ) : (
-              <Badge variant="outline">
-                {t("api_keys.limits.statusActive")}
-              </Badge>
-            )}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  aria-label={t("api_keys.limits.actions")}
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem
-                  disabled={toggling}
-                  onSelect={(e) => {
-                    e.preventDefault();
-                    void toggleDisabled().catch(() => {});
-                  }}
-                >
-                  {disabled
-                    ? t("api_keys.limits.enable")
-                    : t("api_keys.limits.disable")}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Token-quota consumption */}
-        {hasQuota && (
-          <div className="space-y-1">
-            <div className="text-sm font-medium">
-              {t("api_keys.limits.consumptionTitle")}
-            </div>
-            <div className="h-2 w-full overflow-hidden rounded-full bg-primary/20">
-              <div
-                className={cn(
-                  "h-full transition-all",
-                  over
-                    ? "bg-destructive"
-                    : warn
-                      ? "bg-amber-500"
-                      : "bg-primary",
-                )}
-                style={{ width: `${pct}%` }}
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSave)} className="mt-4 space-y-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-xl font-semibold">Project</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <FormFieldGroup
+              {...form}
+              name="project_id"
+              label="API key Project"
+              rules={{ required: "Project is required" }}
+            >
+              <ProjectPicker
+                workspace={workspace}
+                value={form.watch("project_id")}
+                onChange={(id) =>
+                  form.setValue("project_id", id, { shouldValidate: true })
+                }
               />
+            </FormFieldGroup>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between gap-2">
+              <CardTitle className="text-xl font-semibold">
+                {t("api_keys.limits.sectionTitle")}
+              </CardTitle>
+              <div className="flex items-center gap-2">
+                {disabled ? (
+                  <Badge variant="destructive">
+                    {t("api_keys.limits.statusDisabled")}
+                  </Badge>
+                ) : (
+                  <Badge variant="outline">
+                    {t("api_keys.limits.statusActive")}
+                  </Badge>
+                )}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={t("api_keys.limits.actions")}
+                    >
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      disabled={toggling}
+                      onSelect={(e) => {
+                        e.preventDefault();
+                        void toggleDisabled().catch(() => {});
+                      }}
+                    >
+                      {disabled ? (
+                        <Power className="mr-2 h-4 w-4" />
+                      ) : (
+                        <PowerOff className="mr-2 h-4 w-4" />
+                      )}
+                      {disabled
+                        ? t("api_keys.limits.enable")
+                        : t("api_keys.limits.disable")}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             </div>
-            <div className="text-xs text-muted-foreground">
-              {formatTokenQuota(used)} / {formatTokenQuota(limit)}{" "}
-              {t("api_keys.limits.tokensUnit")} ·{" "}
-              {t("api_keys.limits.remainingLabel")}:{" "}
-              {formatTokenQuota(remaining)} ·{" "}
-              {t(`api_keys.limits.periods.${period}`)}
-            </div>
-          </div>
-        )}
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {/* Token-quota consumption */}
+            {hasQuota && (
+              <div className="space-y-1">
+                <div className="text-sm font-medium">
+                  {t("api_keys.limits.consumptionTitle")}
+                </div>
+                <div className="h-2 w-full overflow-hidden rounded-full bg-primary/20">
+                  <div
+                    className={cn(
+                      "h-full transition-all",
+                      over
+                        ? "bg-destructive"
+                        : warn
+                          ? "bg-amber-500"
+                          : "bg-primary",
+                    )}
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {formatTokenQuota(used)} / {formatTokenQuota(limit)}{" "}
+                  {t("api_keys.limits.tokensUnit")} ·{" "}
+                  {t("api_keys.limits.remainingLabel")}:{" "}
+                  {formatTokenQuota(remaining)} ·{" "}
+                  {t(`api_keys.limits.periods.${period}`)}
+                </div>
+              </div>
+            )}
 
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSave)} className="space-y-3">
             <ApiKeyPolicyFields form={form} workspace={workspace} />
             <div className="flex justify-end">
               <Button type="submit" disabled={form.formState.isSubmitting}>
                 {t("buttons.save")}
               </Button>
             </div>
-          </form>
-        </Form>
-      </CardContent>
-    </Card>
+          </CardContent>
+        </Card>
+      </form>
+    </Form>
   );
 };

--- a/src/domains/api-key/components/CreateApiKeyForm.tsx
+++ b/src/domains/api-key/components/CreateApiKeyForm.tsx
@@ -1,7 +1,7 @@
 import { useCustomMutation, useInvalidate } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
 import { Check, Copy } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { FieldValues } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -9,36 +9,68 @@ import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Form } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { ApiKeyPolicyFields } from "@/domains/api-key/components/ApiKeyPolicyFields";
+import { ProjectPicker } from "@/domains/api-key/components/ProjectPicker";
 import {
   type ApiKeyPolicyFormValues,
   apiKeyPolicyDefaults,
   buildApiKeyLimits,
 } from "@/domains/api-key/hooks/use-api-key-policy";
+import { createApiKeyErrorMessage } from "@/domains/api-key/lib/create-api-key-error";
 import type { ApiKey } from "@/domains/api-key/types";
 import { FormCombobox } from "@/foundation/components/FormCombobox";
 import { FormFieldGroup } from "@/foundation/components/FormFieldGroup";
 import { useCopyToClipboard } from "@/foundation/hooks/use-copy-to-clipboard";
 import { useWorkspaceOptions } from "@/foundation/hooks/use-workspace";
 
-type FormValues = { name: string; workspace: string } & ApiKeyPolicyFormValues;
+type FormValues = {
+  name: string;
+  workspace: string;
+  project_id: string;
+  description: string;
+} & ApiKeyPolicyFormValues;
 
-export const CreateApiKeyForm = ({ onClose }: { onClose?: () => void }) => {
+export const CreateApiKeyForm = ({
+  onClose,
+  initialWorkspace = "",
+  initialProjectId = "",
+  onCreated,
+}: {
+  onClose?: () => void;
+  initialWorkspace?: string;
+  initialProjectId?: string;
+  onCreated?: () => void | Promise<void>;
+}) => {
   const { t } = useTranslation();
   const form = useForm<FormValues>({
     mode: "all",
     defaultValues: {
       name: "",
-      workspace: "",
+      workspace: initialWorkspace,
+      project_id: initialProjectId,
+      description: "",
       ...apiKeyPolicyDefaults(),
     },
   });
   const selectedWorkspace = form.watch("workspace");
+  const previousWorkspace = useRef("");
+
+  useEffect(() => {
+    if (
+      previousWorkspace.current &&
+      previousWorkspace.current !== selectedWorkspace
+    ) {
+      form.setValue("project_id", "", { shouldValidate: true });
+    }
+    previousWorkspace.current = selectedWorkspace;
+  }, [form, selectedWorkspace]);
   // Shares the pickers' query so this form isn't stuck on refine's default
   // first page of 10 workspaces either (NEU-505). FormCombobox filters what it
   // is given locally, so the page size is the reach here.
   const { workspaces, isLoading: isLoadingWorkspaces } = useWorkspaceOptions();
   const [apiKey, setApiKey] = useState<ApiKey | null>(null);
+  const [submitError, setSubmitError] = useState("");
   const { copy, copied } = useCopyToClipboard();
 
   const { mutateAsync } = useCustomMutation();
@@ -54,21 +86,31 @@ export const CreateApiKeyForm = ({ onClose }: { onClose?: () => void }) => {
   const onSubmit = async (formValue: FieldValues) => {
     // Create with limits in one atomic call — quota + access live on the key's
     // spec.limits, so create_api_key takes the whole limits object.
-    const { data } = await mutateAsync({
-      url: "/rpc/create_api_key",
-      method: "post",
-      values: {
-        p_workspace: formValue.workspace,
-        p_name: formValue.name,
-        p_quota: 0,
-        p_limits: buildApiKeyLimits(formValue as ApiKeyPolicyFormValues),
-      },
-    });
-    invalidate({
-      resource: "api_keys",
-      invalidates: ["list"],
-    });
-    setApiKey(data as ApiKey);
+    setSubmitError("");
+    try {
+      const { data } = await mutateAsync({
+        url: "/rpc/create_api_key",
+        method: "post",
+        values: {
+          p_workspace: formValue.workspace,
+          p_name: formValue.name,
+          p_project_id: formValue.project_id,
+          p_description: formValue.description,
+          p_quota: 0,
+          p_limits: buildApiKeyLimits(formValue as ApiKeyPolicyFormValues),
+        },
+        successNotification: false,
+        errorNotification: false,
+      });
+      await invalidate({
+        resource: "api_keys",
+        invalidates: ["list"],
+      });
+      await onCreated?.();
+      setApiKey(data as ApiKey);
+    } catch (cause) {
+      setSubmitError(createApiKeyErrorMessage(cause));
+    }
   };
 
   if (apiKey) {
@@ -81,9 +123,6 @@ export const CreateApiKeyForm = ({ onClose }: { onClose?: () => void }) => {
         </Alert>
 
         <div className="space-y-2">
-          <div className="text-sm font-medium">
-            {t("api_keys.fields.secretKey")}:
-          </div>
           <div className="relative">
             <div className="p-3 bg-muted rounded-md border min-h-[60px] flex items-center">
               <code className="text-sm break-all font-mono leading-relaxed">
@@ -135,21 +174,55 @@ export const CreateApiKeyForm = ({ onClose }: { onClose?: () => void }) => {
         >
           <FormCombobox
             placeholder={t("api_keys.placeholders.selectWorkspace")}
-            disabled={isLoadingWorkspaces}
+            disabled={Boolean(initialWorkspace) || isLoadingWorkspaces}
             options={workspaces.map((workspace) => ({
               label: workspace.metadata.name,
               value: workspace.metadata.name,
             }))}
           />
         </FormFieldGroup>
-        <FormFieldGroup {...form} name="name" label={t("common.fields.name")}>
+        <FormFieldGroup
+          {...form}
+          name="project_id"
+          label="Project"
+          rules={{ required: "Project is required" }}
+        >
+          <ProjectPicker
+            workspace={selectedWorkspace}
+            value={form.watch("project_id")}
+            onChange={(id) => {
+              form.setValue("project_id", id, { shouldValidate: true });
+            }}
+            selectDefaultWhenEmpty
+          />
+        </FormFieldGroup>
+        <FormFieldGroup
+          {...form}
+          name="name"
+          label={t("common.fields.name")}
+          rules={{
+            required: "Name is required",
+            maxLength: {
+              value: 63,
+              message: "Name cannot exceed 63 characters",
+            },
+            validate: (value) => value.trim().length > 0 || "Name is required",
+          }}
+        >
           <Input />
+        </FormFieldGroup>
+        <FormFieldGroup {...form} name="description" label="Description">
+          <Textarea />
         </FormFieldGroup>
 
         <div className="pt-1 text-sm font-medium">
           {t("api_keys.limits.sectionTitle")}
         </div>
         <ApiKeyPolicyFields form={form} workspace={selectedWorkspace} />
+
+        {submitError && (
+          <p className="text-sm text-destructive">{submitError}</p>
+        )}
 
         <DialogFooter>
           <Button type="button" variant="secondary" onClick={onClose}>

--- a/src/domains/api-key/components/ProjectPicker.test.tsx
+++ b/src/domains/api-key/components/ProjectPicker.test.tsx
@@ -1,0 +1,119 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mutateAsync = vi.fn();
+const refetch = vi.fn();
+
+vi.mock("@refinedev/core", () => ({
+  useCustomMutation: () => ({ mutateAsync }),
+}));
+
+vi.mock("@/domains/api-key/hooks/use-api-key-projects", () => ({
+  useApiKeyProjects: () => ({
+    data: [
+      {
+        id: "default",
+        name: "Default",
+        description: "",
+        enabled: true,
+        is_default: true,
+      },
+      {
+        id: "active",
+        name: "Active",
+        description: "Ready",
+        enabled: true,
+        is_default: false,
+      },
+      {
+        id: "disabled",
+        name: "Disabled",
+        description: "History",
+        enabled: false,
+        is_default: false,
+      },
+    ],
+    isLoading: false,
+    error: "",
+    refetch,
+  }),
+}));
+
+import { ProjectPicker } from "./ProjectPicker";
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("ProjectPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows disabled projects but prevents selecting them", () => {
+    render(<ProjectPicker workspace="default" value="" onChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole("combobox"));
+    const option = screen.getByRole("option", { name: /Disabled.*History/ });
+    expect(option.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("selects the Default project for create forms", async () => {
+    const onChange = vi.fn();
+    render(
+      <ProjectPicker
+        workspace="default"
+        value=""
+        onChange={onChange}
+        selectDefaultWhenEmpty
+      />,
+    );
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(
+        "default",
+        expect.objectContaining({ id: "default", name: "Default" }),
+      ),
+    );
+  });
+
+  it("creates a project inline, refreshes, and selects it", async () => {
+    const onChange = vi.fn();
+    mutateAsync.mockResolvedValue({ data: { id: "new", name: "New" } });
+    render(<ProjectPicker workspace="default" value="" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: /Create Project/ }));
+    fireEvent.change(screen.getByPlaceholderText("Project name"), {
+      target: { value: "New" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("Description (optional)"), {
+      target: { value: "Calls" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create and select" }));
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(
+        "new",
+        expect.objectContaining({ id: "new", name: "New" }),
+      ),
+    );
+    expect(mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        values: {
+          p_workspace: "default",
+          p_name: "New",
+          p_description: "Calls",
+        },
+      }),
+    );
+    expect(refetch).toHaveBeenCalled();
+  });
+});

--- a/src/domains/api-key/components/ProjectPicker.tsx
+++ b/src/domains/api-key/components/ProjectPicker.tsx
@@ -1,0 +1,207 @@
+import { useCustomMutation } from "@refinedev/core";
+import { Check, ChevronsUpDown, Plus, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Textarea } from "@/components/ui/textarea";
+import { useApiKeyProjects } from "@/domains/api-key/hooks/use-api-key-projects";
+import type { ApiKeyProject } from "@/domains/api-key/types";
+
+export function ProjectPicker({
+  workspace,
+  value,
+  onChange,
+  selectDefaultWhenEmpty = false,
+}: {
+  workspace: string;
+  value: string;
+  onChange: (id: string, project?: ApiKeyProject) => void;
+  selectDefaultWhenEmpty?: boolean;
+}) {
+  const {
+    data: projects,
+    isLoading,
+    error: loadError,
+    refetch,
+  } = useApiKeyProjects(workspace);
+  const [creating, setCreating] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { mutateAsync } = useCustomMutation();
+  useEffect(() => {
+    if (creating) inputRef.current?.focus();
+  }, [creating]);
+  useEffect(() => {
+    if (!selectDefaultWhenEmpty || value || isLoading) return;
+    const defaultProject = projects.find(
+      (project) => project.is_default && project.enabled,
+    );
+    if (defaultProject) onChange(defaultProject.id, defaultProject);
+  }, [isLoading, onChange, projects, selectDefaultWhenEmpty, value]);
+
+  const create = async () => {
+    setError("");
+    setSaving(true);
+    try {
+      const { data: created } = await mutateAsync({
+        url: "/rpc/create_api_key_project",
+        method: "post",
+        values: {
+          p_workspace: workspace,
+          p_name: name,
+          p_description: description,
+        },
+      });
+      const project = created as ApiKeyProject;
+      await refetch();
+      onChange(project.id, project);
+      setCreating(false);
+      setName("");
+      setDescription("");
+    } catch (e) {
+      setError(
+        String((e as { message?: string }).message ?? e).includes(
+          "already exists",
+        )
+          ? "Project name already exists. Choose another name."
+          : String((e as { message?: string }).message ?? e),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Popover open={open} onOpenChange={setOpen} modal>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            disabled={!workspace || isLoading}
+            className="w-full justify-between font-normal"
+          >
+            <span className="truncate">
+              {projects.find((p) => p.id === value)?.name ?? "Select a Project"}
+            </span>
+            <ChevronsUpDown className="h-4 w-4 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
+          <Command>
+            <CommandInput placeholder="Search Projects" />
+            <CommandList>
+              <CommandEmpty>No Projects found.</CommandEmpty>
+              <CommandGroup>
+                {projects.map((p) => (
+                  <CommandItem
+                    key={p.id}
+                    value={`${p.name} ${p.description}`}
+                    disabled={!p.enabled}
+                    onSelect={() => {
+                      if (p.enabled) {
+                        onChange(p.id, p);
+                        setOpen(false);
+                      }
+                    }}
+                  >
+                    <Check
+                      className={`mr-2 h-4 w-4 ${value === p.id ? "opacity-100" : "opacity-0"}`}
+                    />
+                    <span className="min-w-0">
+                      <span className="block truncate">
+                        {p.name}
+                        {!p.enabled ? " (Disabled)" : ""}
+                      </span>
+                      {p.description && (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {p.description}
+                        </span>
+                      )}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+          <div className="border-t p-1">
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full justify-start"
+              onClick={() => {
+                setOpen(false);
+                setCreating(true);
+              }}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Create Project
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+      {loadError && <p className="text-sm text-destructive">{loadError}</p>}
+      {creating && (
+        <div className="space-y-2 border bg-muted/40 p-3">
+          <div className="flex items-center justify-between text-sm font-medium">
+            Create Project
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => setCreating(false)}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <Input
+            ref={inputRef}
+            placeholder="Project name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <Textarea
+            placeholder="Description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setCreating(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={!name.trim() || saving}
+              onClick={() => void create()}
+            >
+              {saving ? "Creating..." : "Create and select"}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/domains/api-key/hooks/use-api-key-project-groups.ts
+++ b/src/domains/api-key/hooks/use-api-key-project-groups.ts
@@ -1,0 +1,85 @@
+import { useCustomMutation } from "@refinedev/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ApiKey, ApiKeyProject } from "@/domains/api-key/types";
+
+type ApiKeyProjectGroup = {
+  project: ApiKeyProject;
+  api_keys: ApiKey[];
+  api_key_count: number;
+  current_usage: number;
+  total_projects: number;
+};
+
+export function useApiKeyProjectGroups(params: {
+  workspace?: string;
+  search: string;
+  projectEnabled: boolean | null;
+  apiKeyDisabled: boolean | null;
+  page: number;
+  pageSize: number;
+}) {
+  const { mutateAsync } = useCustomMutation();
+  const [data, setData] = useState<ApiKeyProjectGroup[]>([]);
+  const [totalApiKeys, setTotalApiKeys] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const request = useRef(0);
+
+  const fetchGroups = useCallback(async () => {
+    const current = ++request.current;
+    setIsLoading(true);
+    setError("");
+    try {
+      const [response, countResponse] = await Promise.all([
+        mutateAsync({
+          url: "/rpc/get_api_key_project_groups",
+          method: "post",
+          values: {
+            p_workspace: params.workspace ?? null,
+            p_search: params.search.trim() || null,
+            p_project_enabled: params.projectEnabled,
+            p_api_key_disabled: params.apiKeyDisabled,
+            p_page: params.page,
+            p_page_size: params.pageSize,
+          },
+        }),
+        mutateAsync({
+          url: "/rpc/count_api_key_project_group_api_keys",
+          method: "post",
+          values: {
+            p_workspace: params.workspace ?? null,
+            p_search: params.search.trim() || null,
+            p_project_enabled: params.projectEnabled,
+            p_api_key_disabled: params.apiKeyDisabled,
+          },
+        }),
+      ]);
+      if (current === request.current) {
+        setData((response.data as ApiKeyProjectGroup[]) ?? []);
+        setTotalApiKeys(Number(countResponse.data) || 0);
+      }
+    } catch (cause) {
+      if (current === request.current) {
+        setData([]);
+        setTotalApiKeys(0);
+        setError(cause instanceof Error ? cause.message : String(cause));
+      }
+    } finally {
+      if (current === request.current) setIsLoading(false);
+    }
+  }, [
+    mutateAsync,
+    params.workspace,
+    params.search,
+    params.projectEnabled,
+    params.apiKeyDisabled,
+    params.page,
+    params.pageSize,
+  ]);
+
+  useEffect(() => {
+    void fetchGroups();
+  }, [fetchGroups]);
+
+  return { data, totalApiKeys, isLoading, error, refetch: fetchGroups };
+}

--- a/src/domains/api-key/hooks/use-api-key-projects.ts
+++ b/src/domains/api-key/hooks/use-api-key-projects.ts
@@ -1,0 +1,48 @@
+import { useCustomMutation } from "@refinedev/core";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ApiKeyProject } from "@/domains/api-key/types";
+
+export function useApiKeyProjects(workspace?: string) {
+  const { mutateAsync } = useCustomMutation();
+  const [data, setData] = useState<ApiKeyProject[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const request = useRef(0);
+
+  const refetch = useCallback(async () => {
+    const current = ++request.current;
+    if (!workspace) {
+      setData([]);
+      setError("");
+      setIsLoading(false);
+      return [];
+    }
+
+    setIsLoading(true);
+    setError("");
+    try {
+      const response = await mutateAsync({
+        url: "/rpc/list_api_key_projects",
+        method: "post",
+        values: { p_workspace: workspace },
+      });
+      const projects = (response.data as ApiKeyProject[] | null) ?? [];
+      if (current === request.current) setData(projects);
+      return projects;
+    } catch (cause) {
+      if (current === request.current) {
+        setData([]);
+        setError(cause instanceof Error ? cause.message : String(cause));
+      }
+      return [];
+    } finally {
+      if (current === request.current) setIsLoading(false);
+    }
+  }, [mutateAsync, workspace]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { data, isLoading, error, refetch };
+}

--- a/src/domains/api-key/lib/create-api-key-error.test.ts
+++ b/src/domains/api-key/lib/create-api-key-error.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  apiKeyActionErrorMessage,
+  createApiKeyErrorMessage,
+} from "./create-api-key-error";
+
+describe("createApiKeyErrorMessage", () => {
+  it("extracts a nested structured message instead of rendering an object", () => {
+    expect(
+      createApiKeyErrorMessage({ message: { message: "Project is disabled" } }),
+    ).toBe("Project is disabled");
+  });
+
+  it("preserves a move error returned as a nested object", () => {
+    expect(
+      apiKeyActionErrorMessage(
+        {
+          message: {
+            message: "Target Project is disabled",
+          },
+        },
+        "Failed to move API keys. Please try again.",
+      ),
+    ).toBe("Target Project is disabled");
+  });
+
+  it("uses the supplied action fallback", () => {
+    expect(
+      apiKeyActionErrorMessage(
+        { reason: "unknown" },
+        "Failed to move API keys. Please try again.",
+      ),
+    ).toBe("Failed to move API keys. Please try again.");
+  });
+
+  it("uses a stable fallback for unknown errors", () => {
+    expect(createApiKeyErrorMessage({ reason: "unknown" })).toBe(
+      "Failed to create API key. Please try again.",
+    );
+  });
+});

--- a/src/domains/api-key/lib/create-api-key-error.ts
+++ b/src/domains/api-key/lib/create-api-key-error.ts
@@ -1,0 +1,27 @@
+type ErrorRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is ErrorRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value instanceof Error) return errorText(value.message);
+  if (isRecord(value) && "message" in value) return errorText(value.message);
+  return "";
+}
+
+export function apiKeyActionErrorMessage(
+  cause: unknown,
+  fallback = "API key operation failed. Please try again.",
+): string {
+  const message = errorText(cause);
+  return message || fallback;
+}
+
+export function createApiKeyErrorMessage(cause: unknown): string {
+  return apiKeyActionErrorMessage(
+    cause,
+    "Failed to create API key. Please try again.",
+  );
+}

--- a/src/domains/api-key/types.ts
+++ b/src/domains/api-key/types.ts
@@ -34,6 +34,20 @@ export type ApiKey = {
   metadata: Metadata;
   spec: ApiKeySpec;
   status: ApiKeyStatus | null;
+  project_id: string;
+  description: string;
+};
+
+export type ApiKeyProject = {
+  id: string;
+  name: string;
+  description: string;
+  workspace: string;
+  enabled: boolean;
+  is_default: boolean;
+  user_id: string;
+  created_at: string;
+  updated_at: string;
 };
 
 export type ApiKeySpec = {

--- a/src/foundation/lib/batch-delete.test.ts
+++ b/src/foundation/lib/batch-delete.test.ts
@@ -6,6 +6,30 @@ const row = (name: string, workspace?: string): BatchDeleteRow => ({
 });
 
 describe("buildBatchDeleteVariables", () => {
+  it("uses stable IDs for API keys whose names can repeat across Projects", () => {
+    const vars = buildBatchDeleteVariables(
+      [
+        {
+          original: {
+            id: "key-id",
+            metadata: { name: "shared-name", workspace: "default" },
+          },
+        },
+      ],
+      "api_keys",
+      false,
+    );
+
+    expect(vars).toEqual([
+      {
+        resource: "api_keys",
+        id: "key-id",
+        meta: { name: "shared-name", workspace: "default" },
+        successNotification: false,
+      },
+    ]);
+  });
+
   it("threads each row's OWN workspace into its delete meta", () => {
     // The regression: workspaced rows selected from different workspaces must
     // each carry their own workspace, not a single shared (or missing) one.

--- a/src/foundation/lib/batch-delete.ts
+++ b/src/foundation/lib/batch-delete.ts
@@ -1,12 +1,11 @@
 // Batch delete threads each selected row's OWN metadata into its delete call.
 //
-// Neutree resources are keyed by `metadata->name` AND (for workspaced resources)
-// `metadata->workspace`; the data provider's soft-delete first re-reads the
-// record by that composite key before stamping `deletion_timestamp`. A batch
-// delete therefore cannot share a single `meta` across rows: each row may live
-// in a different workspace. Passing only the names (and dropping the workspace)
-// makes the re-read match zero rows, and the provider then dereferences an
-// undefined record -> "Cannot read properties of undefined (reading 'metadata')".
+// Most Neutree resources are keyed by `metadata->name` and, for workspaced
+// resources, `metadata->workspace`. API keys are the exception: names can
+// repeat across Projects, so they use their UUID. The data provider's
+// soft-delete first re-reads the record before stamping `deletion_timestamp`.
+// A batch delete therefore cannot share a single `meta` across rows because
+// each row may live in a different workspace.
 //
 // This builds one delete variable object per row, carrying that row's full
 // metadata (so `workspace` reaches the provider), merging the force-delete flag,
@@ -19,7 +18,7 @@ type RowMetadata = {
 } & Record<string, unknown>;
 
 export type BatchDeleteRow = {
-  original: { metadata?: RowMetadata };
+  original: { id?: string; metadata?: RowMetadata };
 };
 
 type BatchDeleteVariable = {
@@ -35,14 +34,18 @@ export function buildBatchDeleteVariables(
   forceDelete: boolean,
 ): BatchDeleteVariable[] {
   return rows
-    .map((row) => row.original.metadata ?? {})
-    .filter(
-      (metadata): metadata is RowMetadata & { name: string } =>
-        typeof metadata.name === "string" && metadata.name.length > 0,
+    .map((row) => ({
+      id: row.original.id,
+      metadata: row.original.metadata ?? {},
+    }))
+    .filter(({ id, metadata }) =>
+      resource === "api_keys"
+        ? typeof id === "string" && id.length > 0
+        : typeof metadata.name === "string" && metadata.name.length > 0,
     )
-    .map((metadata) => ({
+    .map(({ id, metadata }) => ({
       resource,
-      id: metadata.name,
+      id: resource === "api_keys" ? (id as string) : (metadata.name as string),
       meta: forceDelete ? { ...metadata, forceDelete: true } : { ...metadata },
       successNotification: false,
     }));

--- a/src/foundation/providers/data-provider/index.test.ts
+++ b/src/foundation/providers/data-provider/index.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dataProvider } from ".";
+
+const client = {
+  url: "http://example.test/api/v1",
+  headers: {},
+};
+
+describe("dataProvider custom responses", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("accepts a successful response with an empty body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 204 })),
+    );
+
+    await expect(
+      dataProvider(client as never).custom({
+        url: "/rpc/delete_api_key_project",
+        method: "post",
+        payload: { p_project_id: "project-id" },
+      }),
+    ).resolves.toEqual({ data: null });
+  });
+
+  it("continues to parse JSON responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: "project-id" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    await expect(
+      dataProvider(client as never).custom({
+        url: "/rpc/create_api_key_project",
+        method: "post",
+        payload: {},
+      }),
+    ).resolves.toEqual({ data: { id: "project-id" } });
+  });
+});

--- a/src/foundation/providers/data-provider/index.ts
+++ b/src/foundation/providers/data-provider/index.ts
@@ -369,7 +369,8 @@ export const dataProvider = (
           if (meta?.headers?.["Content-Type"] === "text/plain") {
             return res.text();
           }
-          return res.json();
+          const responseText = await res.text();
+          return responseText ? JSON.parse(responseText) : null;
         })
         .then((data) => {
           return {

--- a/src/pages/ai-traces/components/TraceDetailDrawer.tsx
+++ b/src/pages/ai-traces/components/TraceDetailDrawer.tsx
@@ -858,12 +858,13 @@ const WorkspaceLink = ({ name }: { name?: string }) => {
 };
 
 const ApiKeyLink = ({ id, workspace }: { id?: string; workspace?: string }) => {
-  // The api_keys resource has resource-level
-  // meta: { idColumnName: "metadata->name" }, so useOne by uuid id misses
-  // (it looks up metadata.name = <uuid>). Fetch the workspace's keys via
-  // useList and resolve locally — shares the react-query cache with the
-  // list page's identical query.
-  const { data } = useList<{ id: string; metadata?: { name?: string } }>({
+  // Fetch the workspace's keys to resolve the display name. The detail route
+  // uses the UUID because API key names are display labels and may repeat.
+  const { data } = useList<{
+    id: string;
+    description?: string;
+    metadata?: { name?: string };
+  }>({
     resource: "api_keys",
     pagination: { mode: "off" },
     meta: { workspace },
@@ -875,10 +876,9 @@ const ApiKeyLink = ({ id, workspace }: { id?: string; workspace?: string }) => {
     return <span className="font-mono text-xs">{id}</span>;
   }
 
-  const name = data?.data?.find((k) => k.id === id)?.metadata?.name;
+  const apiKey = data?.data?.find((key) => key.id === id);
+  const name = apiKey?.metadata?.name;
 
-  // The api_keys show route is keyed by metadata.name, not the raw key id —
-  // render a link only once the name has resolved, otherwise it 404s.
   if (!name) {
     return <span className="font-mono text-xs">{id}</span>;
   }
@@ -886,12 +886,12 @@ const ApiKeyLink = ({ id, workspace }: { id?: string; workspace?: string }) => {
   return (
     <ShowButton
       resource="api_keys"
-      recordItemId={name}
+      recordItemId={id}
       meta={{ workspace }}
       variant="link"
       className="!h-auto !p-0 font-mono text-xs"
     >
-      {name}
+      {apiKey.description ? `${name} - ${apiKey.description}` : name}
     </ShowButton>
   );
 };

--- a/src/pages/api-keys/list.tsx
+++ b/src/pages/api-keys/list.tsx
@@ -1,7 +1,29 @@
-import { useInvalidate, useList, useNavigation } from "@refinedev/core";
-import { Pencil, Power, PowerOff, Trash2 } from "lucide-react";
-import { useCallback, useMemo, useState } from "react";
+import {
+  useCustomMutation,
+  useDelete,
+  useList,
+  useNavigation,
+  useNotification,
+} from "@refinedev/core";
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  FolderInput,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Power,
+  PowerOff,
+  Search,
+  Trash2,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -9,8 +31,24 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { ApiKeyRankingOverview } from "@/domains/api-key/components/ApiKeyRankingOverview";
 import { CreateApiKeyForm } from "@/domains/api-key/components/CreateApiKeyForm";
+import { ProjectPicker } from "@/domains/api-key/components/ProjectPicker";
 import {
   rateSummary,
   useAllApiKeyTraffic,
@@ -18,19 +56,19 @@ import {
   useApiKeyDisable,
   useWorkspaceModelMap,
 } from "@/domains/api-key/hooks/use-api-key-policy";
+import { useApiKeyProjectGroups } from "@/domains/api-key/hooks/use-api-key-project-groups";
+import { useApiKeyProjects } from "@/domains/api-key/hooks/use-api-key-projects";
+import { apiKeyActionErrorMessage } from "@/domains/api-key/lib/create-api-key-error";
 import type {
   AllowedModel,
   ApiKey,
-  ApiKeyLimits,
+  ApiKeyProject,
 } from "@/domains/api-key/types";
+import { DeleteConfirmDialog } from "@/foundation/components/DeleteConfirmDialog";
 import { ListPage } from "@/foundation/components/ListPage";
-import { useMetadataColumns } from "@/foundation/components/metadata-columns";
-import {
-  defaultSorters,
-  RowAction,
-  Table,
-} from "@/foundation/components/Table";
+import Timestamp from "@/foundation/components/Timestamp";
 import { ALL_WORKSPACES, useWorkspace } from "@/foundation/hooks/use-workspace";
+import { buildBatchDeleteVariables } from "@/foundation/lib/batch-delete";
 import { useTranslation } from "@/foundation/lib/i18n";
 import { formatTokenQuota } from "@/foundation/lib/token-quota";
 import { cn } from "@/foundation/lib/utils";
@@ -56,12 +94,6 @@ const endpointPhaseClass = (phase: string | null | undefined) =>
   })[phase ?? ""] ??
   "border-[var(--nt-stroke-neutral-trans-2)] bg-[var(--nt-fill-neutral-opaque-1)] text-[var(--nt-text-neutral-secondary)]";
 
-// Number of allowed models rendered before the cell collapses the rest behind
-// a "show N more" toggle — keeps rows short when a key allows many models.
-const MODELS_COLLAPSED = 2;
-
-// Allowed-models table cell: renders each model (name + endpoint/type/phase) on
-// its own block, but only the first MODELS_COLLAPSED until expanded in place.
 function ModelsCell({
   models,
   modelMap,
@@ -73,48 +105,54 @@ function ModelsCell({
 }) {
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const visible = expanded ? models : models.slice(0, MODELS_COLLAPSED);
-  const hiddenCount = models.length - MODELS_COLLAPSED;
+  const visible = expanded ? models : models.slice(0, 2);
+
+  if (models.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground">
+        {t("api_keys.limits.allModels")}
+      </span>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-2">
-      {visible.map((m, i) => {
-        // A pinned entry shows only its one endpoint; a wildcard entry (migrated
-        // legacy, no type/endpoint_name) allows any endpoint serving the model.
-        const pinned = !!m.type && !!m.endpoint_name;
-        const servingEndpoint = pinned
+      {visible.map((model, index) => {
+        const pinned = Boolean(model.type && model.endpoint_name);
+        const endpoint = pinned
           ? modelMap
-              .get(m.model)
+              .get(model.model)
               ?.endpoints.find(
-                (e) => e.name === m.endpoint_name && e.type === m.type,
+                (item) =>
+                  item.name === model.endpoint_name && item.type === model.type,
               )
           : undefined;
         return (
           <div
-            key={`${m.type ?? ""}:${m.endpoint_name ?? ""}:${m.model}:${i}`}
+            key={`${model.type ?? ""}:${model.endpoint_name ?? ""}:${model.model}:${index}`}
             className="flex min-w-0 flex-col gap-1"
           >
-            <span className="truncate text-sm font-semibold" title={m.model}>
-              {m.model}
+            <span className="truncate font-semibold" title={model.model}>
+              {model.model}
             </span>
             {pinned ? (
-              <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-                <span className="truncate max-w-[140px]">
-                  {m.endpoint_name}
+              <div className="flex min-w-0 flex-wrap items-center gap-1 text-xs text-muted-foreground">
+                <span className="max-w-[140px] truncate">
+                  {model.endpoint_name}
                 </span>
                 <Badge variant="outline" className="h-5 font-normal">
-                  {t(`api_keys.models.${m.type}`)}
+                  {t(`api_keys.models.${model.type}`)}
                 </Badge>
-                {servingEndpoint ? (
+                {endpoint ? (
                   <Badge
                     variant="outline"
                     className={cn(
                       "h-5 font-normal",
-                      endpointPhaseClass(servingEndpoint.phase),
+                      endpointPhaseClass(endpoint.phase),
                     )}
                   >
-                    {servingEndpoint.phase
-                      ? t(`status.phases.endpoint.${servingEndpoint.phase}`)
+                    {endpoint.phase
+                      ? t(`status.phases.endpoint.${endpoint.phase}`)
                       : t("api_keys.models.unknown")}
                   </Badge>
                 ) : scopedWorkspace ? (
@@ -131,19 +169,15 @@ function ModelsCell({
           </div>
         );
       })}
-      {models.length > MODELS_COLLAPSED && (
+      {models.length > 2 && (
         <button
           type="button"
-          onClick={(e) => {
-            // Don't trigger row navigation when toggling the cell.
-            e.stopPropagation();
-            setExpanded((v) => !v);
-          }}
-          className="self-start text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          className="self-start text-xs text-muted-foreground hover:underline"
+          onClick={() => setExpanded((value) => !value)}
         >
           {expanded
             ? t("api_keys.limits.showLess")
-            : t("api_keys.limits.showMore", { count: hiddenCount })}
+            : t("api_keys.limits.showMore", { count: models.length - 2 })}
         </button>
       )}
     </div>
@@ -152,262 +186,1089 @@ function ModelsCell({
 
 export const ApiKeysList = () => {
   const { t } = useTranslation();
-  const { show } = useNavigation();
-  const [open, setOpen] = useState(false);
-  const metadataColumns = useMetadataColumns();
   const { current: workspace } = useWorkspace();
-  // These aggregates are per-workspace RPCs; ALL_WORKSPACES (`_all_`) is a
-  // UI-only sentinel, not a real workspace, so gate them to a concrete value
-  // (the hooks no-op on undefined) instead of firing p_workspace="_all_".
-  const scopedWorkspace = workspace === ALL_WORKSPACES ? undefined : workspace;
-  const usageByKey = useAllApiKeyUsage(scopedWorkspace);
-  const trafficByKey = useAllApiKeyTraffic(scopedWorkspace);
-  const modelMap = useWorkspaceModelMap(scopedWorkspace);
+  const scoped = workspace === ALL_WORKSPACES ? undefined : workspace;
+  const [open, setOpen] = useState(false);
+  const [createKeyPreset, setCreateKeyPreset] = useState({
+    workspace: "",
+    projectId: "",
+  });
+  const [createKeySession, setCreateKeySession] = useState(0);
+  const [query, setQuery] = useState("");
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [moveOpen, setMoveOpen] = useState(false);
+  const [target, setTarget] = useState("");
+  const [projectStatus, setProjectStatus] = useState("all");
+  const [keyStatus, setKeyStatus] = useState("all");
+  const [page, setPage] = useState(1);
+  const [editing, setEditing] = useState<ApiKeyProject>();
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [actionError, setActionError] = useState("");
+  const [deletingProject, setDeletingProject] = useState<ApiKeyProject>();
+  const [deletingKeys, setDeletingKeys] = useState<ApiKey[]>([]);
+  const [deletingKeyPending, setDeletingKeyPending] = useState(false);
+  const [createProjectOpen, setCreateProjectOpen] = useState(false);
+  const [createProjectName, setCreateProjectName] = useState("");
+  const [createProjectDescription, setCreateProjectDescription] = useState("");
+  const [creatingProject, setCreatingProject] = useState(false);
+  const [pageSize, setPageSize] = useState(10);
+  const { mutateAsync } = useCustomMutation();
+  const { open: openNotification } = useNotification();
+  const { show } = useNavigation();
+  const { mutateAsync: deleteKey } = useDelete();
   const { disable, enable } = useApiKeyDisable();
-  const invalidate = useInvalidate();
-  const refresh = useCallback(
-    () => invalidate({ resource: "api_keys", invalidates: ["list"] }),
-    [invalidate],
-  );
-
-  // Keys (id -> name) for the ranking overview. Workspace-scoped via resource
-  // meta (matches the table query, no cross-workspace over-fetch) and
-  // unpaginated so no key is dropped from the ranking inputs.
+  const trafficByKey = useAllApiKeyTraffic(scoped);
+  const usageByKey = useAllApiKeyUsage(scoped);
+  const modelMap = useWorkspaceModelMap(scoped);
   const { data: keysData } = useList<ApiKey>({
     resource: "api_keys",
     pagination: { mode: "off" },
-    // workspaced: true is what the data provider checks to apply the
-    // metadata->workspace filter (resource meta isn't merged here).
     meta: { workspace, workspaced: true },
     queryOptions: { enabled: Boolean(workspace) },
   });
-  const rankingKeys = useMemo(() => {
-    const rows = keysData?.data ?? [];
-    return rows
-      .filter(
-        (k) =>
-          workspace === ALL_WORKSPACES || k.metadata?.workspace === workspace,
-      )
-      .map((k) => ({
-        id: String(k.id),
-        name: k.metadata?.name ?? String(k.id),
-      }));
-  }, [keysData, workspace]);
-
-  // Limits live on the key itself (spec.limits) — read straight off each row,
-  // no separate fetch.
-  const limitsOf = (original: ApiKey): ApiKeyLimits =>
-    (original.spec?.limits as ApiKeyLimits | undefined) ?? {};
-
-  const dash = <span className="text-muted-foreground">—</span>;
-
-  // Token quota usage: used / limit with a progress bar (amber ≥80%, red over).
-  const usageColumn = (
-    <Table.Column
-      accessorKey="id"
-      id="usage"
-      header={t("api_keys.limits.usageColumn")}
-      cell={({ row: { original } }) => {
-        const u = usageByKey.get(String(original.id));
-        if (!u || u.token_limit <= 0) return dash;
-        const ratio = u.used / u.token_limit;
-        const pct = Math.max(0, Math.min(100, ratio * 100));
-        const over = u.used >= u.token_limit;
-        const warn = !over && ratio >= 0.8;
-        return (
-          <div className="flex w-40 flex-col gap-1">
-            <div className="flex justify-between text-xs text-muted-foreground tabular-nums">
-              <span>
-                {formatTokenQuota(u.used)} / {formatTokenQuota(u.token_limit)}
-              </span>
-              <span>{Math.round(pct)}%</span>
-            </div>
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-primary/20">
-              <div
-                className={cn(
-                  "h-full",
-                  over
-                    ? "bg-destructive"
-                    : warn
-                      ? "bg-amber-500"
-                      : "bg-primary",
-                )}
-                style={{ width: `${pct}%` }}
-              />
-            </div>
-          </div>
-        );
-      }}
-    />
+  const rankingKeys = useMemo(
+    () =>
+      (keysData?.data ?? [])
+        .filter(
+          (key) =>
+            !key.metadata?.deletion_timestamp &&
+            (workspace === ALL_WORKSPACES ||
+              key.metadata?.workspace === workspace),
+        )
+        .map((key) => ({
+          id: String(key.id),
+          name: key.description
+            ? `${key.metadata?.name ?? key.id} - ${key.description}`
+            : (key.metadata?.name ?? String(key.id)),
+        })),
+    [keysData, workspace],
+  );
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  useEffect(() => {
+    const timer = window.setTimeout(() => setDebouncedQuery(query), 300);
+    return () => window.clearTimeout(timer);
+  }, [query]);
+  const groupsQuery = useApiKeyProjectGroups({
+    workspace: scoped,
+    search: debouncedQuery,
+    projectEnabled: projectStatus === "all" ? null : projectStatus === "active",
+    apiKeyDisabled: keyStatus === "all" ? null : keyStatus === "disabled",
+    page,
+    pageSize,
+  });
+  const grouped = groupsQuery.data.map((group) => ({
+    project: group.project,
+    all: group.api_keys,
+    shown: group.api_keys,
+    visible: true,
+    count: group.api_key_count,
+  }));
+  const selectedKeys = (keysData?.data ?? []).filter((key) =>
+    selected.has(key.id),
+  );
+  const selectedWorkspaces = [
+    ...new Set(
+      selectedKeys
+        .map((key) => key.metadata.workspace)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ];
+  const moveWorkspace =
+    selectedWorkspaces.length === 1 ? selectedWorkspaces[0] : "";
+  const movableKeyCount = selectedKeys.filter(
+    (key) => key.project_id !== target,
+  ).length;
+  const { data: moveProjects } = useApiKeyProjects(moveWorkspace);
+  const projects = grouped.map((group) => group.project);
+  const moveProjectNames = new Map(
+    [...moveProjects, ...projects].map((project) => [project.id, project.name]),
+  );
+  const groupedProjectIds = grouped.map((group) => group.project.id).join(",");
+  const expansionContext = [
+    scoped,
+    debouncedQuery,
+    projectStatus,
+    keyStatus,
+    page,
+    pageSize,
+  ].join("\0");
+  const pageCount = Math.max(
+    1,
+    Math.ceil((groupsQuery.data[0]?.total_projects ?? 0) / pageSize),
   );
 
-  // Rate limits (RPS / RPM / concurrency).
-  const rateColumn = (
-    <Table.Column
-      accessorKey="id"
-      id="rate_limits"
-      header={t("api_keys.limits.rateColumn")}
-      cell={({ row: { original } }) => {
-        const rate = rateSummary(limitsOf(original as ApiKey));
-        return rate.length > 0 ? (
-          <span className="text-xs text-muted-foreground">
-            {rate.join(" · ")}
-          </span>
-        ) : (
-          dash
+  const pageGroups = grouped;
+  const pageKeys = pageGroups.flatMap((group) => group.shown);
+  const pageKeyIds = pageKeys.map((key) => key.id);
+  const selectedPageKeyCount = pageKeyIds.filter((id) =>
+    selected.has(id),
+  ).length;
+  const pageSelectionState =
+    selectedPageKeyCount === 0
+      ? false
+      : selectedPageKeyCount === pageKeyIds.length
+        ? true
+        : "indeterminate";
+  // Reset only when the result context changes. User toggles must not cause a
+  // collapsed Project to immediately reopen.
+  useEffect(() => {
+    const projectIds = expansionContext
+      ? groupedProjectIds.split(",").filter(Boolean)
+      : [];
+    setExpanded(new Set(projectIds));
+  }, [expansionContext, groupedProjectIds]);
+  const refresh = async () => {
+    await groupsQuery.refetch();
+  };
+  const createKey = (project?: ApiKeyProject) => {
+    setCreateKeyPreset({
+      workspace: project?.workspace ?? scoped ?? "",
+      projectId: project?.id ?? "",
+    });
+    setCreateKeySession((session) => session + 1);
+    setOpen(true);
+  };
+  const createProject = async () => {
+    if (!scoped || !createProjectName.trim()) return;
+    setActionError("");
+    setCreatingProject(true);
+    try {
+      const response = await mutateAsync({
+        url: "/rpc/create_api_key_project",
+        method: "post",
+        values: {
+          p_workspace: scoped,
+          p_name: createProjectName.trim(),
+          p_description: createProjectDescription.trim(),
+        },
+      });
+      const project = response.data as ApiKeyProject;
+      setCreateProjectOpen(false);
+      setCreateProjectName("");
+      setCreateProjectDescription("");
+      setExpanded((current) => new Set([...current, project.id]));
+      await refresh();
+    } catch (cause) {
+      setActionError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setCreatingProject(false);
+    }
+  };
+  const migrate = async () => {
+    setActionError("");
+    try {
+      const response = await mutateAsync({
+        url: "/rpc/move_api_keys_to_project",
+        method: "post",
+        values: { p_api_key_ids: [...selected], p_project_id: target },
+        successNotification: false,
+        errorNotification: false,
+      });
+      setSelected(new Set());
+      setMoveOpen(false);
+      setExpanded((v) => new Set([...v, target]));
+      openNotification?.({
+        type: "success",
+        message: `${Number(response.data) || 0} API key${Number(response.data) === 1 ? "" : "s"} moved`,
+      });
+      await refresh();
+    } catch (cause) {
+      setActionError(
+        apiKeyActionErrorMessage(
+          cause,
+          "Failed to move API keys. Please try again.",
+        ),
+      );
+    }
+  };
+  const startEdit = (project: ApiKeyProject) => {
+    setEditing(project);
+    setEditName(project.name);
+    setEditDescription(project.description);
+  };
+  const saveProject = async () => {
+    if (!editing) return;
+    setActionError("");
+    try {
+      await mutateAsync({
+        url: "/rpc/update_api_key_project",
+        method: "post",
+        values: {
+          p_project_id: editing.id,
+          p_name: editName,
+          p_description: editDescription,
+        },
+      });
+      setEditing(undefined);
+      await refresh();
+    } catch (cause) {
+      setActionError(cause instanceof Error ? cause.message : String(cause));
+    }
+  };
+  const deleteApiKeys = async (forceDelete: boolean) => {
+    if (deletingKeys.length === 0) return;
+    if (deletingKeys.some((key) => !key.metadata.workspace)) {
+      setActionError(
+        "An API key is missing its workspace. Refresh and try again.",
+      );
+      return;
+    }
+    const variables = buildBatchDeleteVariables(
+      deletingKeys.map((key) => ({
+        original: {
+          id: key.id,
+          metadata: {
+            ...key.metadata,
+            workspace: key.metadata.workspace ?? undefined,
+          },
+        },
+      })),
+      "api_keys",
+      forceDelete,
+    );
+    if (variables.length !== deletingKeys.length) {
+      setActionError("An API key is missing its name. Refresh and try again.");
+      return;
+    }
+    setActionError("");
+    setDeletingKeyPending(true);
+    try {
+      const results = await Promise.allSettled(
+        variables.map((variable) => deleteKey(variable)),
+      );
+      const failed = results.filter((result) => result.status === "rejected");
+      if (failed.length > 0) {
+        setActionError(
+          `${failed.length} of ${variables.length} API keys could not be deleted.`,
         );
-      }}
-    />
-  );
-
-  // Supported (allowed) models — "All" when no allowlist.
-  const modelsColumn = (
-    <Table.Column
-      accessorKey="id"
-      id="supported_models"
-      header={t("api_keys.limits.modelsColumn")}
-      cell={({ row: { original } }) => {
-        const models = limitsOf(original as ApiKey).allowed_models ?? [];
-        if (models.length === 0) {
-          return (
-            <span className="text-xs text-muted-foreground">
-              {t("api_keys.limits.allModels")}
-            </span>
-          );
-        }
-        return (
-          <ModelsCell
-            models={models}
-            modelMap={modelMap}
-            scopedWorkspace={scopedWorkspace}
-          />
-        );
-      }}
-    />
-  );
-
-  // Status: Disabled (a 'disabled' access rule blocks the key) > Quota exceeded
-  // (current-period usage at/over the limit) > Active.
-  const statusColumn = (
-    <Table.Column
-      accessorKey="id"
-      id="status"
-      header={t("api_keys.limits.statusColumn")}
-      cell={({ row: { original } }) => {
-        const id = String(original.id);
-        if (limitsOf(original as ApiKey).disabled) {
-          return (
-            <Badge variant="destructive">
-              {t("api_keys.limits.statusDisabled")}
-            </Badge>
-          );
-        }
-        const u = usageByKey.get(id);
-        if (u && u.token_limit > 0 && u.used >= u.token_limit) {
-          return (
-            <Badge variant="destructive">
-              {t("api_keys.limits.statusQuotaExceeded")}
-            </Badge>
-          );
-        }
-        return (
-          <Badge variant="outline">{t("api_keys.limits.statusActive")}</Badge>
-        );
-      }}
-    />
-  );
-
-  const actionColumn = (
-    <Table.Column
-      accessorKey={"id"}
-      id={"actions"}
-      cell={({ row: { original } }) => {
-        const isDisabled = limitsOf(original as ApiKey).disabled;
-        return (
-          <Table.Actions>
-            <RowAction
-              title={t("buttons.edit")}
-              icon={<Pencil size={16} />}
-              onClick={() => {
-                const k = original as ApiKey;
-                // The api_keys show route is keyed by metadata.name (not the raw
-                // key id), and in the ALL_WORKSPACES view the row's own
-                // workspace must fill the :workspace route param.
-                if (k.metadata?.name) {
-                  show("api_keys", k.metadata.name, "push", {
-                    workspace: k.metadata.workspace,
-                  });
-                }
-              }}
-            />
-            <RowAction
-              title={
-                isDisabled
-                  ? t("api_keys.limits.enable")
-                  : t("api_keys.limits.disable")
-              }
-              icon={isDisabled ? <Power size={16} /> : <PowerOff size={16} />}
-              onClick={() => {
-                const id = String(original.id);
-                void (isDisabled ? enable(id) : disable(id))
-                  .then(() => refresh())
-                  .catch(() => {});
-              }}
-            />
-            <Table.DeleteAction
-              title={t("buttons.delete")}
-              row={original}
-              resource="api_keys"
-              icon={<Trash2 size={16} />}
-            />
-          </Table.Actions>
-        );
-      }}
-    />
-  );
+        if (failed.length === variables.length) return;
+      }
+      const deletedIds = new Set(
+        deletingKeys
+          .filter((_, index) => results[index]?.status === "fulfilled")
+          .map((key) => key.id),
+      );
+      setSelected((current) => {
+        const next = new Set(current);
+        for (const id of deletedIds) next.delete(id);
+        return next;
+      });
+      setDeletingKeys([]);
+      openNotification?.({
+        type: "success",
+        message:
+          deletedIds.size === 1
+            ? "Successfully deleted API key"
+            : `Successfully deleted ${deletedIds.size} API keys`,
+      });
+      await refresh();
+    } catch (cause) {
+      setActionError(cause instanceof Error ? cause.message : String(cause));
+    } finally {
+      setDeletingKeyPending(false);
+    }
+  };
 
   return (
-    <ListPage
-      createButtonProps={{
-        onClick: () => {
-          setOpen(true);
-        },
-      }}
-    >
+    <ListPage createButtonProps={{ onClick: () => createKey() }}>
+      <ApiKeyRankingOverview keys={rankingKeys} traffic={trafficByKey} />
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="sm:max-w-2xl">
+        <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-2xl">
           <DialogHeader>
-            <DialogTitle>{t("api_keys.create")}</DialogTitle>
-            <DialogDescription>
-              {t("api_keys.messages.createDescription")}
-            </DialogDescription>
+            <DialogTitle>Create API Key</DialogTitle>
+            <DialogDescription>Create a key in a Project.</DialogDescription>
           </DialogHeader>
-          <CreateApiKeyForm onClose={() => setOpen(false)} />
+          <CreateApiKeyForm
+            key={createKeySession}
+            initialWorkspace={createKeyPreset.workspace}
+            initialProjectId={createKeyPreset.projectId}
+            onClose={() => setOpen(false)}
+            onCreated={refresh}
+          />
         </DialogContent>
       </Dialog>
-
-      <div className="mb-4">
-        <ApiKeyRankingOverview keys={rankingKeys} traffic={trafficByKey} />
-      </div>
-
-      <Table
-        enableSorting
-        enableFilters
-        enableBatchDelete
-        searchField="metadata->>name"
-        refineCoreProps={{
-          sorters: defaultSorters,
+      <Dialog
+        open={createProjectOpen}
+        onOpenChange={(nextOpen) => {
+          setCreateProjectOpen(nextOpen);
+          setActionError("");
         }}
       >
-        {metadataColumns.name}
-        {metadataColumns.workspace}
-        {statusColumn}
-        {usageColumn}
-        {rateColumn}
-        {modelsColumn}
-        {metadataColumns.creation_timestamp}
-        {actionColumn}
-      </Table>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Project</DialogTitle>
+            <DialogDescription>
+              Create a Project in workspace {scoped}.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <label
+              htmlFor="new-project-name"
+              className="block text-sm font-medium"
+            >
+              Name
+              <Input
+                id="new-project-name"
+                value={createProjectName}
+                onChange={(event) => setCreateProjectName(event.target.value)}
+              />
+            </label>
+            <label
+              htmlFor="new-project-description"
+              className="block text-sm font-medium"
+            >
+              Description
+              <Textarea
+                id="new-project-description"
+                value={createProjectDescription}
+                onChange={(event) =>
+                  setCreateProjectDescription(event.target.value)
+                }
+              />
+            </label>
+          </div>
+          {actionError && (
+            <p className="text-sm text-destructive">{actionError}</p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => setCreateProjectOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={!createProjectName.trim() || creatingProject}
+              onClick={() => void createProject()}
+            >
+              {creatingProject ? "Creating..." : "Create Project"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={moveOpen} onOpenChange={setMoveOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Move API keys</DialogTitle>
+            <DialogDescription>
+              {selected.size} selected. The operation is atomic.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="overflow-hidden rounded-md border">
+            <div className="grid grid-cols-2 gap-4 border-b bg-muted/50 px-3 py-2 text-xs font-medium text-muted-foreground">
+              <span>API key</span>
+              <span>Current Project</span>
+            </div>
+            <div className="max-h-48 overflow-y-auto">
+              {selectedKeys.map((key) => (
+                <div
+                  key={key.id}
+                  className="grid grid-cols-2 gap-4 border-b px-3 py-2 text-sm last:border-b-0"
+                >
+                  <span className="min-w-0 truncate font-medium">
+                    {key.metadata.name}
+                  </span>
+                  <span className="min-w-0 truncate text-muted-foreground">
+                    {moveProjectNames.get(key.project_id) ?? "Unknown Project"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <ProjectPicker
+            workspace={moveWorkspace}
+            value={target}
+            onChange={setTarget}
+          />
+          {selectedWorkspaces.length > 1 && (
+            <p className="text-sm text-destructive">
+              Selected API keys span multiple workspaces. Move one workspace at
+              a time.
+            </p>
+          )}
+          {target && movableKeyCount === 0 && (
+            <p className="text-sm text-muted-foreground">
+              The selected API keys already belong to this Project.
+            </p>
+          )}
+          {actionError && (
+            <p className="text-sm text-destructive">{actionError}</p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setMoveOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={
+                !target ||
+                !selected.size ||
+                selectedWorkspaces.length !== 1 ||
+                movableKeyCount === 0
+              }
+              onClick={() => void migrate()}
+            >
+              Move
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={Boolean(editing)}
+        onOpenChange={(v) => !v && setEditing(undefined)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Project</DialogTitle>
+            <DialogDescription>
+              Renaming does not change API key associations or usage history.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <label htmlFor="project-name" className="block text-sm font-medium">
+              Name
+              <Input
+                id="project-name"
+                value={editName}
+                onChange={(e) => setEditName(e.target.value)}
+              />
+            </label>
+            <label
+              htmlFor="project-description"
+              className="block text-sm font-medium"
+            >
+              Description
+              <Textarea
+                id="project-description"
+                value={editDescription}
+                onChange={(e) => setEditDescription(e.target.value)}
+              />
+            </label>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="secondary" onClick={() => setEditing(undefined)}>
+              Cancel
+            </Button>
+            <Button
+              disabled={!editName.trim()}
+              onClick={() => void saveProject()}
+            >
+              Save
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={Boolean(deletingProject)}
+        onOpenChange={(open) => !open && setDeletingProject(undefined)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Project</DialogTitle>
+            <DialogDescription>
+              Delete {deletingProject?.name}? Only an empty Project can be
+              deleted.
+            </DialogDescription>
+          </DialogHeader>
+          {actionError && (
+            <p className="text-sm text-destructive">{actionError}</p>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => setDeletingProject(undefined)}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (!deletingProject) return;
+                setActionError("");
+                void mutateAsync({
+                  url: "/rpc/delete_api_key_project",
+                  method: "post",
+                  values: { p_project_id: deletingProject.id },
+                })
+                  .then(async () => {
+                    setDeletingProject(undefined);
+                    openNotification?.({
+                      type: "success",
+                      message: "Successfully deleted Project",
+                    });
+                    await refresh();
+                  })
+                  .catch((cause) =>
+                    setActionError(
+                      cause instanceof Error ? cause.message : String(cause),
+                    ),
+                  );
+              }}
+            >
+              Delete
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+      <DeleteConfirmDialog
+        open={deletingKeys.length > 0}
+        onOpenChange={(nextOpen) => !nextOpen && setDeletingKeys([])}
+        loading={deletingKeyPending}
+        title={
+          deletingKeys.length > 1
+            ? `Delete ${deletingKeys.length} API keys?`
+            : undefined
+        }
+        errorMessage={actionError || undefined}
+        onConfirm={(forceDelete) => void deleteApiKeys(forceDelete)}
+      >
+        <span className="hidden" />
+      </DeleteConfirmDialog>
+      <div className="my-4 flex items-center gap-3">
+        <div className="relative max-w-md flex-1">
+          <Search className="absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            className="pl-9"
+            placeholder="Search Project, API key, or description"
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setPage(1);
+            }}
+          />
+        </div>
+        <Select
+          value={projectStatus}
+          onValueChange={(value) => {
+            setProjectStatus(value);
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Projects</SelectItem>
+            <SelectItem value="active">Active Projects</SelectItem>
+            <SelectItem value="disabled">Disabled Projects</SelectItem>
+          </SelectContent>
+        </Select>
+        <Select
+          value={keyStatus}
+          onValueChange={(value) => {
+            setKeyStatus(value);
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All API keys</SelectItem>
+            <SelectItem value="active">Active API keys</SelectItem>
+            <SelectItem value="disabled">Disabled API keys</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          className="h-8 w-36 shrink-0 whitespace-nowrap"
+          variant="outline"
+          disabled={!scoped}
+          onClick={() => setCreateProjectOpen(true)}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Create Project
+        </Button>
+        {selected.size > 0 && (
+          <>
+            <span className="inline-flex h-8 shrink-0 items-center whitespace-nowrap text-sm">
+              {selected.size} selected
+            </span>
+            <Button
+              className="h-8 w-36 shrink-0 whitespace-nowrap"
+              onClick={() => {
+                setActionError("");
+                setTarget("");
+                setMoveOpen(true);
+              }}
+            >
+              Move to Project
+            </Button>
+            <Button
+              className="h-8 shrink-0 whitespace-nowrap"
+              variant="destructive"
+              onClick={() => {
+                setActionError("");
+                setDeletingKeys(selectedKeys);
+              }}
+            >
+              <Trash2 className="mr-1 h-4 w-4" />
+              Delete
+            </Button>
+            <Button
+              className="h-8 shrink-0"
+              variant="ghost"
+              onClick={() => setSelected(new Set())}
+            >
+              Clear
+            </Button>
+          </>
+        )}
+      </div>
+      <div className="overflow-hidden rounded-md border">
+        <div className="grid grid-cols-[minmax(240px,2fr)_100px_120px_48px] gap-4 border-b bg-muted/50 px-4 py-3 text-xs font-medium text-muted-foreground">
+          <span className="flex items-center gap-3">
+            <Checkbox
+              aria-label="Select all API keys on this page"
+              checked={pageSelectionState}
+              disabled={pageKeyIds.length === 0}
+              onCheckedChange={(checked) =>
+                setSelected((current) => {
+                  const next = new Set(current);
+                  for (const id of pageKeyIds) {
+                    checked ? next.add(id) : next.delete(id);
+                  }
+                  return next;
+                })
+              }
+            />
+            Project / description
+          </span>
+          <span>API keys</span>
+          <span>Status</span>
+          <span />
+        </div>
+        {groupsQuery.isLoading && (
+          <div className="p-8 text-center text-muted-foreground">
+            Loading...
+          </div>
+        )}
+        {groupsQuery.error && (
+          <div className="p-8 text-center text-destructive">
+            {groupsQuery.error}
+          </div>
+        )}
+        {!groupsQuery.isLoading &&
+          !groupsQuery.error &&
+          grouped.length === 0 && (
+            <div className="p-8 text-center text-muted-foreground">
+              No matching Projects or API keys
+            </div>
+          )}
+        {pageGroups.map(({ project, shown, count }) => {
+          const isOpen = expanded.has(project.id);
+          const projectKeyIds = shown.map((key) => key.id);
+          const selectedProjectKeyCount = projectKeyIds.filter((id) =>
+            selected.has(id),
+          ).length;
+          const projectSelectionState =
+            selectedProjectKeyCount === 0
+              ? false
+              : selectedProjectKeyCount === projectKeyIds.length
+                ? true
+                : "indeterminate";
+          return (
+            <div key={project.id} className="border-b last:border-b-0">
+              <div className="grid grid-cols-[minmax(240px,2fr)_100px_120px_48px] items-center gap-4 px-4 py-3">
+                <button
+                  type="button"
+                  className="flex min-w-0 items-center gap-2 text-left"
+                  onClick={() =>
+                    setExpanded((old) => {
+                      const n = new Set(old);
+                      n.has(project.id)
+                        ? n.delete(project.id)
+                        : n.add(project.id);
+                      return n;
+                    })
+                  }
+                >
+                  {isOpen ? (
+                    <ChevronDown className="h-4 w-4 shrink-0" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 shrink-0" />
+                  )}
+                  <span className="min-w-0">
+                    <strong className="block truncate">{project.name}</strong>
+                    <span
+                      className="block truncate text-xs text-muted-foreground"
+                      title={project.description}
+                    >
+                      {project.description || "No description"}
+                    </span>
+                  </span>
+                </button>
+                <span className="text-sm">{count}</span>
+                <Badge
+                  className="w-fit"
+                  variant={project.enabled ? "outline" : "destructive"}
+                >
+                  {project.enabled ? "Active" : "Disabled"}
+                </Badge>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon">
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => startEdit(project)}>
+                      <Pencil className="mr-2 h-4 w-4" />
+                      Edit Project
+                    </DropdownMenuItem>
+                    {project.enabled && (
+                      <DropdownMenuItem onClick={() => createKey(project)}>
+                        <Plus className="mr-2 h-4 w-4" />
+                        Create API key
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                      onClick={() => {
+                        setActionError("");
+                        void mutateAsync({
+                          url: "/rpc/update_api_key_project",
+                          method: "post",
+                          values: {
+                            p_project_id: project.id,
+                            p_enabled: !project.enabled,
+                          },
+                        })
+                          .then(refresh)
+                          .catch((cause) =>
+                            setActionError(
+                              cause instanceof Error
+                                ? cause.message
+                                : String(cause),
+                            ),
+                          );
+                      }}
+                    >
+                      {project.enabled ? (
+                        <PowerOff className="mr-2 h-4 w-4" />
+                      ) : (
+                        <Power className="mr-2 h-4 w-4" />
+                      )}
+                      {project.enabled ? "Disable" : "Enable"}
+                    </DropdownMenuItem>
+                    {!project.is_default && (
+                      <DropdownMenuItem
+                        className="text-destructive"
+                        disabled={count > 0}
+                        title={
+                          count > 0
+                            ? `Move or delete the ${count} API key${count === 1 ? "" : "s"} first`
+                            : undefined
+                        }
+                        onClick={() => setDeletingProject(project)}
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Delete
+                      </DropdownMenuItem>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+              {isOpen && (
+                <div className="border-t bg-muted/20 px-6 py-3">
+                  {shown.length === 0 ? (
+                    <div className="py-8 text-center text-sm text-muted-foreground">
+                      This Project has no API keys
+                      {project.enabled && (
+                        <div>
+                          <Button
+                            variant="link"
+                            onClick={() => createKey(project)}
+                          >
+                            Create API key
+                          </Button>
+                        </div>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="overflow-x-auto">
+                      <table className="w-full min-w-[960px] text-sm">
+                        <thead>
+                          <tr className="text-left text-xs text-muted-foreground">
+                            <th className="w-10">
+                              <Checkbox
+                                aria-label={`Select all API keys in ${project.name}`}
+                                checked={projectSelectionState}
+                                onCheckedChange={(checked) =>
+                                  setSelected((current) => {
+                                    const next = new Set(current);
+                                    for (const id of projectKeyIds) {
+                                      checked ? next.add(id) : next.delete(id);
+                                    }
+                                    return next;
+                                  })
+                                }
+                              />
+                            </th>
+                            <th className="py-2">API key / description</th>
+                            <th>Workspace</th>
+                            <th>Status</th>
+                            <th>Usage</th>
+                            <th>Rate limit</th>
+                            <th>Supported models</th>
+                            <th>Created</th>
+                            <th className="w-12" />
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {shown.map((key) => {
+                            const limits = key.spec.limits ?? {};
+                            const usage = usageByKey.get(String(key.id));
+                            const usageRatio =
+                              usage && usage.token_limit > 0
+                                ? usage.used / usage.token_limit
+                                : 0;
+                            const usagePercent = Math.max(
+                              0,
+                              Math.min(100, usageRatio * 100),
+                            );
+                            const usageOver = usage
+                              ? usage.used >= usage.token_limit
+                              : false;
+                            const usageWarn = !usageOver && usageRatio >= 0.8;
+                            return (
+                              <tr key={key.id} className="border-t">
+                                <td>
+                                  <Checkbox
+                                    checked={selected.has(key.id)}
+                                    onCheckedChange={(v) =>
+                                      setSelected((old) => {
+                                        const n = new Set(old);
+                                        v ? n.add(key.id) : n.delete(key.id);
+                                        return n;
+                                      })
+                                    }
+                                  />
+                                </td>
+                                <td className="py-3">
+                                  <strong>{key.metadata.name}</strong>
+                                  <div
+                                    className="max-w-xs truncate text-xs text-muted-foreground"
+                                    title={key.description}
+                                  >
+                                    {key.description || "No description"}
+                                  </div>
+                                </td>
+                                <td>{key.metadata.workspace}</td>
+                                <td>
+                                  <Badge
+                                    variant={
+                                      limits.disabled || usageOver
+                                        ? "destructive"
+                                        : "outline"
+                                    }
+                                  >
+                                    {limits.disabled
+                                      ? t("api_keys.limits.statusDisabled")
+                                      : usageOver
+                                        ? t(
+                                            "api_keys.limits.statusQuotaExceeded",
+                                          )
+                                        : t("api_keys.limits.statusActive")}
+                                  </Badge>
+                                </td>
+                                <td>
+                                  {usage && usage.token_limit > 0 ? (
+                                    <div className="flex w-40 flex-col gap-1">
+                                      <div className="flex justify-between text-xs text-muted-foreground tabular-nums">
+                                        <span>
+                                          {formatTokenQuota(usage.used)} /{" "}
+                                          {formatTokenQuota(usage.token_limit)}
+                                        </span>
+                                        <span>{Math.round(usagePercent)}%</span>
+                                      </div>
+                                      <div className="h-1.5 w-full overflow-hidden rounded-full bg-primary/20">
+                                        <div
+                                          className={cn(
+                                            "h-full",
+                                            usageOver
+                                              ? "bg-destructive"
+                                              : usageWarn
+                                                ? "bg-amber-500"
+                                                : "bg-primary",
+                                          )}
+                                          style={{
+                                            width: `${usagePercent}%`,
+                                          }}
+                                        />
+                                      </div>
+                                    </div>
+                                  ) : (
+                                    <span className="text-muted-foreground">
+                                      —
+                                    </span>
+                                  )}
+                                </td>
+                                <td>
+                                  {rateSummary(limits).length > 0 ? (
+                                    <span className="text-xs text-muted-foreground">
+                                      {rateSummary(limits).join(" · ")}
+                                    </span>
+                                  ) : (
+                                    <span className="text-muted-foreground">
+                                      —
+                                    </span>
+                                  )}
+                                </td>
+                                <td>
+                                  <ModelsCell
+                                    models={limits.allowed_models ?? []}
+                                    modelMap={modelMap}
+                                    scopedWorkspace={scoped}
+                                  />
+                                </td>
+                                <td>
+                                  <Timestamp
+                                    timestamp={key.metadata.creation_timestamp}
+                                    relative
+                                  />
+                                </td>
+                                <td>
+                                  <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                      <Button variant="ghost" size="icon">
+                                        <MoreHorizontal className="h-4 w-4" />
+                                      </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent align="end">
+                                      <DropdownMenuItem
+                                        onClick={() =>
+                                          show("api_keys", key.id, "push", {
+                                            workspace: key.metadata.workspace,
+                                          })
+                                        }
+                                      >
+                                        <Pencil className="mr-2 h-4 w-4" />
+                                        Edit
+                                      </DropdownMenuItem>
+                                      <DropdownMenuItem
+                                        onClick={() =>
+                                          void (
+                                            limits.disabled
+                                              ? enable(key.id)
+                                              : disable(key.id)
+                                          ).then(refresh)
+                                        }
+                                      >
+                                        {limits.disabled ? (
+                                          <Power className="mr-2 h-4 w-4" />
+                                        ) : (
+                                          <PowerOff className="mr-2 h-4 w-4" />
+                                        )}
+                                        {limits.disabled ? "Enable" : "Disable"}
+                                      </DropdownMenuItem>
+                                      <DropdownMenuItem
+                                        onClick={() => {
+                                          setSelected(new Set([key.id]));
+                                          setTarget("");
+                                          setMoveOpen(true);
+                                        }}
+                                      >
+                                        <FolderInput className="mr-2 h-4 w-4" />
+                                        Move to Project
+                                      </DropdownMenuItem>
+                                      <DropdownMenuItem
+                                        className="text-destructive"
+                                        onClick={() => {
+                                          setActionError("");
+                                          setDeletingKeys([key]);
+                                        }}
+                                      >
+                                        <Trash2 className="mr-2 h-4 w-4" />
+                                        Delete
+                                      </DropdownMenuItem>
+                                    </DropdownMenuContent>
+                                  </DropdownMenu>
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-4 flex flex-col items-center justify-between gap-4 text-sm text-muted-foreground sm:flex-row">
+        <span>
+          {groupsQuery.data[0]?.total_projects ?? 0} Projects,{" "}
+          {groupsQuery.totalApiKeys} API keys
+        </span>
+        <div className="flex flex-wrap items-center justify-center gap-6">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-foreground">
+              {t("table.pagination.rowsPerPage")}
+            </span>
+            <Select
+              value={String(pageSize)}
+              onValueChange={(value) => {
+                setPageSize(Number(value));
+                setPage(1);
+              }}
+            >
+              <SelectTrigger className="h-8 w-[70px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {[10, 20, 30, 40, 50].map((size) => (
+                  <SelectItem key={size} value={String(size)}>
+                    {size}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <span className="font-medium text-foreground">
+            {t("table.pagination.page", { current: page, total: pageCount })}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              disabled={page <= 1}
+              onClick={() => setPage(1)}
+              aria-label={t("table.pagination.goToFirstPage")}
+            >
+              <ChevronsLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+              aria-label={t("table.pagination.goToPreviousPage")}
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              disabled={page >= pageCount}
+              onClick={() => setPage((p) => p + 1)}
+              aria-label={t("table.pagination.goToNextPage")}
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              disabled={page >= pageCount}
+              onClick={() => setPage(pageCount)}
+              aria-label={t("table.pagination.goToLastPage")}
+            >
+              <ChevronsRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
     </ListPage>
   );
 };

--- a/src/pages/api-keys/show.tsx
+++ b/src/pages/api-keys/show.tsx
@@ -1,7 +1,11 @@
-import { useShow } from "@refinedev/core";
+import { useNavigation, useShow } from "@refinedev/core";
+import { ArrowLeft } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
 import { ApiKeyLimitsCard } from "@/domains/api-key/components/ApiKeyLimitsCard";
 import { ApiKeyPerformanceCard } from "@/domains/api-key/components/ApiKeyPerformanceCard";
+import { useApiKeyProjects } from "@/domains/api-key/hooks/use-api-key-projects";
+import type { ApiKey } from "@/domains/api-key/types";
 import { MetadataDisclosure } from "@/foundation/components/MetadataDisclosure";
 import { MetadataTimestampMeta } from "@/foundation/components/MetadataTimestampMeta";
 import { ShowPage } from "@/foundation/components/ShowPage";
@@ -12,6 +16,15 @@ export const ApiKeysShow = () => {
     query: { data, isLoading },
   } = useShow();
   const record = data?.data;
+  const { list } = useNavigation();
+  const {
+    data: projects,
+    isLoading: isProjectLoading,
+    error: projectError,
+  } = useApiKeyProjects(record?.metadata.workspace);
+  const project = projects.find(
+    (candidate) => candidate.id === record?.project_id,
+  );
 
   if (isLoading) {
     return <div>{t("api_keys.messages.loading")}</div>;
@@ -23,13 +36,37 @@ export const ApiKeysShow = () => {
 
   return (
     <div className="w-full h-full">
-      <ShowPage record={record} canEdit={false} showCurrentBreadcrumb={false}>
+      <Button
+        variant="ghost"
+        className="mb-2 px-0"
+        onClick={() => list("api_keys")}
+      >
+        <ArrowLeft className="mr-2 h-4 w-4" /> Back to Projects
+      </Button>
+      <ShowPage
+        record={record as ApiKey}
+        canEdit={false}
+        showCurrentBreadcrumb={false}
+      >
         <ShowPage.ObjectHeader
           title={record.metadata.name}
           description={
             <span className="inline-flex flex-wrap items-center gap-x-4 gap-y-1">
+              <ShowPage.Meta label={t("common.fields.workspace")}>
+                {record.metadata.workspace ?? "-"}
+              </ShowPage.Meta>
+              <ShowPage.Meta label="Description">
+                {record.description || "-"}
+              </ShowPage.Meta>
               <ShowPage.Meta label={t("api_keys.fields.usage")}>
                 {record.status?.usage ?? "-"}
+              </ShowPage.Meta>
+              <ShowPage.Meta label="Project">
+                {isProjectLoading
+                  ? "Loading..."
+                  : projectError
+                    ? "Unable to load Project"
+                    : (project?.name ?? "-")}
               </ShowPage.Meta>
               <MetadataTimestampMeta metadata={record.metadata} />
             </span>
@@ -45,6 +82,7 @@ export const ApiKeysShow = () => {
             <ApiKeyLimitsCard
               apiKeyId={String(record.id)}
               workspace={record.metadata.workspace}
+              projectId={record.project_id}
             />
           </div>
         )}


### PR DESCRIPTION
## Issue

NEU-682, NEU-683, NEU-684

## Summary

Deliver the API key Project UI for project-aware creation and editing, grouped browsing and filtering, and single or bulk API key moves.

## Changes

- Add reusable Project picker, project/group query hooks, and project-aware API key types.
- Add Project selection and inline creation to API key creation and limits editing flows.
- Replace the flat API key list with project-grouped search, filters, totals, pagination, usage, and lifecycle actions.
- Add single and bulk move workflows with validation and feedback.
- Surface Project metadata on API key details and update shared delete/data-provider behavior.
- Add focused tests for the Project picker, create errors, batch deletion, and data-provider behavior.

## Dependency

Requires neutree-ai/neutree#561 for the API key Project schema and RPC contracts.

## Test Plan

Automated UI validation was not rerun during this PR creation pass.