### PR TITLE
fix: align VRAM badge verdict with its displayed rounding

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -322,7 +322,7 @@
   "src/foundation/recipe/compose.ts": "c0cfe4da9024b651f47e4773318641d9",
   "src/foundation/recipe/normalize.ts": "37973e33217df534c07c56a63d07c1ed",
   "src/foundation/recipe/types.ts": "6b11c3319d89fc7158795a4dc2bfe661",
-  "src/foundation/recipe/vram.ts": "7cdf1eda25921556f7991b37ba5d8a16",
+  "src/foundation/recipe/vram.ts": "f88e860dfad69d93ddf339f47e663faa",
   "src/domains/model-catalog/components/ModelInfoBadges.tsx": "1608ced09a1c2236d30ee644f974dda2",
   "src/domains/endpoint/components/ComposePreview.tsx": "ab9fb6ee6b9dfed17c774cbf0f6dd823",
   "src/domains/endpoint/components/FeaturePicker.tsx": "fb93b3df12379521129bd4c758795a9e",

--- a/src/foundation/recipe/vram.test.ts
+++ b/src/foundation/recipe/vram.test.ts
@@ -62,6 +62,64 @@ describe("checkVRAM", () => {
     const r = checkVRAM({ acceleratorProduct: "H100", gpuCount: 1 });
     expect(r.kind).toBe("unknown");
   });
+
+  it("judges on the rounded total the badge displays", () => {
+    // The badge renders formatGb(totalGb), rounded to one decimal — the UI's
+    // rule for available resources (cluster panels use toFixed(1)). The check
+    // compares that rounded total against the requirement, so a verdict can
+    // never contradict what the user sees. Notably 2 × 23.98828125 GiB =
+    // 47.9765625 GiB rounds to 48: a pair of 24 GB cards meets a 48 GB
+    // requirement, fixing the false "insufficient" verdict.
+    const cases: Array<[number, number, "sufficient" | "insufficient"]> = [
+      [47.9, 48, "insufficient"], // rounds to 47.9 < 48
+      [47.95, 48, "sufficient"], // rounds to 48 (half-up) == 48
+      [47.9765625, 48, "sufficient"], // 2×23.98828125 GiB RTX-4090 case
+      [47.5, 48, "insufficient"], // rounds to 47.5 < 48
+      [48.0001, 48, "sufficient"], // rounds to 48 == 48
+    ];
+    for (const [available, required, expected] of cases) {
+      const r = checkVRAM({
+        acceleratorProduct: "NVIDIA-GeForce-RTX-4090",
+        perGpuGb: available,
+        gpuCount: 1,
+        requiredGb: required,
+      });
+      expect(r.kind, `avail=${available} req=${required}`).toBe(expected);
+    }
+  });
+
+  it("compares the requirement as declared, not rounded", () => {
+    // Only the available total is rounded to display precision; the
+    // requirement is used verbatim. 48.04 GiB required stays 48.04 (not 48.0),
+    // so 48.03 GiB available (rounds to 48.0) is insufficient even though
+    // formatGb would show both as "48".
+    expect(
+      checkVRAM({
+        acceleratorProduct: "X",
+        perGpuGb: 48.03,
+        gpuCount: 1,
+        requiredGb: 48.04,
+      }).kind,
+    ).toBe("insufficient");
+    // A fractional requirement near a .1 boundary: 48.06 rounds to 48.1 which
+    // meets 48.09 as declared; 48.04 rounds to 48.0 which does not.
+    expect(
+      checkVRAM({
+        acceleratorProduct: "X",
+        perGpuGb: 48.06,
+        gpuCount: 1,
+        requiredGb: 48.09,
+      }).kind,
+    ).toBe("sufficient");
+    expect(
+      checkVRAM({
+        acceleratorProduct: "X",
+        perGpuGb: 48.04,
+        gpuCount: 1,
+        requiredGb: 48.09,
+      }).kind,
+    ).toBe("insufficient");
+  });
 });
 
 describe("formatGb", () => {
@@ -74,6 +132,14 @@ describe("formatGb", () => {
   it("keeps whole numbers clean (no trailing .0)", () => {
     expect(formatGb(140)).toBe("140");
     expect(formatGb(16)).toBe("16");
+    expect(formatGb(48)).toBe("48");
+  });
+
+  it("rounds a just-sufficient value up to show equal numbers (48.0001 -> 48)", () => {
+    // 48.0001 GiB is sufficient for a 48 GB floor; rounding shows "48 GB
+    // available, 48 GB required" beside a green check, which reads as "just
+    // enough" — consistent with the check judging on the same rounded value.
+    expect(formatGb(48.0001)).toBe("48");
   });
 
   it("preserves a meaningful single decimal", () => {

--- a/src/foundation/recipe/vram.ts
+++ b/src/foundation/recipe/vram.ts
@@ -112,8 +112,19 @@ export function checkVRAM(opts: {
     return { kind: "unknown", reason: "no GPUs selected yet" };
   }
   const totalGb = perGpu * count;
+  // The badge renders the same value it judges on: formatGb rounds the
+  // available total to one decimal (the UI's rule for available resources,
+  // e.g. cluster panels use toFixed(1)), and the check compares that rounded
+  // total against the requirement so the verdict always matches what the user
+  // sees. Rounding the available total to display precision means 2 ×
+  // 23.98828125 GiB = 47.9765625 GiB counts as meeting a 48 GB requirement —
+  // a pair of 24 GB cards genuinely provides that much, and showing a false
+  // "insufficient" was the bug. The requirement is compared as declared, not
+  // rounded; recipe vram_minimum_gb values are integers, so rounding it would
+  // be a no-op anyway.
+  const roundedTotalGb = Math.round(totalGb * 10) / 10;
   return {
-    kind: totalGb >= opts.requiredGb ? "sufficient" : "insufficient",
+    kind: roundedTotalGb >= opts.requiredGb ? "sufficient" : "insufficient",
     perGpuGb: perGpu,
     gpuCount: count,
     totalGb,
@@ -123,9 +134,11 @@ export function checkVRAM(opts: {
 
 // Format a VRAM amount (GB) for display. Live per-GPU memory reported by a
 // cluster is often fractional (e.g. 44.988 GiB × 2 = 89.9765625), which reads
-// as noise in the badge. Round to at most one decimal and drop a trailing
-// ".0" so whole numbers stay clean. Display-only — the sufficiency comparison
-// in checkVRAM still uses the exact value.
+// as noise in the badge. Round to one decimal and drop a trailing ".0" so whole
+// numbers stay clean. Rounding matches how the rest of the UI shows available
+// resources (cluster panels use toFixed(1)). Display-only — checkVRAM rounds
+// the available total the same way before comparing, so the verdict can never
+// contradict what the badge renders.
 export function formatGb(gb: number): string {
   const rounded = Math.round(gb * 10) / 10;
   return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);


### PR DESCRIPTION
## Problem

Creating an Endpoint with the fp8 variant of `qwen3-6-27b-test-4` on cluster `fake-k8s-rtx4090` (2x RTX-4090, 24564 MiB each) produced a VRAM badge showing:

```
Insufficient VRAM: 48 GB available, 48 GB required
```

The displayed value reads as "enough", but the verdict was Insufficient — display and determination contradicted each other. Root cause (as documented in NEU-586): `checkVRAM` compared the **exact** available total (`2 x 23.98828125 = 47.9765625 GiB < 48`) while `formatGb` rounded the display to one decimal (`47.9765625` -> `"48"`), so a genuinely-sufficient pair of 24 GB cards was flagged insufficient while the badge showed 48 = 48.

## Changes

- `src/foundation/recipe/vram.ts`:
  - `checkVRAM` now rounds the **available total** to one decimal (`Math.round(x*10)/10`) **before** comparing against the requirement — the same rounding `formatGb` applies for display, and the UI's existing rule for showing available resources (cluster panels use `toFixed(1)`). Display and verdict can no longer disagree, and `2 x 23.98828125 GiB` correctly counts as meeting a 48 GB requirement.
  - The requirement is compared **as declared, not rounded** (recipe `vram_minimum_gb` values are integers, so rounding it would be a no-op).
  - `formatGb` stays round-to-nearest; the consistency lives in the comparison, not the display.
- `src/foundation/recipe/vram.test.ts`: verdict-vs-display consistency table (incl. the NEU-586 boundary now `sufficient`), a raw-requirement pinning case (`48.03` vs `48.04` as-declared -> insufficient), and restored `formatGb` round assertions.

## Tests

- `npx vitest run src/foundation/recipe/vram.test.ts` -> 13/13 pass (RED observed first: `47.95 -> "48"` was still `insufficient` under the exact-value comparison; `48.03` vs `48.04` was `sufficient` when the requirement was wrongly rounded).
- `npm run typecheck` (`tsgo -b`) -> pass; `biome lint` on changed files -> clean.
- Full suite: 1401 pass, 2 failures in `src/foundation/components/Timestamp.render.test.tsx` — pre-existing and timezone-dependent (`setSystemTime(2026-08-11T12:00:00Z)` against local-time assertions), present on `main`, untouched by this change.
- No e2e run: classified Trivial (single-file display/logic-consistency fix). Existing `model-catalogs-recipe-gpu.spec.ts` badge cases assert `data-state` and verdict text with non-boundary values, so they are unaffected.

Closes NEU-586