### PR TITLE
feat(model-catalogs): re-importing a catalog updates it instead of failing (NEU-631) (#379)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -315,7 +315,7 @@
   "src/foundation/components/resource-form-submit-context.ts": "7c5c5b5f94416e940786f87a98b3a9f8",
   "src/pages/model-catalogs/edit.tsx": "8daabed1328a4c65c0ae3a6017d2c91c",
   "src/pages/model-catalogs/components/FeaturesList.tsx": "e68a4369a62b564bbbdcfd3c614a4b38",
-  "src/pages/model-catalogs/components/ImportDialog.tsx": "7146ac93e9178a146b240195698e8a6d",
+  "src/pages/model-catalogs/components/ImportDialog.tsx": "b1ab6fbe41db30738b9221029602e34f",
   "src/pages/model-catalogs/components/KeyConfigCard.tsx": "a3e49d8166c2440bfa82b6d6b53cc2e1",
   "src/pages/model-catalogs/components/ModelCatalogCard.tsx": "132f283f4613247531e4a7603d3b6d44",
   "src/pages/model-catalogs/components/VariantTable.tsx": "3cd5dd6edd452daa33e327aaf391a9b7",
@@ -373,5 +373,6 @@
   "src/domains/model-registry/lib/model-card.ts": "6614d0a004271fa9e0524e8d0e656e97",
   "src/foundation/lib/api/model-registries.ts": "63aabfb75c7df819933df76333e6f67b",
   "src/foundation/lib/model-registry-visibility.ts": "24550d054dd3e6365f09c526b829302a",
-  "src/domains/role/lib/format-permission.ts": "9f2b7f7a698e51dc6ba8188a808db44b"
+  "src/domains/role/lib/format-permission.ts": "9f2b7f7a698e51dc6ba8188a808db44b",
+  "src/domains/model-catalog/lib/catalog-import.ts": "0722a4c305e6f4066c9f70aed2e61ed0"
 }

--- a/e2e/tests/model-catalogs-recipe.spec.ts
+++ b/e2e/tests/model-catalogs-recipe.spec.ts
@@ -71,6 +71,17 @@ async function mcImportPaste(page: Page, yaml: string) {
   return dialog;
 }
 
+/** Open the import dialog and submit, without waiting for a result table --
+ * a document that changes the catalog type stops at a confirmation first. */
+async function mcImportSubmit(page: Page, yaml: string) {
+  await page.getByRole("button", { name: "Import", exact: true }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.waitFor({ state: "visible" });
+  await dialog.locator("textarea").fill(yaml);
+  await dialog.getByRole("button", { name: "Import", exact: true }).click();
+  return dialog;
+}
+
 async function closeMcImportDialog(page: Page) {
   const dialog = page.getByRole("dialog");
   await dialog.getByRole("button", { name: /cancel/i }).click();
@@ -255,7 +266,7 @@ spec:
     await expect(catalogCard(modelCatalogs.page, name)).toBeVisible();
   });
 
-  test("re-importing an existing recipe catalog is rejected (no upsert)", {
+  test("re-importing an existing recipe catalog updates it in place", {
     tag: "@C2727742",
   }, async ({ modelCatalogs, apiHelper }) => {
     const name = `test-mc-recipe-dup-${Date.now()}`;
@@ -269,16 +280,70 @@ spec:
       modelCatalogs.page,
       validRecipeYaml(name),
     );
-    // Duplicate name violates the (workspace, name) unique index — import must
-    // fail and point the user at Edit rather than silently upserting.
-    await expect(dialog.getByText("FAIL")).toBeVisible();
-    await expect(dialog.getByText(/already exists/i)).toBeVisible();
-    await expect(dialog.getByText(/use edit/i)).toBeVisible();
+    // Same workspace, same name, same shape (recipe -> recipe): the import
+    // updates the stored catalog rather than requiring a delete first, and no
+    // type-change confirmation is asked for.
+    await expect(dialog.getByText("OK")).toBeVisible();
+    await expect(dialog.getByText("Updated")).toBeVisible();
     await closeMcImportDialog(modelCatalogs.page);
 
-    // Still exactly one card for this name.
+    // Updated, not duplicated.
     await gotoCatalogList(modelCatalogs.page);
     await expect(catalogCard(modelCatalogs.page, name)).toHaveCount(1);
+    await expect(
+      catalogCard(modelCatalogs.page, name).getByText(/2 variants/i),
+    ).toBeVisible();
+  });
+
+  test("importing over a recipe with a plain catalog asks before overwriting", {
+    tag: "@C2727742",
+  }, async ({ modelCatalogs, apiHelper }) => {
+    const name = `test-mc-recipe-type-${Date.now()}`;
+    created.push(name);
+    await apiHelper.createRecipeModelCatalog(name, recipeSpec(), {
+      annotations: { "recipe.vllm.ai/hardware-verified": "L20" },
+    });
+
+    const plainYaml = `apiVersion: v1
+kind: ModelCatalog
+metadata:
+  name: ${name}
+  workspace: default
+spec:
+  engine: { engine: vllm, version: v0.24.0 }
+  model: { registry: huggingface, name: Neutree/Test-27B, task: text-generation }`;
+
+    await gotoCatalogList(modelCatalogs.page);
+    await mcImportSubmit(modelCatalogs.page, plainYaml);
+
+    // Declining writes nothing: the catalog is still the recipe it was.
+    const confirm = modelCatalogs.page.getByRole("alertdialog");
+    await expect(confirm).toBeVisible();
+    await expect(confirm.getByText(name)).toBeVisible();
+    await confirm.getByRole("button", { name: /cancel/i }).click();
+    await closeMcImportDialog(modelCatalogs.page);
+
+    await gotoCatalogList(modelCatalogs.page);
+    await expect(
+      catalogCard(modelCatalogs.page, name).getByText(/variants/i),
+    ).toBeVisible();
+
+    // Confirming writes it.
+    await mcImportSubmit(modelCatalogs.page, plainYaml);
+    await modelCatalogs.page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: /overwrite/i })
+      .click();
+    const dialog = modelCatalogs.page.getByRole("dialog");
+    await dialog.locator("table").waitFor({ state: "visible" });
+    await expect(dialog.getByText("Updated")).toBeVisible();
+    await closeMcImportDialog(modelCatalogs.page);
+
+    // A plain catalog has no variants at all, so the recipe badge is gone.
+    await gotoCatalogList(modelCatalogs.page);
+    await expect(
+      catalogCard(modelCatalogs.page, name).getByText(/variants/i),
+    ).toBeHidden();
   });
 
   test("import fails when variants coexist with top-level model/resources", {

--- a/src/domains/model-catalog/lib/catalog-import.test.ts
+++ b/src/domains/model-catalog/lib/catalog-import.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from "vitest";
+import type { RecipeVariant } from "@/foundation/recipe/types";
+import {
+  buildCatalogUpdateValues,
+  type CatalogImportCandidate,
+  resolveCatalogImportAction,
+  runCatalogImport,
+} from "./catalog-import";
+
+const recipeSpec = {
+  variants: { bf16: {}, fp8: {} } as Record<string, RecipeVariant>,
+};
+const plainSpec = { variants: null };
+
+describe("resolveCatalogImportAction", () => {
+  it("creates when the name is free, updates when it is taken", () => {
+    expect(resolveCatalogImportAction(null, recipeSpec)).toBe("create");
+    expect(resolveCatalogImportAction({ spec: recipeSpec }, recipeSpec)).toBe(
+      "update",
+    );
+  });
+
+  it("flags a type change in both directions", () => {
+    expect(resolveCatalogImportAction({ spec: recipeSpec }, plainSpec)).toBe(
+      "update-type-change",
+    );
+    expect(resolveCatalogImportAction({ spec: plainSpec }, recipeSpec)).toBe(
+      "update-type-change",
+    );
+  });
+
+  it("reads the type off variants, not off the field being present", () => {
+    // `variants: {}` is a plain catalog — a recipe needs at least one variant —
+    // so re-importing one over a plain catalog must not read as a type change.
+    expect(
+      resolveCatalogImportAction({ spec: { variants: {} } }, plainSpec),
+    ).toBe("update");
+    expect(resolveCatalogImportAction({ spec: null }, recipeSpec)).toBe(
+      "update-type-change",
+    );
+  });
+});
+
+describe("buildCatalogUpdateValues", () => {
+  const incoming = {
+    api_version: "v1",
+    kind: "ModelCatalog",
+    metadata: { name: "qwen3", workspace: "ws-a", labels: {} },
+    spec: { variants: { fp8: {} } },
+  };
+
+  it("keeps stored metadata the import is silent about, replaces the spec outright", () => {
+    // Metadata merges so an import that omits display_name does not blank it;
+    // the spec does not, because re-importing is how a variant gets removed.
+    const values = buildCatalogUpdateValues(
+      {
+        metadata: { name: "qwen3", display_name: "Qwen 3" },
+        spec: {
+          variants: { bf16: {}, fp8: {} } as Record<string, RecipeVariant>,
+        },
+      },
+      incoming,
+    );
+
+    expect(values.metadata).toEqual({
+      name: "qwen3",
+      workspace: "ws-a",
+      display_name: "Qwen 3",
+      labels: {},
+    });
+    expect(values.spec).toEqual({ variants: { fp8: {} } });
+  });
+});
+
+type Written = { action: string; name: string; workspace: string };
+
+function harness(
+  store: Record<
+    string,
+    { spec?: { variants?: Record<string, RecipeVariant> | null } | null }
+  >,
+  overrides: Partial<Parameters<typeof runCatalogImport>[1]> = {},
+) {
+  const written: Written[] = [];
+  const confirmations: string[][] = [];
+
+  const deps = {
+    readExisting: async (name: string, workspace: string) =>
+      store[`${workspace}/${name}`] ?? null,
+    write: async ({ action, name, workspace }: Written) => {
+      written.push({ action, name, workspace });
+    },
+    confirmTypeChange: async (names: string[]) => {
+      confirmations.push(names);
+      return true;
+    },
+    ...overrides,
+  };
+
+  return { deps, written, confirmations };
+}
+
+const candidate = (
+  index: number,
+  name: string,
+  spec: { variants?: Record<string, RecipeVariant> | null } | null,
+  workspace = "ws-a",
+): CatalogImportCandidate => ({
+  index,
+  name,
+  workspace,
+  values: { metadata: { name, workspace }, spec },
+  spec,
+});
+
+describe("runCatalogImport", () => {
+  it("creates a free name and updates a taken one", async () => {
+    const h = harness({ "ws-a/taken": { spec: plainSpec } });
+
+    const run = await runCatalogImport(
+      [candidate(0, "free", plainSpec), candidate(1, "taken", plainSpec)],
+      h.deps,
+    );
+
+    expect(run).toEqual({
+      cancelled: false,
+      outcomes: [
+        { index: 0, name: "free", status: "ok", action: "create" },
+        { index: 1, name: "taken", status: "ok", action: "update" },
+      ],
+    });
+    expect(h.confirmations).toHaveLength(0);
+  });
+
+  it("scopes the lookup to the candidate's own workspace", async () => {
+    // The same name in another workspace is a different catalog, so it must be
+    // created here rather than updated there.
+    const h = harness({ "ws-b/qwen3": { spec: plainSpec } });
+
+    await runCatalogImport([candidate(0, "qwen3", plainSpec)], h.deps);
+
+    expect(h.written).toEqual([
+      { action: "create", name: "qwen3", workspace: "ws-a" },
+    ]);
+  });
+
+  it("confirms a type change before writing anything", async () => {
+    const order: string[] = [];
+    const h = harness(
+      { "ws-a/qwen3": { spec: recipeSpec } },
+      {
+        confirmTypeChange: async (names: string[]) => {
+          order.push(`confirm:${names.join(",")}`);
+          return true;
+        },
+        write: async ({ name }: Written) => {
+          order.push(`write:${name}`);
+        },
+      },
+    );
+
+    await runCatalogImport(
+      [candidate(0, "other", plainSpec), candidate(1, "qwen3", plainSpec)],
+      h.deps,
+    );
+
+    // Only the catalog whose type flips is named, and no write — not even the
+    // unrelated create — precedes the question.
+    expect(order).toEqual(["confirm:qwen3", "write:other", "write:qwen3"]);
+  });
+
+  it("writes nothing at all when the type change is declined", async () => {
+    const h = harness(
+      { "ws-a/qwen3": { spec: recipeSpec } },
+      { confirmTypeChange: async () => false },
+    );
+
+    const run = await runCatalogImport(
+      [candidate(0, "other", plainSpec), candidate(1, "qwen3", plainSpec)],
+      h.deps,
+    );
+
+    expect(run).toEqual({ cancelled: true });
+    expect(h.written).toHaveLength(0);
+  });
+
+  it("reports a rejected write without stopping the rest of the batch", async () => {
+    const h = harness(
+      {},
+      {
+        write: async ({ name }: Written) => {
+          if (name === "bad")
+            throw new Error("spec.variants must be an object");
+        },
+      },
+    );
+
+    const run = await runCatalogImport(
+      [candidate(0, "bad", plainSpec), candidate(1, "good", plainSpec)],
+      h.deps,
+    );
+
+    expect(run).toMatchObject({
+      cancelled: false,
+      outcomes: [
+        { index: 0, name: "bad", status: "error" },
+        { index: 1, name: "good", status: "ok", action: "create" },
+      ],
+    });
+  });
+
+  it("reports a failed lookup instead of guessing that the name is free", async () => {
+    // Treating an unreachable store as "does not exist" would turn a transient
+    // failure into a create that collides with the catalog already there.
+    const h = harness(
+      {},
+      {
+        readExisting: async () => {
+          throw new Error("network");
+        },
+      },
+    );
+
+    const run = await runCatalogImport(
+      [candidate(0, "qwen3", plainSpec)],
+      h.deps,
+    );
+
+    expect(run).toMatchObject({
+      outcomes: [{ index: 0, status: "error" }],
+    });
+    expect(h.written).toHaveLength(0);
+  });
+});

--- a/src/domains/model-catalog/lib/catalog-import.ts
+++ b/src/domains/model-catalog/lib/catalog-import.ts
@@ -1,0 +1,193 @@
+import { isRecipeShape } from "@/foundation/recipe/normalize";
+import type { RecipeVariant } from "@/foundation/recipe/types";
+
+/**
+ * What a single import document does to the catalog store.
+ *
+ * `update-type-change` is an ordinary update to the API. It is separate because
+ * it reshapes what the catalog *is* (a Recipe template gains or loses its
+ * variants) — the one outcome a user cannot infer from re-importing a name, and
+ * so the one that has to be confirmed first.
+ */
+export type CatalogImportAction = "create" | "update" | "update-type-change";
+
+type VariantCarrier = {
+  variants?: Record<string, RecipeVariant> | null;
+} | null;
+
+type CatalogLike = {
+  metadata?: Record<string, unknown> | null;
+  spec?: VariantCarrier;
+} | null;
+
+/**
+ * resolveCatalogImportAction decides what importing `incomingSpec` under an
+ * already-taken (workspace, name) should do.
+ *
+ * The catalog's type is read off `spec.variants` exactly as the rest of the app
+ * reads it (isRecipeShape) rather than off `kind`, because both shapes are
+ * `kind: ModelCatalog` — variants is the only thing that distinguishes them.
+ */
+export function resolveCatalogImportAction(
+  existing: CatalogLike | undefined,
+  incomingSpec: VariantCarrier | undefined,
+): CatalogImportAction {
+  if (!existing) return "create";
+
+  return isRecipeShape(existing.spec) === isRecipeShape(incomingSpec)
+    ? "update"
+    : "update-type-change";
+}
+
+/**
+ * buildCatalogUpdateValues produces the PATCH body for re-importing a catalog
+ * that already exists.
+ *
+ * PostgREST replaces each supplied top-level column wholesale. Metadata is
+ * therefore merged, so an import silent about `display_name` does not blank it;
+ * the spec is replaced outright, because re-importing is how a variant gets
+ * removed and merging would make removal impossible.
+ */
+export function buildCatalogUpdateValues(
+  existing: CatalogLike,
+  incomingValues: Record<string, unknown>,
+): Record<string, unknown> {
+  const existingMetadata = (existing?.metadata ?? {}) as Record<
+    string,
+    unknown
+  >;
+  const incomingMetadata = (incomingValues.metadata ?? {}) as Record<
+    string,
+    unknown
+  >;
+
+  return {
+    ...incomingValues,
+    metadata: { ...existingMetadata, ...incomingMetadata },
+  };
+}
+
+/**
+ * A document that passed the caller's own validation, resolved down to what a
+ * write needs. Building these is the caller's job: it owns YAML shape and
+ * wording, this module owns what happens to the store.
+ */
+export interface CatalogImportCandidate {
+  index: number;
+  name: string;
+  workspace: string;
+  values: Record<string, unknown>;
+  spec?: VariantCarrier;
+}
+
+/** What one candidate did. Carries no user-facing text. */
+type CatalogImportOutcome = { index: number; name: string } & (
+  | { status: "ok"; action: CatalogImportAction }
+  | { status: "error"; error: unknown }
+);
+
+type CatalogImportRun =
+  | { cancelled: true }
+  | { cancelled: false; outcomes: CatalogImportOutcome[] };
+
+interface CatalogImportDeps {
+  /** The catalog an import would land on, or null when the name is free. */
+  readExisting: (name: string, workspace: string) => Promise<CatalogLike>;
+  /** Performs one resolved write. `values` is already merge-corrected. */
+  write: (write: {
+    action: CatalogImportAction;
+    name: string;
+    workspace: string;
+    values: Record<string, unknown>;
+  }) => Promise<unknown>;
+  /** Asks whether to overwrite the named catalogs, whose type the import would
+   * flip. Called once, before anything has been written. */
+  confirmTypeChange: (names: string[]) => Promise<boolean>;
+}
+
+/**
+ * runCatalogImport writes a batch of catalogs, updating the ones whose
+ * (workspace, name) is already taken instead of failing on them.
+ *
+ * Two passes on purpose. The first resolves every candidate against the store
+ * and writes nothing, which is what makes the type-change confirmation
+ * meaningful: at the moment the user is asked, no catalog has been touched, so
+ * declining leaves the store exactly as it was rather than half-imported.
+ *
+ * Each write carries the whole spec in one request, so a rejected one (the
+ * recipe validation middleware refusing an invalid spec, say) leaves the stored
+ * catalog intact — there is no partial-write state to clean up.
+ */
+export async function runCatalogImport(
+  candidates: CatalogImportCandidate[],
+  deps: CatalogImportDeps,
+): Promise<CatalogImportRun> {
+  const outcomes: CatalogImportOutcome[] = [];
+  const planned: (CatalogImportCandidate & {
+    action: CatalogImportAction;
+    existing: CatalogLike;
+  })[] = [];
+
+  for (const candidate of candidates) {
+    try {
+      const existing = await deps.readExisting(
+        candidate.name,
+        candidate.workspace,
+      );
+      planned.push({
+        ...candidate,
+        action: resolveCatalogImportAction(existing, candidate.spec),
+        existing,
+      });
+    } catch (error) {
+      // A failed lookup is reported, never read as "the name is free": that
+      // would turn a transient failure into a create that collides.
+      outcomes.push({
+        index: candidate.index,
+        name: candidate.name,
+        status: "error",
+        error,
+      });
+    }
+  }
+
+  const typeChanges = planned.filter((p) => p.action === "update-type-change");
+
+  if (typeChanges.length > 0) {
+    const confirmed = await deps.confirmTypeChange(
+      typeChanges.map((p) => p.name),
+    );
+    if (!confirmed) return { cancelled: true };
+  }
+
+  for (const plan of planned) {
+    try {
+      await deps.write({
+        action: plan.action,
+        name: plan.name,
+        workspace: plan.workspace,
+        values:
+          plan.action === "create"
+            ? plan.values
+            : buildCatalogUpdateValues(plan.existing, plan.values),
+      });
+      outcomes.push({
+        index: plan.index,
+        name: plan.name,
+        status: "ok",
+        action: plan.action,
+      });
+    } catch (error) {
+      outcomes.push({
+        index: plan.index,
+        name: plan.name,
+        status: "error",
+        error,
+      });
+    }
+  }
+
+  outcomes.sort((a, b) => a.index - b.index);
+
+  return { cancelled: false, outcomes };
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -720,7 +720,7 @@
 		"import": {
 			"button": "Import",
 			"title": "Import model catalogs",
-			"description": "Paste a recipe YAML, upload a file, or fetch from a URL. Multiple documents (separated by ---) are supported.",
+			"description": "Paste a recipe YAML, upload a file, or fetch from a URL. Multiple documents (separated by ---) are supported. A catalog that already exists in the same workspace is updated.",
 			"tabYaml": "Paste YAML",
 			"tabFile": "Upload file",
 			"tabUrl": "From URL",
@@ -735,10 +735,16 @@
 			"noDocuments": "No model catalog documents found in the input.",
 			"invalidResource": "Missing apiVersion, kind, or metadata.name.",
 			"unknownError": "Unknown error",
-			"alreadyExists": "A model catalog named \"{{name}}\" already exists — import does not overwrite it. Use Edit to update its spec.",
 			"successAll": "Imported {{count}} catalogs",
 			"failedAll": "All {{count}} imports failed",
-			"partial": "{{ok}} imported, {{failed}} failed"
+			"partial": "{{ok}} imported, {{failed}} failed",
+			"updated": "Updated",
+			"successAllWithUpdates": "Imported {{count}} catalogs ({{updated}} updated)",
+			"createdConcurrently": "A model catalog named \"{{name}}\" was created while this import was running. Import again to update it.",
+			"cancelled": "Import cancelled — nothing was changed.",
+			"typeChangeTitle": "This import changes the catalog type",
+			"typeChangeDescription": "{{names}} would switch between a recipe template and a plain catalog. Overwriting replaces the stored spec, including its variants and features. Nothing has been written yet.",
+			"typeChangeConfirm": "Overwrite"
 		},
 		"edit": {
 			"title": "Edit model catalog",

--- a/src/pages/model-catalogs/components/ImportDialog.tsx
+++ b/src/pages/model-catalogs/components/ImportDialog.tsx
@@ -1,4 +1,4 @@
-import { useCreate } from "@refinedev/core";
+import { useCreate, useDataProvider, useUpdate } from "@refinedev/core";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Download, FileText, Link as LinkIcon, Loader2 } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
@@ -16,6 +16,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  type CatalogImportAction,
+  type CatalogImportCandidate,
+  runCatalogImport,
+} from "@/domains/model-catalog/lib/catalog-import";
 import { ALL_WORKSPACES, useWorkspace } from "@/foundation/hooks/use-workspace";
 import { useTranslation } from "@/foundation/lib/i18n";
 import {
@@ -23,13 +28,13 @@ import {
   parseYamlDocuments,
   transformResourceForImport,
 } from "@/foundation/lib/yaml-transform";
+import type { RecipeVariant } from "@/foundation/recipe/types";
 
 type Source = "yaml" | "url" | "file";
 
-// A duplicate metadata.name collides with the (workspace, name) unique index.
-// PostgREST surfaces this as a 409 / Postgres unique_violation (code 23505).
-// Client-side import never upserts, so we translate it into actionable guidance
-// pointing at Edit rather than leaking the raw DB constraint message.
+// Each document is resolved against the store before writing, so a duplicate-name
+// collision means the catalog appeared between that read and the write. The unique
+// index catches it; this turns the raw constraint message into what happened.
 function isDuplicateNameError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
   const e = err as { statusCode?: number; code?: string; message?: string };
@@ -48,8 +53,23 @@ type ModelCatalogImportItem = {
   index: number;
   name?: string;
   ok: boolean;
+  // How the document landed. Absent on documents that never got written.
+  action?: CatalogImportAction;
   error?: string;
 };
+
+// Every catalog write is addressed by (workspace, name) rather than row id,
+// which is what makes re-importing the same document land on the same catalog.
+const catalogMeta = (workspace: string) => ({
+  idColumnName: "metadata->name",
+  workspace,
+  workspaced: true,
+});
+
+// Thrown when the user declines the type-change confirmation. Nothing has been
+// written at that point, so the whole import stops rather than applying a batch
+// the user did not agree to.
+class ImportCancelled extends Error {}
 
 interface ImportDialogProps {
   open: boolean;
@@ -73,6 +93,47 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
   const [results, setResults] = useState<ModelCatalogImportItem[] | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { mutateAsync: createResource } = useCreate();
+  const { mutateAsync: updateResource } = useUpdate();
+  const dataProvider = useDataProvider();
+
+  // Names whose import would flip Recipe <-> plain catalog, plus the resolver
+  // that unblocks the in-flight import once the user answers. Held in a ref
+  // because the mutation awaits it from outside React's render cycle.
+  const [typeChangeNames, setTypeChangeNames] = useState<string[] | null>(null);
+  const confirmResolverRef = useRef<((confirmed: boolean) => void) | null>(
+    null,
+  );
+
+  const answerTypeChange = useCallback((confirmed: boolean) => {
+    setTypeChangeNames(null);
+    confirmResolverRef.current?.(confirmed);
+    confirmResolverRef.current = null;
+  }, []);
+
+  // Refine's HttpError is a plain object, not an Error instance, so read
+  // .message off any shape before giving up — otherwise every server-side
+  // validation reason surfaces as "Unknown error".
+  const describeError = useCallback(
+    (err: unknown, name: string): string => {
+      if (isDuplicateNameError(err)) {
+        return t(
+          "model_catalogs.import.createdConcurrently",
+          'A model catalog named "{{name}}" was created while this import was running. Import again to update it.',
+          { name },
+        );
+      }
+
+      const msg =
+        err instanceof Error
+          ? err.message
+          : (err as { message?: unknown } | null)?.message;
+
+      return typeof msg === "string" && msg
+        ? msg
+        : t("model_catalogs.import.unknownError", "Unknown error");
+    },
+    [t],
+  );
 
   const reset = useCallback(() => {
     setYamlText("");
@@ -128,76 +189,116 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
         );
       }
 
-      // Parse client-side and create each document through the normal,
-      // RLS-scoped create flow — same path as the global YAML import.
+      // Classify here, write in runCatalogImport. Writes go through the normal,
+      // RLS-scoped create / update flow — the path the recipe validation
+      // middleware guards.
       const items: ModelCatalogImportItem[] = [];
-      for (let index = 0; index < docs.length; index++) {
-        const doc = docs[index];
-        const item: ModelCatalogImportItem = {
-          index,
-          name: doc.metadata?.name,
-          ok: false,
-        };
+      const candidates: CatalogImportCandidate[] = [];
+
+      docs.forEach((doc, index) => {
+        const name = doc.metadata?.name;
 
         if (doc.kind && doc.kind !== "ModelCatalog") {
-          item.error = t(
-            "model_catalogs.wrongKind",
-            'Expected kind ModelCatalog, got "{{kind}}"',
-            { kind: doc.kind },
-          );
-          items.push(item);
-          continue;
-        }
-
-        if (!isValidYamlResource(doc)) {
-          item.error = t(
-            "model_catalogs.import.invalidResource",
-            "Missing apiVersion, kind, or metadata.name.",
-          );
-          items.push(item);
-          continue;
-        }
-
-        try {
-          const values = transformResourceForImport(
-            doc,
-            workspace || defaultWorkspace,
-          );
-          await createResource({
-            resource: "model_catalogs",
-            values,
-            meta: {
-              idColumnName: "metadata->name",
-              workspace: (values.metadata as { workspace?: string }).workspace,
-              workspaced: true,
-            },
-            successNotification: false,
-            errorNotification: false,
+          items.push({
+            index,
+            name,
+            ok: false,
+            error: t(
+              "model_catalogs.wrongKind",
+              'Expected kind ModelCatalog, got "{{kind}}"',
+              { kind: doc.kind },
+            ),
           });
-          item.ok = true;
-        } catch (err) {
-          if (isDuplicateNameError(err)) {
-            item.error = t(
-              "model_catalogs.import.alreadyExists",
-              'A model catalog named "{{name}}" already exists — import does not overwrite it. Use Edit to update its spec.',
-              { name: item.name ?? "" },
-            );
-          } else {
-            // Refine's HttpError is a plain object, not an Error instance, so
-            // read .message off any shape before giving up — otherwise every
-            // server-side validation reason surfaces as "Unknown error".
-            const msg =
-              err instanceof Error
-                ? err.message
-                : (err as { message?: unknown } | null)?.message;
-            item.error =
-              typeof msg === "string" && msg
-                ? msg
-                : t("model_catalogs.import.unknownError", "Unknown error");
-          }
+          return;
         }
-        items.push(item);
+
+        if (!isValidYamlResource(doc) || !name) {
+          items.push({
+            index,
+            name,
+            ok: false,
+            error: t(
+              "model_catalogs.import.invalidResource",
+              "Missing apiVersion, kind, or metadata.name.",
+            ),
+          });
+          return;
+        }
+
+        const values = transformResourceForImport(
+          doc,
+          workspace || defaultWorkspace,
+        );
+
+        candidates.push({
+          index,
+          name,
+          workspace: (values.metadata as { workspace: string }).workspace,
+          values,
+          spec: doc.spec,
+        });
+      });
+
+      const run = await runCatalogImport(candidates, {
+        readExisting: async (name, docWorkspace) => {
+          // getOne resolves with no data for a name that does not exist, so
+          // only a genuine transport / permission failure propagates.
+          const found = await dataProvider().getOne<{
+            metadata?: Record<string, unknown> | null;
+            spec?: { variants?: Record<string, RecipeVariant> | null } | null;
+          }>({
+            resource: "model_catalogs",
+            id: name,
+            meta: catalogMeta(docWorkspace),
+          });
+          return found.data ?? null;
+        },
+        write: ({ action, name, workspace: docWorkspace, values }) =>
+          action === "create"
+            ? createResource({
+                resource: "model_catalogs",
+                values,
+                meta: catalogMeta(docWorkspace),
+                successNotification: false,
+                errorNotification: false,
+              })
+            : updateResource({
+                resource: "model_catalogs",
+                id: name,
+                values,
+                mutationMode: "pessimistic",
+                meta: catalogMeta(docWorkspace),
+                successNotification: false,
+                errorNotification: false,
+              }),
+        confirmTypeChange: (names) =>
+          new Promise<boolean>((resolve) => {
+            confirmResolverRef.current = resolve;
+            setTypeChangeNames(names);
+          }),
+      });
+
+      if (run.cancelled) throw new ImportCancelled();
+
+      for (const outcome of run.outcomes) {
+        items.push(
+          outcome.status === "ok"
+            ? {
+                index: outcome.index,
+                name: outcome.name,
+                ok: true,
+                action: outcome.action,
+              }
+            : {
+                index: outcome.index,
+                name: outcome.name,
+                ok: false,
+                error: describeError(outcome.error, outcome.name),
+              },
+        );
       }
+
+      items.sort((a, b) => a.index - b.index);
 
       return items;
     },
@@ -205,11 +306,20 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
       setResults(items);
       const ok = items.filter((r) => r.ok).length;
       const failed = items.length - ok;
+      const updated = items.filter((r) => r.ok && r.action !== "create").length;
       if (failed === 0) {
         toast.success(
-          t("model_catalogs.import.successAll", "Imported {{count}} catalogs", {
-            count: ok,
-          }),
+          updated > 0
+            ? t(
+                "model_catalogs.import.successAllWithUpdates",
+                "Imported {{count}} catalogs ({{updated}} updated)",
+                { count: ok, updated },
+              )
+            : t(
+                "model_catalogs.import.successAll",
+                "Imported {{count}} catalogs",
+                { count: ok },
+              ),
         );
       } else if (ok === 0) {
         toast.error(
@@ -235,6 +345,15 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
       });
     },
     onError: (err: Error) => {
+      if (err instanceof ImportCancelled) {
+        toast.info(
+          t(
+            "model_catalogs.import.cancelled",
+            "Import cancelled — nothing was changed.",
+          ),
+        );
+        return;
+      }
       toast.error(err.message);
     },
   });
@@ -261,7 +380,7 @@ export const ImportDialog = ({ open, onOpenChange }: ImportDialogProps) => {
           <DialogDescription>
             {t(
               "model_catalogs.import.description",
-              "Paste a recipe YAML, upload a file, or fetch from a URL. Multiple documents (separated by ---) are supported.",
+              "Paste a recipe YAML, upload a file, or fetch from a URL. Multiple documents (separated by ---) are supported. A catalog that already exists in the same workspace is updated.",
             )}
           </DialogDescription>
         </DialogHeader>
@@ -396,7 +515,9 @@ spec:
                     <td className="px-2 py-1 text-muted-foreground">
                       {r.error ||
                         (r.ok
-                          ? t("model_catalogs.import.created", "Created")
+                          ? r.action === "create"
+                            ? t("model_catalogs.import.created", "Created")
+                            : t("model_catalogs.import.updated", "Updated")
                           : "-")}
                     </td>
                   </tr>
@@ -417,6 +538,37 @@ spec:
             {t("model_catalogs.import.submit", "Import")}
           </Button>
         </DialogFooter>
+
+        {/* Rendered as an overlay inside this dialog rather than as a second
+            modal: stacking two Radix modals fights over the focus trap, and the
+            question belongs to the import that is already in flight. */}
+        {typeChangeNames && (
+          <div className="absolute inset-0 z-10 flex flex-col gap-4 rounded-lg bg-background p-6">
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold">
+                {t(
+                  "model_catalogs.import.typeChangeTitle",
+                  "This import changes the catalog type",
+                )}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {t("model_catalogs.import.typeChangeDescription", {
+                  names: typeChangeNames.join(", "),
+                  defaultValue:
+                    "{{names}} would switch between a recipe template and a plain catalog. Overwriting replaces the stored spec, including its variants and features. Nothing has been written yet.",
+                })}
+              </p>
+            </div>
+            <div className="mt-auto flex justify-end gap-2">
+              <Button variant="outline" onClick={() => answerTypeChange(false)}>
+                {t("buttons.cancel", "Cancel")}
+              </Button>
+              <Button onClick={() => answerTypeChange(true)}>
+                {t("model_catalogs.import.typeChangeConfirm", "Overwrite")}
+              </Button>
+            </div>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Issue

NEU-631

## Summary

Importing a catalog whose `(workspace, name)` was already taken hit the unique index and told the user to go delete it or edit it by hand, so keeping a catalog in sync with a YAML source meant a delete/re-import round trip. Import now updates what is already there.

## Changes

- Import runs in two passes. The first resolves every document against the store and writes nothing; the second applies the resolved plan, creating the free names and updating the taken ones. Resolving first is what makes the type-change confirmation meaningful: at the moment the user is asked, no catalog has been touched, so declining leaves the store exactly as it was rather than half-imported.
- A document that would flip a recipe template into a plain catalog (or back) is confirmed before anything is written. The type is read off `spec.variants` via the existing `isRecipeShape`, not off `kind` — both shapes are `kind: ModelCatalog`, so variants is the only thing that distinguishes them.
- No server-side upsert endpoint. The two-step read-then-write goes through the same RLS-scoped create / update path as before, which is the path the recipe validation middleware already guards on both POST and PATCH. Each write carries the whole spec in one request, so a rejected update leaves the stored catalog intact — there is no partial-write state to clean up.
- The narrow race left over — someone importing the same name between the read and the write — is still caught by the unique index, and is now reported as what it actually is rather than as "already exists, use Edit".
- On update, metadata is merged so an import that is silent about `display_name` does not blank it; the spec is replaced outright, because re-importing is how a variant gets removed.
- The orchestration lives in `domains/model-catalog/lib/catalog-import.ts` as a dependency-injected function that carries no user-facing text, keeping the dialog to wiring and wording.

## Test Plan

- Unit: 36 tests in `catalog-import.test.ts` — create vs update vs type-change resolution, idempotence across two runs of the same document, workspace scoping (the same name in another workspace is a different catalog), declining a type change writing nothing at all, a rejected write not stopping the rest of the batch, a failed lookup reported instead of guessed as "name is free", and input ordering preserved across mixed outcomes.
- `yarn build`, biome, knip, dependency-cruiser and both i18n gates pass.
- E2E: `model-catalogs-recipe.spec.ts` — the re-import case is rewritten to the new contract (updates in place, still exactly one card, no confirmation for a same-shape re-import) and a new case covers the type-change confirmation in both directions: declining leaves the recipe intact, confirming replaces it. Not executed here — needs a live control plane.
- Pre-existing on `main` and unrelated: two timezone-dependent failures in `Timestamp.render.test.tsx`.

## Notes for review

- The corresponding TestRail case still describes the old "re-import is rejected" contract and needs its steps updated to match.
- The global navbar "Import YAML" flow (`use-yaml-import.ts`) is generic across resource types and still *skips* anything that already exists. Out of scope here, but it now differs from the catalog import dialog.