### PR TITLE
fix: show aggregate available GPU capacity

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -302,7 +302,7 @@
   "src/domains/endpoint/lib/resource-status.ts": "bacc15601bd3a76a8420ae4c9db09f06",
   "src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx": "6877323daf0538ae6bc24ae13274dc0c",
   "src/domains/cluster/lib/resource-status.ts": "9e759f014c4589740efe23ebdaf8bf74",
-  "src/foundation/lib/gpu-device-resources.ts": "59f46618ac8098f015314861e62e808a",
+  "src/foundation/lib/gpu-device-resources.ts": "803730d6bb3736003b593d6f5ffa4f7d",
   "src/foundation/components/GpuDeviceResourcesView.tsx": "c45ca47ecb48f65b774a1442155c1ffc",
   "src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.tsx": "370182322503b9721428b89f3aaffca0",
   "src/domains/cluster/lib/accelerator-virtualization.ts": "f03487cd61685f0a76f4d2c0f6a31fb6",

--- a/src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.test.tsx
+++ b/src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.test.tsx
@@ -64,11 +64,11 @@ const resourceInfo: ClusterResourceInfo = {
     memory: 192,
     accelerator_groups: {
       nvidia_gpu: {
-        quantity: 2,
+        quantity: 1.5,
         product_groups: null,
         products: {
           "Tesla-T4": {
-            quantity: 2,
+            quantity: 1.5,
           },
         },
       },
@@ -165,7 +165,7 @@ describe("EndpointClusterGpuResourcesPanel", () => {
     ).toBeTruthy();
   });
 
-  it("counts only fully free devices as usable when no request context exists", () => {
+  it("uses aggregate capacity in the summary and fully free devices in cards", () => {
     render(
       <EndpointClusterGpuResourcesPanel
         resourceInfo={resourceInfo}
@@ -176,6 +176,11 @@ describe("EndpointClusterGpuResourcesPanel", () => {
       />,
     );
 
+    const summaryCards = screen.getAllByTestId(
+      "endpoint-resource-summary-card",
+    );
+    const cardCountCard = findByExactLabel(summaryCards, "Card Count");
+    expect(within(cardCountCard).getByText("Free 1.5")).toBeTruthy();
     expect(
       screen.getByText((_, node) => node?.textContent === "Usable 1"),
     ).toBeTruthy();
@@ -362,13 +367,10 @@ describe("EndpointClusterGpuResourcesPanel", () => {
     const cardCountCard = findByExactLabel(summaryCards, "Card Count");
     const vramCard = findByExactLabel(summaryCards, "Memory Usage");
 
-    expect(
-      within(cardCountCard).getByText((text) => text.includes("1.0 / 2.0")),
-    ).toBeTruthy();
+    expect(cardCountCard.textContent).toContain("Used 0.5 / 2.0");
+    expect(cardCountCard.textContent).toContain("Free 1.5");
     expect(cardCountCard.textContent).not.toContain("Used -");
-    expect(
-      within(vramCard).getByText((text) => text.includes("7.5 / 30.0")),
-    ).toBeTruthy();
+    expect(vramCard.textContent).toContain("Used 7.5 / 30.0");
     expect(vramCard.textContent).not.toContain("Used -");
   });
 });

--- a/src/foundation/lib/gpu-device-resources.test.ts
+++ b/src/foundation/lib/gpu-device-resources.test.ts
@@ -432,10 +432,10 @@ describe("gpu device resource helpers", () => {
         matchesSelectedAccelerator: true,
         memoryTotalMiB: 15360,
         quantity: {
-          available: 0,
+          available: 1,
           total: 2,
-          used: 2,
-          percent: 100,
+          used: 1,
+          percent: 50,
         },
         memory: {
           available: 15360,
@@ -535,6 +535,43 @@ describe("gpu device resource helpers", () => {
     ]);
   });
 
+  it("uses group availability for a single product when its breakdown is missing", () => {
+    expect(
+      buildGpuCardResourceRows({
+        allocatable: {
+          cpu: 32,
+          memory: 128,
+          accelerator_groups: {
+            nvidia_gpu: {
+              quantity: 2,
+              product_groups: null,
+              products: {
+                "Tesla-T4": { quantity: 2 },
+              },
+            },
+          },
+        },
+        available: {
+          cpu: 24,
+          memory: 96,
+          accelerator_groups: {
+            nvidia_gpu: {
+              quantity: 1.5,
+              product_groups: null,
+              products: null,
+            },
+          },
+        },
+        node_resources: null,
+      })[0].quantity,
+    ).toEqual({
+      available: 1.5,
+      total: 2,
+      used: 0.5,
+      percent: 25,
+    });
+  });
+
   it("builds a generic card row when product breakdown is missing", () => {
     expect(
       buildGpuCardResourceRows({
@@ -590,7 +627,7 @@ describe("gpu device resource helpers", () => {
     ]);
   });
 
-  it("counts only devices with no vGPU allocation as full-card available", () => {
+  it("uses aggregate available quantity for summary rows when cards are partially allocated", () => {
     expect(
       buildGpuCardResourceRows({
         allocatable: {
@@ -617,11 +654,11 @@ describe("gpu device resource helpers", () => {
           memory: 96,
           accelerator_groups: {
             nvidia_gpu: {
-              quantity: 2,
+              quantity: 1.5,
               product_groups: null,
               products: {
                 "Tesla-T4": {
-                  quantity: 2,
+                  quantity: 1.5,
                   virtualization: {
                     memory_mib: 23040,
                     core_units: 150,
@@ -675,14 +712,14 @@ describe("gpu device resource helpers", () => {
         },
       })[0].quantity,
     ).toEqual({
-      available: 1,
+      available: 1.5,
       total: 2,
-      used: 1,
-      percent: 50,
+      used: 0.5,
+      percent: 25,
     });
   });
 
-  it("does not fall back to product availability when device full-card signals are incomplete", () => {
+  it("falls back to aggregate availability when device details are incomplete", () => {
     expect(
       buildGpuCardResourceRows({
         allocatable: {
@@ -735,10 +772,10 @@ describe("gpu device resource helpers", () => {
         },
       })[0].quantity,
     ).toEqual({
-      available: 0,
+      available: 1,
       total: 1,
-      used: 1,
-      percent: 100,
+      used: 0,
+      percent: 0,
     });
   });
 
@@ -846,7 +883,6 @@ describe("gpu device resource helpers", () => {
       used: 90,
       percent: 90,
     });
-    expect(rows[0].quantity.available).toBe(0);
   });
 
   it("builds used-over-total GPU device rows from node resources", () => {

--- a/src/foundation/lib/gpu-device-resources.ts
+++ b/src/foundation/lib/gpu-device-resources.ts
@@ -597,9 +597,6 @@ export function buildGpuCardResourceRows(
   const devicePoolsByProduct = sumDevicePoolsByProduct(
     resourceInfo?.node_resources,
   );
-  const fullCardAvailableDevicesByProduct =
-    countFullCardAvailableDevicesByProduct(resourceInfo?.node_resources);
-
   return Object.entries(allocatableGroups).flatMap(
     ([acceleratorType, allocatableGroup]) => {
       const availableGroup =
@@ -607,16 +604,29 @@ export function buildGpuCardResourceRows(
       const metadataProducts =
         resourceInfo?.accelerator_metadata?.[acceleratorType]?.products ?? {};
 
-      const allocatableProducts = allocatableGroup.products;
+      const allocatableProductEntries = Object.entries(
+        allocatableGroup.products ?? {},
+      );
+      const allocatableProductGroupEntries = Object.entries(
+        allocatableGroup.product_groups ?? {},
+      );
+      const availableQuantityForProduct = (
+        product: string,
+        hasSingleProduct: boolean,
+      ) =>
+        availableGroup?.products?.[product]?.quantity ??
+        availableGroup?.product_groups?.[product] ??
+        (hasSingleProduct ? availableGroup?.quantity : undefined) ??
+        0;
       const products =
-        allocatableProducts && Object.keys(allocatableProducts).length > 0
-          ? Object.entries(allocatableProducts).map(([product, resources]) => ({
+        allocatableProductEntries.length > 0
+          ? allocatableProductEntries.map(([product, resources]) => ({
               product,
               quantity: resources.quantity ?? 0,
-              availableQuantity:
-                fullCardAvailableDevicesByProduct.get(product) ??
-                availableGroup?.products?.[product]?.quantity ??
-                0,
+              availableQuantity: availableQuantityForProduct(
+                product,
+                allocatableProductEntries.length === 1,
+              ),
               allocatableMemoryMiB: resources.virtualization?.memory_mib,
               availableMemoryMiB:
                 availableGroup?.products?.[product]?.virtualization?.memory_mib,
@@ -624,21 +634,19 @@ export function buildGpuCardResourceRows(
               availableCoreUnits:
                 availableGroup?.products?.[product]?.virtualization?.core_units,
             }))
-          : Object.keys(allocatableGroup.product_groups ?? {}).length > 0
-            ? Object.entries(allocatableGroup.product_groups ?? {}).map(
-                ([product, quantity]) => ({
+          : allocatableProductGroupEntries.length > 0
+            ? allocatableProductGroupEntries.map(([product, quantity]) => ({
+                product,
+                quantity,
+                availableQuantity: availableQuantityForProduct(
                   product,
-                  quantity,
-                  availableQuantity:
-                    fullCardAvailableDevicesByProduct.get(product) ??
-                    availableGroup?.product_groups?.[product] ??
-                    0,
-                  allocatableMemoryMiB: undefined,
-                  availableMemoryMiB: undefined,
-                  allocatableCoreUnits: undefined,
-                  availableCoreUnits: undefined,
-                }),
-              )
+                  allocatableProductGroupEntries.length === 1,
+                ),
+                allocatableMemoryMiB: undefined,
+                availableMemoryMiB: undefined,
+                allocatableCoreUnits: undefined,
+                availableCoreUnits: undefined,
+              }))
             : [
                 {
                   product: "",


### PR DESCRIPTION
## Issue

NEU-608

## Summary

Show the backend's aggregate available GPU capacity in resource summary cards.
In vGPU clusters this can be fractional; the per-device view and whole-card
selection behavior remain based on fully free physical devices.

## Changes

- Use available product, product-group, or single-product group quantities for
  GPU card summary rows instead of deriving summary capacity from device cards.
- Preserve device-pool memory/core fallbacks and avoid duplicating a
  multi-product group aggregate across each product row.
- Add coverage for fractional summary capacity and single-product fallback
  behavior in the endpoint resource panel.

## Test Plan

### Unit test

- [x] `yarn test src/foundation/lib/gpu-device-resources.test.ts src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.test.tsx`
- [x] `yarn typecheck`
- [x] `yarn biome lint src/foundation/lib/gpu-device-resources.ts src/foundation/lib/gpu-device-resources.test.ts src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.test.tsx`
- [x] `node tools/i18n-tracker.cjs --limit 20`
- [x] Pre-commit checks under Node 22 (typecheck, dependency checks, Knip, formatting, i18n)

### DB test

- [x] Not affected: UI-only change.

### E2E test

- [x] Not required: this PR changes only resource-summary presentation; targeted unit tests cover fractional aggregate capacity and whole-card selection separation.
- [x] Manual testing is not required.

## Risk & Rollback

The change only affects displayed aggregate GPU capacity. Whole-card selection
and device-level usable-card indicators are unchanged. Rollback is a revert of
this change; no migration is required.