### PR TITLE
feat(endpoints): hide model fields for engines that need no model spec (NEU-634)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -238,7 +238,7 @@
   "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "60d6fab6e42a96ac0c4a91ff0c2e4c29",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "198c3c1f753d8605cca9ab4a189b38e8",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "1594a31221c4667dcec2bc6c1ee36ec7",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "7fc5186989f74eb21ecf621ac24e5ee4",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",
@@ -375,5 +375,6 @@
   "src/foundation/lib/model-registry-visibility.ts": "24550d054dd3e6365f09c526b829302a",
   "src/domains/role/lib/format-permission.ts": "9f2b7f7a698e51dc6ba8188a808db44b",
   "src/domains/model-catalog/lib/catalog-import.ts": "0722a4c305e6f4066c9f70aed2e61ed0",
-  "src/foundation/lib/error-message.ts": "2785e4aefa66aa19662cf51d21aa6874"
+  "src/foundation/lib/error-message.ts": "2785e4aefa66aa19662cf51d21aa6874",
+  "src/domains/endpoint/lib/model-spec.ts": "18639ba24921f56eef631d1cbe1398fe"
 }

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -918,6 +918,7 @@ function setupMocks(
     metadata: { name: string };
     visibility?: "public" | "private";
   }> = [],
+  engines: Array<Record<string, unknown>> = [],
 ) {
   vi.mocked(useSelect).mockImplementation(((opts: { resource: string }) => {
     if (opts.resource === "model_catalogs") {
@@ -928,6 +929,9 @@ function setupMocks(
     }
     if (opts.resource === "model_registries") {
       return { query: { data: { data: registries }, isLoading: false } };
+    }
+    if (opts.resource === "engines") {
+      return { query: { data: { data: engines }, isLoading: false } };
     }
     return defaultSelectResult;
   }) as unknown as typeof useSelect);
@@ -941,6 +945,24 @@ function setupMocks(
     error: null,
     refetch: vi.fn(),
   } as unknown as ReturnType<typeof useRegistryModels>);
+}
+
+function engineRef(name: string, tasks: string[] = ["text-generation"]) {
+  return {
+    metadata: {
+      name,
+      workspace: "default",
+      deletion_timestamp: null,
+      creation_timestamp: "",
+      update_timestamp: "",
+      labels: {},
+      annotations: {},
+    },
+    spec: {
+      versions: [{ version: "v1", values_schema: {} }],
+      supported_tasks: tasks,
+    },
+  };
 }
 
 // --- Test components ---
@@ -4844,5 +4866,45 @@ describe("what the chosen registry costs at deploy time", () => {
     expect(
       screen.queryByTestId("endpoint-runtime-download-unknown"),
     ).toBeNull();
+  });
+});
+
+describe("engines that need no model spec", () => {
+  // The Flex engine runs an arbitrary workload; Neutree manages no model for it,
+  // so the form must not ask which model to serve.
+  const modelFieldLabels = [
+    "endpoints.fields.modelRegistry",
+    "endpoints.fields.modelName",
+    "endpoints.fields.modelVersion",
+    "endpoints.fields.modelFile",
+    "endpoints.fields.taskType",
+  ];
+
+  it("hides every model field once Flex is selected", async () => {
+    setupMocks([], [], [], [engineRef("flex"), engineRef("vllm")]);
+    render(<CreateForm />);
+
+    await act(async () => {
+      formInstance?.setValue("spec.engine", { engine: "flex", version: "v1" });
+    });
+
+    for (const label of modelFieldLabels) {
+      expect(screen.queryByText(label)).toBeNull();
+    }
+    // Replicas shares the card with the model fields and must survive.
+    expect(screen.queryByText("endpoints.fields.replicas")).not.toBeNull();
+  });
+
+  it("keeps them for an ordinary engine", async () => {
+    setupMocks([], [], [], [engineRef("flex"), engineRef("vllm")]);
+    render(<CreateForm />);
+
+    await act(async () => {
+      formInstance?.setValue("spec.engine", { engine: "vllm", version: "v1" });
+    });
+
+    for (const label of modelFieldLabels) {
+      expect(screen.queryByText(label)).not.toBeNull();
+    }
   });
 });

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -35,6 +35,7 @@ import {
   transformEndpointValues,
   validateEndpointValues,
 } from "@/domains/endpoint/lib/endpoint-form-helpers";
+import { engineNeedsModelSpec } from "@/domains/endpoint/lib/model-spec";
 import {
   formatVgpuMemoryGiBInputValue,
   getEffectiveVgpuMemoryMiB,
@@ -222,6 +223,11 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   const currentRegistry = form.watch("spec.model.registry");
   const currentCluster = form.watch("spec.cluster");
   const engineSpec = form.watch("spec.engine");
+  // An engine that needs no spec.model has nothing to ask about: the registry,
+  // model, version, file and task fields are all hidden for it. spec.model.task
+  // is still set from the engine's declared tasks when the engine is picked, so
+  // the gateway keeps routing the endpoint as that task.
+  const hidesModelFields = !engineNeedsModelSpec(engineSpec?.engine);
 
   const selectedAccelerator = normalizedResources?.accelerator;
   const gpuUsage = normalizedResources?.gpu || 0;
@@ -1372,87 +1378,93 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
               </FormFieldGroup>
             </div>
           )}
-          {/* Model registry + name are shown by default (so a recipe deploy
+          {!hidesModelFields && (
+            <>
+              {/* Model registry + name are shown by default (so a recipe deploy
               surfaces which model/registry it resolves to); version + file are
               advanced and stay under "Show all options". */}
-          <FormFieldGroup
-            {...form}
-            name="spec.model.registry"
-            label={t("endpoints.fields.modelRegistry")}
-          >
-            <FormCombobox
-              placeholder={t("endpoints.placeholders.selectModelRegistry")}
-              disabled={modelRegistries.query.isLoading}
-              options={(modelRegistries.query.data?.data || []).map((e) => ({
-                label: e.metadata.name,
-                value: e.metadata.name,
-              }))}
-              onChange={(value) => {
-                form.setValue("spec.model.registry", value as string);
-                // Reset model name and search when registry changes
-                form.setValue("spec.model.name", "");
-                setModelSearch("");
-              }}
-            />
-          </FormFieldGroup>
-          <FormFieldGroup
-            {...form}
-            name="spec.model.name"
-            label={t("endpoints.fields.modelName")}
-          >
-            <div className="space-y-2">
-              <AsyncCombobox
-                placeholder={t("endpoints.placeholders.selectModel")}
-                loading={
-                  modelsData.isFetching ? (
-                    <CommandLoading className="px-2 py-1.5 text-muted-foreground">
-                      {t("endpoints.messages.fetching")}
-                    </CommandLoading>
-                  ) : null
-                }
-                options={modelsData.models.map((e) => ({
-                  label: e.name,
-                  value: e.name,
-                }))}
-                shouldFilter={false}
-                onSearchChange={setModelSearch}
-                triggerClassName="w-full"
-                disabled={!currentRegistry}
-                value={currentModelName}
-                onChange={(value: string) => {
-                  form.setValue("spec.model.name", value);
-                }}
-              />
-              {/* Said here rather than in release notes: a model that is not on
+              <FormFieldGroup
+                {...form}
+                name="spec.model.registry"
+                label={t("endpoints.fields.modelRegistry")}
+              >
+                <FormCombobox
+                  placeholder={t("endpoints.placeholders.selectModelRegistry")}
+                  disabled={modelRegistries.query.isLoading}
+                  options={(modelRegistries.query.data?.data || []).map(
+                    (e) => ({
+                      label: e.metadata.name,
+                      value: e.metadata.name,
+                    }),
+                  )}
+                  onChange={(value) => {
+                    form.setValue("spec.model.registry", value as string);
+                    // Reset model name and search when registry changes
+                    form.setValue("spec.model.name", "");
+                    setModelSearch("");
+                  }}
+                />
+              </FormFieldGroup>
+              <FormFieldGroup
+                {...form}
+                name="spec.model.name"
+                label={t("endpoints.fields.modelName")}
+              >
+                <div className="space-y-2">
+                  <AsyncCombobox
+                    placeholder={t("endpoints.placeholders.selectModel")}
+                    loading={
+                      modelsData.isFetching ? (
+                        <CommandLoading className="px-2 py-1.5 text-muted-foreground">
+                          {t("endpoints.messages.fetching")}
+                        </CommandLoading>
+                      ) : null
+                    }
+                    options={modelsData.models.map((e) => ({
+                      label: e.name,
+                      value: e.name,
+                    }))}
+                    shouldFilter={false}
+                    onSearchChange={setModelSearch}
+                    triggerClassName="w-full"
+                    disabled={!currentRegistry}
+                    value={currentModelName}
+                    onChange={(value: string) => {
+                      form.setValue("spec.model.name", value);
+                    }}
+                  />
+                  {/* Said here rather than in release notes: a model that is not on
                   local storage is fetched when the endpoint starts, so the first
                   start is slow and an air-gapped site cannot start it at all.
                   Keyed off the registry's stated capability, so a second public
                   provider inherits the warning without being named. */}
-              {selectedModelDelivery === "at-deploy-time" && (
-                <Alert data-testid="endpoint-runtime-download-hint">
-                  <AlertDescription>
-                    {t("endpoints.messages.runtimeDownloadHint")}
-                  </AlertDescription>
-                </Alert>
-              )}
-              {/* The registry answered without saying which kind it is, which
+                  {selectedModelDelivery === "at-deploy-time" && (
+                    <Alert data-testid="endpoint-runtime-download-hint">
+                      <AlertDescription>
+                        {t("endpoints.messages.runtimeDownloadHint")}
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                  {/* The registry answered without saying which kind it is, which
                   only happens when a request here drops MODEL_REGISTRY_SELECT.
                   Rendering nothing would take the warning above away with no
                   symptom at all; this makes the omission visible to whoever is
                   looking at the screen. */}
-              {selectedModelDelivery === "unknown" && (
-                <Alert
-                  variant="warning"
-                  data-testid="endpoint-runtime-download-unknown"
-                >
-                  <AlertDescription>
-                    {t("endpoints.messages.runtimeDownloadUnknown")}
-                  </AlertDescription>
-                </Alert>
-              )}
-            </div>
-          </FormFieldGroup>
-          {showFull && (
+                  {selectedModelDelivery === "unknown" && (
+                    <Alert
+                      variant="warning"
+                      data-testid="endpoint-runtime-download-unknown"
+                    >
+                      <AlertDescription>
+                        {t("endpoints.messages.runtimeDownloadUnknown")}
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                </div>
+              </FormFieldGroup>
+            </>
+          )}
+          {showFull && !hidesModelFields && (
             <>
               <FormFieldGroup
                 {...form}
@@ -1528,25 +1540,27 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                 }))}
               />
             </FormFieldGroup>
-            <FormFieldGroup
-              {...form}
-              name="spec.model.task"
-              label={t("endpoints.fields.taskType")}
-            >
-              <FormCombobox
-                placeholder={t("endpoints.placeholders.selectTaskType")}
-                disabled={!form.getValues().spec.engine.engine}
-                options={(
-                  engineTasks[form.getValues().spec.engine.engine] || []
-                ).map((v) => ({
-                  label:
-                    t(`models.tasks.${v}`) === `models.tasks.${v}`
-                      ? formatTaskName(v)
-                      : t(`models.tasks.${v}`),
-                  value: v,
-                }))}
-              />
-            </FormFieldGroup>
+            {!hidesModelFields && (
+              <FormFieldGroup
+                {...form}
+                name="spec.model.task"
+                label={t("endpoints.fields.taskType")}
+              >
+                <FormCombobox
+                  placeholder={t("endpoints.placeholders.selectTaskType")}
+                  disabled={!form.getValues().spec.engine.engine}
+                  options={(
+                    engineTasks[form.getValues().spec.engine.engine] || []
+                  ).map((v) => ({
+                    label:
+                      t(`models.tasks.${v}`) === `models.tasks.${v}`
+                        ? formatTaskName(v)
+                        : t(`models.tasks.${v}`),
+                    value: v,
+                  }))}
+                />
+              </FormFieldGroup>
+            )}
           </FormCardGrid>
         )}
       </>

--- a/src/domains/endpoint/lib/model-spec.test.ts
+++ b/src/domains/endpoint/lib/model-spec.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { engineNeedsModelSpec } from "./model-spec";
+
+describe("engineNeedsModelSpec", () => {
+  it("is false for the Flex engine", () => {
+    expect(engineNeedsModelSpec("flex")).toBe(false);
+  });
+
+  it("is true for every other engine", () => {
+    // Including engines the server already treats as self-contained: an
+    // unrecognised engine must show a field too many, never a field too few.
+    for (const engine of [
+      "vllm",
+      "llama-cpp",
+      "sglang",
+      "e2e",
+      "some-new-engine",
+    ]) {
+      expect(engineNeedsModelSpec(engine)).toBe(true);
+    }
+  });
+
+  it("is true while no engine is selected, so the fields start visible", () => {
+    expect(engineNeedsModelSpec(undefined)).toBe(true);
+    expect(engineNeedsModelSpec(null)).toBe(true);
+    expect(engineNeedsModelSpec("")).toBe(true);
+  });
+});

--- a/src/domains/endpoint/lib/model-spec.ts
+++ b/src/domains/endpoint/lib/model-spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Engines whose model, if they have one at all, is baked into their image. The
+ * Flex engine runs an arbitrary HTTP workload — it may be serving a model, or an
+ * OCR service, or nothing model-shaped at all — and Neutree neither fetches nor
+ * names whatever it serves.
+ */
+const ENGINES_WITHOUT_MODEL_SPEC = ["flex"];
+
+/**
+ * engineNeedsModelSpec reports whether an endpoint on this engine has a
+ * `spec.model` worth filling in, and therefore whether the form should ask.
+ *
+ * Phrased as a need rather than as a fact about the engine: one that brings its
+ * own workload may serve no model at all, so "it provides the model" would
+ * assert more than is true. What is true is that Neutree manages no model for
+ * it.
+ *
+ * Recognised by engine name. The server answers the neighbouring question —
+ * "does Neutree download this model?" — by excluding the three built-in
+ * downloader engines, and copying that inverted rule here would drop the model
+ * fields for every newly registered external engine, silently, with no way for
+ * the user to supply what it does need. Naming the engines instead means an
+ * unrecognised one keeps today's form: a field too many, never a field too few.
+ *
+ * The two rules are therefore deliberately different and both fail safe — do not
+ * "align" them. The convergence is an engine capability declaration both sides
+ * read, which is a separate change; it lives here rather than under the engine
+ * domain because an L2 domain may not import from another one.
+ */
+export function engineNeedsModelSpec(engineName?: string | null): boolean {
+  return !engineName || !ENGINES_WITHOUT_MODEL_SPEC.includes(engineName);
+}


### PR DESCRIPTION
## Issue

NEU-634

## Summary

The Flex engine runs an arbitrary HTTP workload whose model, if it has one, is baked into its image — Neutree neither fetches nor names it. The endpoint form nevertheless asks for a model registry, model, version, file and task: five values that mean nothing for such an engine and that a user cannot answer correctly.

All five are hidden when the selected engine needs no `spec.model`.

## Changes

- `src/domains/endpoint/lib/model-spec.ts` — `engineNeedsModelSpec(name)`, false only for `flex` today.
- `use-endpoint-form.tsx` — the model registry / model / version / file group and the task field are gated on it. Replicas shares that card and stays.

`spec.model.task` is still set from the engine's declared tasks when the engine is picked, so nothing about routing changes: Flex declares `text-generation`, which is exactly what it received before the field was hidden.

### Why by engine name

The server answers the neighbouring question — *does Neutree download this model?* — by excluding the three built-in downloader engines. Copying that inverted rule here would hide the model fields from **every newly registered external engine**, silently, with no way for the user to supply what it does need.

Naming the engines instead means an unrecognised engine keeps today's form: a field too many, never a field too few. The two rules are deliberately different and both fail safe — please don't "align" them. Converging is an engine capability declaration both sides read (one boolean, two consumers), which is a separate change.

Phrased as a *need* rather than as a fact about the engine: one bringing its own workload may serve no model at all, so "it provides the model" would assert more than is true. The predicate sits in the endpoint domain rather than the engine domain because `no-L2-cross-domain` forbids one L2 domain importing another.

## Test Plan

`yarn build`, biome, knip, dependency-cruiser and both i18n gates pass.

A render test drives the real form: selecting `flex` removes all five labels, selecting `vllm` keeps them, and replicas survives either way. It is a guard rather than a restatement — forcing the condition off fails it:

```
FAIL  use-endpoint-form.test.tsx > engines that need no model spec
      > hides every model field once Flex is selected
```

`engineNeedsModelSpec` is unit-tested for `flex`, for ordinary engines, for engines the *server* already treats as self-contained (`e2e`), and for an unset engine.

Pre-existing on `main` and unrelated: two timezone-dependent failures in `Timestamp.render.test.tsx`.

## Draft — blocked on the server side

Hiding a field only helps if the server stops requiring it. Today:

| field | server state |
|---|---|
| `spec.model.file`, `spec.model.task` | already optional |
| `spec.model.registry` | required by a database trigger until neutree#574 lands |
| `spec.model.name`, `spec.model.version` | still required by database triggers (`004`/`017`, `013`) |

So creating a Flex endpoint with these fields hidden fails until neutree#574 merges **and** NEU-633's remaining server step drops the name/version requirement. This PR is complete and reviewable now; it must not merge before both.

## Not in scope

The ticket also carries "workload image supports a user-configured Image Registry". That is a separate question still under discussion — the per-endpoint image override (`engine_args.image`) is currently passed through raw, while the engine's registered image is prefixed with the cluster's image registry. Deliberately untouched here.
