### PR TITLE
feat(endpoints): label models by alias and fill in the version on selection (NEU-630)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -238,7 +238,7 @@
   "src/foundation/components/VariablesInput.tsx": "1d43ebad87c1dcbb3053798477ab3722",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "60d6fab6e42a96ac0c4a91ff0c2e4c29",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "47376e2e25f9fa5b5089251fe7f74e37",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "cc05243baff2e4e9542f4244049ebcc8",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "7fc5186989f74eb21ecf621ac24e5ee4",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",
@@ -384,5 +384,6 @@
   "src/domains/api-key/components/ApiKeyLabel.tsx": "3cdf5f7478d547f4cf3fc71a97e53e28",
   "src/domains/api-key/components/ProjectPicker.tsx": "f0fa514cf0497fdc5cbedda67192f53c",
   "src/domains/model-registry/lib/model-card-html.ts": "c122c65d212a4fd311ef8abe86dcadd6",
-  "src/domains/endpoint/components/WorkloadImageInput.tsx": "304fa99fa65a207a26b7ee097550af48"
+  "src/domains/endpoint/components/WorkloadImageInput.tsx": "304fa99fa65a207a26b7ee097550af48",
+  "src/foundation/lib/registry-model-display.ts": "1a385e0a97717a0b6f0d3e77d18c7224"
 }

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -6083,3 +6083,45 @@ describe("engines that need no model spec", () => {
     }
   });
 });
+
+describe("model picker", () => {
+  // Renaming the alias later must leave this endpoint pointing where it was.
+  it("labels a model by its alias but submits the physical name", async () => {
+    setupMocks([], [], [{ metadata: { name: "hf" } }]);
+    vi.mocked(useRegistryModels).mockReturnValue({
+      page: null,
+      models: [
+        {
+          name: "Qwen/Qwen3-8B",
+          versions: [{ name: "v2", creation_time: "", alias: "qwen-chat" }],
+        },
+      ],
+      total: 1,
+      isLoading: false,
+      isFetching: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useRegistryModels>);
+
+    render(<CreateForm />);
+
+    await act(async () => {
+      formInstance?.setValue("spec.model.registry", "hf");
+    });
+
+    const field = screen.getByTestId("field-spec.model.name");
+    const trigger = field.querySelector('button[role="combobox"]');
+    if (!trigger) throw new Error("model combobox trigger not found");
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("option", { name: "qwen-chat" }));
+    });
+
+    expect(formInstance?.getValues().spec.model.name).toBe("Qwen/Qwen3-8B");
+    expect(formInstance?.getValues().spec.model.version).toBe("v2");
+  });
+});

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -80,6 +80,10 @@ import {
   MODEL_REGISTRY_SELECT,
   registryModelDelivery,
 } from "@/foundation/lib/model-registry-visibility";
+import {
+  registryModelDefaultVersion,
+  registryModelLabel,
+} from "@/foundation/lib/registry-model-display";
 import { cn } from "@/foundation/lib/utils";
 import {
   composeEndpointSpec,
@@ -1696,8 +1700,10 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                         </CommandLoading>
                       ) : null
                     }
+                    // Labelled by alias, valued by the physical name: the
+                    // endpoint is stored against the name it is served under.
                     options={modelsData.models.map((e) => ({
-                      label: e.name,
+                      label: registryModelLabel(e),
                       value: e.name,
                     }))}
                     shouldFilter={false}
@@ -1707,6 +1713,19 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                     value={currentModelName}
                     onChange={(value: string) => {
                       form.setValue("spec.model.name", value);
+
+                      // Fill in the version the registry reports, so the
+                      // reference is complete without opening "Show all options".
+                      const picked = modelsData.models.find(
+                        (e) => e.name === value,
+                      );
+                      const version = picked
+                        ? registryModelDefaultVersion(picked)
+                        : undefined;
+
+                      if (version) {
+                        form.setValue("spec.model.version", version);
+                      }
                     }}
                   />
                   {/* Said here rather than in release notes: a model that is not on

--- a/src/foundation/lib/registry-model-display.test.ts
+++ b/src/foundation/lib/registry-model-display.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { RegistryModel } from "@/foundation/types/model-types";
+import {
+  registryModelDefaultVersion,
+  registryModelLabel,
+} from "./registry-model-display";
+
+const version = (name: string, alias?: string) => ({
+  name,
+  creation_time: "",
+  ...(alias ? { alias } : {}),
+});
+
+const model = (name: string, versions: RegistryModel["versions"]) =>
+  ({ name, versions }) as RegistryModel;
+
+describe("registryModelLabel", () => {
+  it("shows the alias when a version carries one", () => {
+    expect(
+      registryModelLabel(model("Qwen/Qwen3-8B", [version("v1", "qwen")])),
+    ).toBe("qwen");
+  });
+
+  it("falls back to the physical name", () => {
+    // Public registries never carry aliases and take this path.
+    expect(registryModelLabel(model("Qwen/Qwen3-8B", [version("v1")]))).toBe(
+      "Qwen/Qwen3-8B",
+    );
+    expect(registryModelLabel(model("Qwen/Qwen3-8B", []))).toBe(
+      "Qwen/Qwen3-8B",
+    );
+  });
+
+  it("takes the first alias when several versions carry one", () => {
+    expect(
+      registryModelLabel(
+        model("m", [
+          version("v1"),
+          version("v2", "second"),
+          version("v3", "third"),
+        ]),
+      ),
+    ).toBe("second");
+  });
+
+  it("ignores an empty alias rather than showing a blank label", () => {
+    expect(registryModelLabel(model("m", [version("v1", "")]))).toBe("m");
+  });
+});
+
+describe("registryModelDefaultVersion", () => {
+  it("takes the first version the registry reported", () => {
+    expect(
+      registryModelDefaultVersion(model("m", [version("v2"), version("v1")])),
+    ).toBe("v2");
+  });
+
+  it("is undefined when the registry reported no versions", () => {
+    expect(registryModelDefaultVersion(model("m", []))).toBeUndefined();
+  });
+});

--- a/src/foundation/lib/registry-model-display.ts
+++ b/src/foundation/lib/registry-model-display.ts
@@ -1,0 +1,27 @@
+import type { RegistryModel } from "@/foundation/types/model-types";
+
+/**
+ * The label to show for a model: its alias when one of its versions carries
+ * one, otherwise the physical name.
+ *
+ * The alias is a label only — it never reaches `spec.model.name`, so renaming
+ * it later leaves existing endpoints pointing where they always did. Aliases
+ * are scoped to their registry, so the same alias under two registries stays
+ * two different models. Public registries carry none and take the fallback.
+ *
+ * Aliases live on versions, so a model can have several; the first wins,
+ * matching the order the registry reports.
+ */
+export function registryModelLabel(model: RegistryModel): string {
+  return model.versions?.find((version) => version.alias)?.alias || model.name;
+}
+
+/**
+ * The version to fill in when a model is picked, or undefined when the registry
+ * reported none. The first one, in the registry's own order.
+ */
+export function registryModelDefaultVersion(
+  model: RegistryModel,
+): string | undefined {
+  return model.versions?.[0]?.name || undefined;
+}


### PR DESCRIPTION
## Issue

NEU-630 — partial; see **What is still missing**.

## Summary

The model picker labelled every model by its physical name, so an alias a user gave a model in its registry was invisible at the one moment it is meant to help. Selecting a model also left the version empty, pushing the user into "Show all options" to finish a reference the registry had already answered.

## Changes

- `src/foundation/lib/registry-model-display.ts` — `registryModelLabel` (alias where a version carries one, else the physical name) and `registryModelDefaultVersion`.
- The endpoint form's model picker labels by the former and fills `spec.model.version` from the latter on selection.

The option **value** stays the physical name. The endpoint is stored against the name it is served under, which is what makes the ticket's two requirements hold: renaming an alias afterwards leaves existing endpoints pointing where they always did, and a new endpoint can be created by the new alias. Aliases are scoped to their registry, so the same alias under two registries stays two different models.

A public registry carries no aliases and therefore takes the fallback without needing a branch of its own.

The rule lives in `foundation` because `domains/endpoint` needs it and `no-L2-cross-domain` forbids importing `domains/model-registry`; that is the same reason `useRegistryModels` already sits there.

## Test Plan

`yarn build`, biome, knip, dependency-cruiser and both i18n gates pass. Full suite green apart from the two timezone-dependent `Timestamp.render.test.tsx` failures that also fail on a clean `main`.

A render test drives the real picker: opening it shows `qwen-chat`, choosing it stores `Qwen/Qwen3-8B` and version `v2`. Reverting the label mapping fails it, so it guards the behaviour rather than restating it.

`registryModelLabel` / `registryModelDefaultVersion` are unit-tested for an alias, for the fallback, for several versions carrying aliases, and for an empty alias string (which must not render a blank label).

## Already delivered, not touched here

Two of the ticket's acceptance items were already in place and are unchanged:

- **backend paged search** — `useRegistryModels` is the single fetch point for the models listing, with `search` / `limit` / `offset` and a `Content-Range` total;
- **workspace scoping** — the same hook keys on workspace, so switching workspace re-lists.

## What is still missing

Three of the ticket's acceptance items are left for follow-ups, for reasons that differ:

1. **The model's static parameters are not filled in.** The listing does not carry them — only the detail read does, and that hook (`useRegistryModelVersion`) lives in `domains/model-registry`, which `domains/endpoint` may not import. Filling `spec.model.info` means moving that hook to `foundation` the way `useRegistryModels` already was. Mechanical.
2. **An unreachable registry is still selectable.** The predicates exist (`registryIsUnreachable` / `registryIsDisabled`) but likewise sit in `domains/model-registry`, and the shared `Combobox` takes `{ label, value }` options with no per-option `disabled`, so showing the reason means extending a component the whole app uses. Mechanical, but the shared-component edit is better off landing on its own.
3. **`spec.model.file` cannot be filled in at all yet.** This one is not a UI gap: the model registry API has no file dimension. `ModelVersion` reports name, size, module, labels, alias and info and nothing else, and no registry backend enumerates a version's files. Auto-filling the field needs a server-side capability that does not exist, so it is a backend ticket rather than a continuation of this one.
