### PR TITLE
feat(model-registry): render the HTML a model card is written with

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -363,7 +363,7 @@
   "src/domains/endpoint/components/EndpointAdvancedParameters.tsx": "747ce1445ef75df6316c942332856247",
   "src/domains/engine/lib/resolve-capabilities.ts": "9a444cc413dae9066a7983c28c1d0fba",
   "src/domains/cluster/lib/upgrade-versions.ts": "0b8da429b7f5a4c73d1ee2cada4556ae",
-  "src/domains/model-registry/components/ModelReadme.tsx": "a3c984589e9451d251553161799078c4",
+  "src/domains/model-registry/components/ModelReadme.tsx": "c3f21f41c6a82adc1bc70c85f2d336e3",
   "src/domains/model-registry/components/RegistryAvailabilityNotice.tsx": "2c9dcfb8c2befffc176756510462d653",
   "src/domains/model-registry/components/RegistryVisibility.tsx": "757a8e29d1c3a91d9dac5e76e6fba909",
   "src/domains/model-registry/components/RegistryVisibilityFilter.tsx": "eb78ddfcb4ea2833fd16a6699b79014f",
@@ -382,5 +382,6 @@
   "src/domains/api-key/hooks/use-api-key-project-groups.ts": "ea25e396a339f2c9356bdde173120454",
   "src/domains/api-key/hooks/use-api-key-projects.ts": "cfef148cad7902f1de0e4ea87f66adbb",
   "src/domains/api-key/components/ApiKeyLabel.tsx": "3cdf5f7478d547f4cf3fc71a97e53e28",
-  "src/domains/api-key/components/ProjectPicker.tsx": "f0fa514cf0497fdc5cbedda67192f53c"
+  "src/domains/api-key/components/ProjectPicker.tsx": "f0fa514cf0497fdc5cbedda67192f53c",
+  "src/domains/model-registry/lib/model-card-html.ts": "c122c65d212a4fd311ef8abe86dcadd6"
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
 		"react-use": "^17.6.0",
 		"react-window": "^1.8.11",
 		"recharts": "^2.15.1",
+		"rehype-raw": "^7.0.0",
+		"rehype-sanitize": "^6.0.0",
 		"sonner": "^2.0.2",
 		"tailwind-merge": "^3.0.1",
 		"tailwindcss-animate": "^1.0.7",

--- a/src/domains/model-registry/components/ModelReadme.test.tsx
+++ b/src/domains/model-registry/components/ModelReadme.test.tsx
@@ -55,21 +55,22 @@ beforeEach(() => {
 });
 
 describe("ModelReadme — a card is untrusted content", () => {
-  it("renders raw HTML in a card as text, never as markup", () => {
-    // The XSS acceptance for this feature, asserted directly rather than argued.
-    // It holds because the pipeline has no HTML step in it: the server returns
-    // the markdown as stored, and react-markdown builds elements from a parsed
-    // tree with no `rehype-raw` to turn raw nodes back into markup. Adding that
-    // plugin — anywhere in this repo — is what would break this test.
+  it("drops the tags that would run or embed something", () => {
+    // Half of the XSS acceptance for this feature, asserted rather than argued.
+    // The card's HTML *is* rendered, so what carries the safety is the
+    // allow-list: a tag not on it never becomes an element, and `script` is
+    // stripped with its contents rather than left behind as text.
     returns({
       content: [
         "# Card",
         "",
         "<script>window.__pwned = true</script>",
         "",
-        '<img src="x" onerror="window.__pwned = true">',
-        "",
         '<iframe src="https://evil.invalid"></iframe>',
+        "",
+        '<object data="https://evil.invalid"></object>',
+        "",
+        '<form action="https://evil.invalid"><input type="text" /></form>',
       ].join("\n"),
     });
 
@@ -79,36 +80,117 @@ describe("ModelReadme — a card is untrusted content", () => {
 
     expect(content.querySelector("script")).toBeNull();
     expect(content.querySelector("iframe")).toBeNull();
-    // No <img> either: the tag was written as raw HTML, so it is text.
-    expect(content.querySelector("img")).toBeNull();
-    // And it is visible as source, which is what "passed through as text" means.
-    expect(content.textContent).toContain("<script>");
+    expect(content.querySelector("object")).toBeNull();
+    expect(content.querySelector("form")).toBeNull();
+    expect(content.textContent).not.toContain("window.__pwned");
     expect(
       (globalThis as unknown as { __pwned?: boolean }).__pwned,
     ).toBeUndefined();
   });
 
-  it("does not emit a javascript: link from a markdown link", () => {
-    returns({ content: "[click](javascript:window.__pwned = true)" });
+  it("strips the attributes a card could act or paint through", () => {
+    // The other half: the tags here are allowed, and it is the attributes that
+    // would do the damage. An event handler is code, and inline CSS is how a
+    // card would cover the page it is embedded in.
+    returns({
+      content: [
+        '<img src="https://example.invalid/logo.png" onerror="window.__pwned = true" alt="logo">',
+        "",
+        '<div style="position:fixed;inset:0;background:red" onclick="window.__pwned = true">hi</div>',
+      ].join("\n"),
+    });
 
     render(<ModelReadme modelRef={modelRef} />);
 
-    const link = screen.getByTestId("readme-content").querySelector("a");
+    const content = screen.getByTestId("readme-content");
+    const image = content.querySelector("img");
+    const div = content.querySelector("div");
 
-    // The library's default URL transform drops the scheme rather than the
-    // element, so what remains must not be executable.
-    expect(link?.getAttribute("href") ?? "").not.toContain("javascript:");
+    expect(image).not.toBeNull();
+    expect(image?.getAttribute("onerror")).toBeNull();
+    expect(div?.getAttribute("style")).toBeNull();
+    expect(div?.getAttribute("onclick")).toBeNull();
+    expect(
+      (globalThis as unknown as { __pwned?: boolean }).__pwned,
+    ).toBeUndefined();
   });
 
-  it("sends card links out with no referrer", () => {
-    returns({ content: "[hub](https://example.invalid/model)" });
+  it("renders the HTML hub cards are actually written with", () => {
+    // The reason the pipeline renders HTML at all. Passed through as text, the
+    // top of a typical card is a wall of angle brackets.
+    returns({
+      content: [
+        '<div align="center">',
+        '  <img src="https://example.invalid/logo.png" width="200" alt="logo">',
+        "  <p><b>Qwen2.5</b></p>",
+        "</div>",
+        "",
+        "<details><summary>Benchmarks</summary>",
+        "",
+        "**mmlu** 86.1",
+        "",
+        "</details>",
+      ].join("\n"),
+    });
 
     render(<ModelReadme modelRef={modelRef} />);
 
-    const link = screen.getByTestId("readme-content").querySelector("a");
+    const content = screen.getByTestId("readme-content");
 
-    expect(link?.getAttribute("rel")).toContain("noreferrer");
-    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(content.querySelector("div")?.getAttribute("align")).toBe("center");
+    expect(content.querySelector("img")?.getAttribute("src")).toBe(
+      "https://example.invalid/logo.png",
+    );
+    expect(content.querySelector("img")?.getAttribute("width")).toBe("200");
+    expect(content.querySelector("details")).not.toBeNull();
+    // Markdown inside the raw block is still markdown: `rehype-raw` reassembles
+    // the two into one tree rather than treating the span between the tags as
+    // opaque text.
+    expect(content.querySelector("details strong")?.textContent).toBe("mmlu");
+    expect(content.textContent).not.toContain("<div");
+  });
+
+  it("does not emit a javascript: link, written either way", () => {
+    returns({
+      content: [
+        "[markdown](javascript:alert(1))",
+        "",
+        '<a href="javascript:alert(1)">html</a>',
+      ].join("\n"),
+    });
+
+    render(<ModelReadme modelRef={modelRef} />);
+
+    const links = screen.getByTestId("readme-content").querySelectorAll("a");
+
+    expect(links).toHaveLength(2);
+
+    for (const link of links) {
+      expect(link.getAttribute("href") ?? "").not.toContain("javascript:");
+    }
+  });
+
+  it("sends card links out with no referrer, and on this app's terms", () => {
+    // Including the ones written as raw HTML: every link is rebuilt by the
+    // component, so a card cannot choose its own target or rel.
+    returns({
+      content: [
+        "[hub](https://example.invalid/model)",
+        "",
+        '<a href="https://example.invalid/other" target="_self" rel="opener">html</a>',
+      ].join("\n"),
+    });
+
+    render(<ModelReadme modelRef={modelRef} />);
+
+    const links = screen.getByTestId("readme-content").querySelectorAll("a");
+
+    expect(links).toHaveLength(2);
+
+    for (const link of links) {
+      expect(link.getAttribute("rel")).toContain("noreferrer");
+      expect(link.getAttribute("target")).toBe("_blank");
+    }
   });
 });
 

--- a/src/domains/model-registry/components/ModelReadme.tsx
+++ b/src/domains/model-registry/components/ModelReadme.tsx
@@ -1,8 +1,11 @@
 import "github-markdown-css/github-markdown-light.css";
 import type { AnchorHTMLAttributes } from "react";
 import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 import { useRegistryModelReadme } from "@/domains/model-registry/hooks/use-registry-model-readme";
 import { splitModelCard } from "@/domains/model-registry/lib/model-card";
+import { modelCardSanitizeSchema } from "@/domains/model-registry/lib/model-card-html";
 import { EmptyState } from "@/foundation/components/EmptyState";
 import { Loader } from "@/foundation/components/Loader";
 import { ShowPage } from "@/foundation/components/ShowPage";
@@ -15,22 +18,31 @@ import { useTranslation } from "@/foundation/lib/i18n";
  * ## Why this is safe to display
  *
  * A card is content from outside this system — anybody who can publish to a
- * public hub can write one — so it is treated as data all the way to the screen:
+ * public hub can write one — and hub cards use raw HTML for the parts that
+ * matter most: the centred title block, the logo, the badges, the `<details>`
+ * around the long table. So the HTML is rendered, and every step from the wire
+ * to the screen treats it as hostile:
  *
  * - the server returns the markdown **as stored** and never renders it, so no
  *   HTML arrives that something else already decided to trust;
- * - `react-markdown` builds React elements from a parsed syntax tree. It has no
- *   `dangerouslySetInnerHTML` path unless `rehype-raw` is added, so raw HTML in
- *   the source — `<script>`, `<img onerror=…>`, `<iframe>` — is passed through as
- *   text rather than becoming markup. **Adding `rehype-raw` to this repo, here or
- *   anywhere, is what would break that**;
- * - link and image targets go through the library's default URL transform, which
- *   drops `javascript:` and other executable schemes, and links carry
- *   `rel="noreferrer nofollow"` so a card cannot pass this app's URL on as a
- *   referrer.
+ * - `rehype-raw` reparses the raw HTML into the same syntax tree as the
+ *   markdown, and `rehype-sanitize` then prunes that tree against
+ *   {@link modelCardSanitizeSchema} — an allow-list of tags, attributes and URL
+ *   protocols. `<script>` and `<iframe>` are dropped, `onerror=…` never survives
+ *   as an attribute, and `javascript:` never survives as a URL. **The two
+ *   plugins are a pair: `rehype-raw` without `rehype-sanitize` after it is
+ *   `dangerouslySetInnerHTML` on hub content**;
+ * - `react-markdown` then builds React elements from what is left, so what
+ *   reaches the DOM is a tree this app constructed and not a string it was
+ *   handed;
+ * - link targets additionally go through the library's default URL transform,
+ *   and every link — written in markdown or in raw HTML — is rebuilt by
+ *   {@link MarkdownLink} below, so a card cannot choose its own `target` and
+ *   carries `rel="noreferrer nofollow"` rather than passing this app's URL on as
+ *   a referrer.
  *
- * Nothing here sanitises HTML, because nothing here ever produces any. That is
- * the whole argument, and it is why there is no allow-list to keep up to date.
+ * The XSS acceptance for all of this is asserted in the sibling test rather than
+ * argued here.
  *
  * ## Why it is not always present
  *
@@ -111,7 +123,17 @@ export const ModelReadme = ({ modelRef }: Props) => {
           className="markdown-body max-w-none overflow-x-auto rounded-md bg-transparent p-2 text-sm dark:text-gray-200 [&_img]:max-w-full"
           data-testid="readme-content"
         >
-          <ReactMarkdown components={{ a: MarkdownLink }}>
+          <ReactMarkdown
+            components={{ a: MarkdownLink }}
+            // Order is the safety property: raw HTML becomes tree nodes first,
+            // and the allow-list is applied to the result. Reversed, the
+            // sanitiser would run over a tree the raw HTML is not yet part of
+            // and pass everything.
+            rehypePlugins={[
+              rehypeRaw,
+              [rehypeSanitize, modelCardSanitizeSchema],
+            ]}
+          >
             {splitModelCard(readme.content).body}
           </ReactMarkdown>
         </div>

--- a/src/domains/model-registry/lib/model-card-html.ts
+++ b/src/domains/model-registry/lib/model-card-html.ts
@@ -1,0 +1,44 @@
+import type { Options as SanitizeOptions } from "rehype-sanitize";
+import { defaultSchema } from "rehype-sanitize";
+
+/**
+ * What a model card is allowed to render as HTML.
+ *
+ * Cards on a public hub are written in markdown that carries raw HTML, and the
+ * conventions are load-bearing rather than decorative: a centred title block, a
+ * logo, a row of badges, a `<details>` holding the long benchmark table. Passing
+ * that through as text — which is what happens with no HTML step at all — turns
+ * the top of a typical card into a wall of angle brackets.
+ *
+ * So the HTML is rendered, and a card is still content from outside this system
+ * that anybody who can publish to a hub can write. The safety argument is no
+ * longer "nothing here produces HTML"; it is this allow-list, applied by
+ * `hast-util-sanitize` to the parsed tree after `rehype-raw` has turned raw
+ * nodes back into elements and before anything reaches React:
+ *
+ * - the tag list is an allow-list, so `script`, `iframe`, `object`, `embed`,
+ *   `form` and everything else not named are dropped rather than escaped;
+ * - the attribute list is an allow-list too, so no `on*` handler survives, and
+ *   `style` is not on it — inline CSS is how a card would otherwise cover the
+ *   page it is embedded in;
+ * - `href` and `src` are restricted by protocol, which is what stops
+ *   `javascript:` and `data:` URLs;
+ * - `id` and `name` are prefixed, so a card cannot mint an element that
+ *   collides with one of this app's.
+ *
+ * Everything below is the published default schema — the one modelled on what
+ * GitHub itself permits in a README — plus the single addition noted there.
+ * Widening it further is a security decision and belongs in review as one: the
+ * two tags most likely to be asked for, `iframe` and `video`, are the two that
+ * hand a card the ability to run and play things on its own initiative.
+ */
+export const modelCardSanitizeSchema: SanitizeOptions = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames ?? []),
+    // Long deprecated and still all over the hub, where it wraps the title
+    // block of cards written years ago. It is an inert container: it carries no
+    // attributes and does nothing but centre its children.
+    "center",
+  ],
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2813,6 +2813,11 @@ enhanced-resolve@^5.7.0:
     graceful-fs "^4.2.4"
     tapable "^2.3.3"
 
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
 entities@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz#c1df5fe3602429747fa233d0dd26f142f0ce4743"
@@ -3181,6 +3186,55 @@ hasown@^2.0.2, hasown@^2.0.3:
   dependencies:
     function-bind "^1.1.2"
 
+hast-util-from-parse5@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz#830a35022fff28c3fea3697a98c2f4cc6b835a2e"
+  integrity sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    devlop "^1.0.0"
+    hastscript "^9.0.0"
+    property-information "^7.0.0"
+    vfile "^6.0.0"
+    vfile-location "^5.0.0"
+    web-namespaces "^2.0.0"
+
+hast-util-parse-selector@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz#352879fa86e25616036037dd8931fb5f34cb4a27"
+  integrity sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==
+  dependencies:
+    "@types/hast" "^3.0.0"
+
+hast-util-raw@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz#79b66b26f6f68fb50dfb4716b2cdca90d92adf2e"
+  integrity sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@types/unist" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    hast-util-from-parse5 "^8.0.0"
+    hast-util-to-parse5 "^8.0.0"
+    html-void-elements "^3.0.0"
+    mdast-util-to-hast "^13.0.0"
+    parse5 "^7.0.0"
+    unist-util-position "^5.0.0"
+    unist-util-visit "^5.0.0"
+    vfile "^6.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
+hast-util-sanitize@^5.0.0:
+  version "5.0.2"
+  resolved "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz#edb260d94e5bba2030eb9375790a8753e5bf391f"
+  integrity sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    "@ungap/structured-clone" "^1.0.0"
+    unist-util-position "^5.0.0"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
   resolved "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz"
@@ -3202,12 +3256,36 @@ hast-util-to-jsx-runtime@^2.0.0:
     unist-util-position "^5.0.0"
     vfile-message "^4.0.0"
 
+hast-util-to-parse5@^8.0.0:
+  version "8.0.1"
+  resolved "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz#95aa391cc0514b4951418d01c883d1038af42f5d"
+  integrity sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    devlop "^1.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
+    web-namespaces "^2.0.0"
+    zwitch "^2.0.0"
+
 hast-util-whitespace@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz"
   integrity sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==
   dependencies:
     "@types/hast" "^3.0.0"
+
+hastscript@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz#dbc84bef6051d40084342c229c451cd9dc567dff"
+  integrity sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    comma-separated-tokens "^2.0.0"
+    hast-util-parse-selector "^4.0.0"
+    property-information "^7.0.0"
+    space-separated-tokens "^2.0.0"
 
 highlight.js@^11.11.1, highlight.js@~11.11.0:
   version "11.11.1"
@@ -3237,6 +3315,11 @@ html-url-attributes@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz"
   integrity sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==
+
+html-void-elements@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz#fc9dbd84af9e747249034d4d62602def6517f1d7"
+  integrity sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==
 
 http-proxy-agent@^7.0.2:
   version "7.0.2"
@@ -4436,6 +4519,13 @@ parse-entities@^4.0.0:
     is-decimal "^2.0.0"
     is-hexadecimal "^2.0.0"
 
+parse5@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parse5@^8.0.0:
   version "8.0.1"
   resolved "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz#f43bcd2cd683efe084075333e9ce0da7d06da31e"
@@ -4990,6 +5080,23 @@ regexp-tree@~0.1.1:
   version "0.1.27"
   resolved "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz#2198f0ef54518ffa743fe74d983b56ffd631b6cd"
   integrity sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==
+
+rehype-raw@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz#59d7348fd5dbef3807bbaa1d443efd2dd85ecee4"
+  integrity sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-raw "^9.0.0"
+    vfile "^6.0.0"
+
+rehype-sanitize@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz#16e95f4a67a69cbf0f79e113c8e0df48203db73c"
+  integrity sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==
+  dependencies:
+    "@types/hast" "^3.0.0"
+    hast-util-sanitize "^5.0.0"
 
 remark-parse@^11.0.0:
   version "11.0.0"
@@ -5801,6 +5908,14 @@ uuid@^11.1.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz"
   integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
+vfile-location@^5.0.0:
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz#cb9eacd20f2b6426d19451e0eafa3d0a846225c3"
+  integrity sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    vfile "^6.0.0"
+
 vfile-message@^4.0.0:
   version "4.0.2"
   resolved "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz"
@@ -5913,6 +6028,11 @@ watskeburt@5.0.3:
   version "5.0.3"
   resolved "https://registry.npmjs.org/watskeburt/-/watskeburt-5.0.3.tgz#5821cbec4043cf219730b4ce099bc84b5de14960"
   integrity sha512-g9CXukMjazlJJVQ3OHzXsnG25KFYgSgKMIyoJrD8ggr0DbS9UNF7OzIqWmmKKBMedkxj3T01uqEaGnn+y7QhMA==
+
+web-namespaces@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
+  integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Hub cards use raw HTML for the parts that carry the most: the centred title block, the logo, the badge row, the `<details>` around a long table. The pipeline had no HTML step at all, so every one of those tags arrived as text and the top of a typical card was a wall of angle brackets.

`rehype-raw` reparses the raw HTML into the same tree as the markdown, and `rehype-sanitize` prunes that tree against an allow-list before anything reaches React. The two are a pair, and the order is the safety property: `rehype-raw` on its own is `dangerouslySetInnerHTML` on content anybody with a hub account can write.

## The allow-list

`hast-util-sanitize`'s published default schema — the one modelled on what GitHub itself permits in a README — plus `<center>`, which is long deprecated and still all over the hub, and which carries no attributes.

What that buys, verified against the installed schema rather than assumed:

- tags are an allow-list, so `script` (stripped with its contents), `iframe`, `object`, `embed`, `form`, `video` are gone rather than escaped;
- attributes are an allow-list too, so no `on*` handler survives, and `style` is not on it — inline CSS is how a card would otherwise paint over the page it is embedded in;
- `href` and `src` are restricted by protocol: `javascript:` and `data:` are dropped, relative `src` (an image committed next to the card) is kept;
- `id` and `name` are prefixed, so a card cannot mint an element colliding with one of ours.

`<div align="center">`, `<img width=…>` and `<details>` all work with no widening — `align`, `width` and `height` are already in the schema's global attribute list.

Widening it further is a security decision and the module says so: the two tags most likely to be asked for, `iframe` and `video`, are the two that let a card run and play things on its own initiative.

## Tests

The old first test asserted that no HTML rendered at all; that acceptance is replaced, not dropped. The new one covers tags dropped, attributes stripped from tags that are allowed, `javascript:` neutralised whether written as markdown or as HTML, and every link — hand-written `target` and `rel` included — still rebuilt by the component so it leaves with `rel="noreferrer nofollow"` and `target="_blank"`.

One of those cases was previously vacuous: `[markdown](javascript:window.__pwned = true)` is not a link at all (the URL has spaces), so the old assertion ran against `null`. It now uses a URL that does parse.

## Note

Card images now load from wherever the card points, which is a request to a third party from the user's browser. That is what rendering a hub card means, and it is the same thing the hub's own page does; in an air-gapped install they simply fail to load. Flagging it rather than deciding it silently.

## Separately

Model cards are full of GFM tables, and `remark-gfm` is not in the pipeline — those render as paragraphs of pipe characters, before and after this change. Left alone here rather than folded in as an unrelated dependency; happy to do it as a follow-up.