### PR TITLE
feat(endpoints): offer the registry's tags for an engine's workload image (NEU-634)

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -172,7 +172,7 @@
   "src/domains/engine/components/EngineVersions.tsx": "46eb6987394db5f7c5cf8fed3204e074",
   "src/domains/engine/components/JsonSchemaValueVisualizer.tsx": "803cf91cd6e73b7c54d736e5cf6a7283",
   "src/domains/engine/components/JsonSchemaVisualizer.tsx": "3a6003cccf8d04994704c95adf0ee6af",
-  "src/domains/endpoint/types.ts": "f9445bfb33644d2bb02777d9857be343",
+  "src/domains/endpoint/types.ts": "41d63b4a42232e80a01c65ab424927c6",
   "src/domains/endpoint/hooks/use-chat-state.ts": "7555e18e5668956e332598e536bdb46a",
   "src/domains/endpoint/hooks/use-endpoint-log-sources.ts": "db5f58fbfdf90e73192f68cd4c29b7da",
   "src/domains/endpoint/hooks/use-endpoint-monitor-panels.ts": "f81266b161eca80a40cbba56086e81b6",
@@ -235,10 +235,10 @@
   "src/domains/cluster/hooks/use-cluster-form.tsx": "5d4ca2e20acacb990501aed14cb69d75",
   "src/foundation/types/resource-types.ts": "6fecb3bc5fdd96313e1745a5defcfd87",
   "src/foundation/hooks/use-variables-input.ts": "4e7645dd01994e5fd252bc3e2ad7676f",
-  "src/foundation/components/VariablesInput.tsx": "24057e155ee2272d6ba949b42639d752",
+  "src/foundation/components/VariablesInput.tsx": "1d43ebad87c1dcbb3053798477ab3722",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "60d6fab6e42a96ac0c4a91ff0c2e4c29",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "4f892e3e79398416f58d491661f4e025",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "47376e2e25f9fa5b5089251fe7f74e37",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "7fc5186989f74eb21ecf621ac24e5ee4",
   "src/pages/external-endpoints/create.tsx": "bd5d137b2a4a49d077ea1891707f2988",
@@ -383,5 +383,6 @@
   "src/domains/api-key/hooks/use-api-key-projects.ts": "cfef148cad7902f1de0e4ea87f66adbb",
   "src/domains/api-key/components/ApiKeyLabel.tsx": "3cdf5f7478d547f4cf3fc71a97e53e28",
   "src/domains/api-key/components/ProjectPicker.tsx": "f0fa514cf0497fdc5cbedda67192f53c",
-  "src/domains/model-registry/lib/model-card-html.ts": "c122c65d212a4fd311ef8abe86dcadd6"
+  "src/domains/model-registry/lib/model-card-html.ts": "c122c65d212a4fd311ef8abe86dcadd6",
+  "src/domains/endpoint/components/WorkloadImageInput.tsx": "304fa99fa65a207a26b7ee097550af48"
 }

--- a/src/domains/endpoint/components/WorkloadImageInput.test.tsx
+++ b/src/domains/endpoint/components/WorkloadImageInput.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { WorkloadImageInput } from "./WorkloadImageInput";
+
+vi.mock("@/foundation/lib/i18n", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+const useCustom = vi.fn();
+
+vi.mock("@refinedev/core", () => ({
+  useCustom: (args: unknown) => useCustom(args),
+}));
+
+function answer(tags?: string[], isFetching = false) {
+  useCustom.mockReturnValue({
+    data: tags ? { data: { tags } } : undefined,
+    isFetching,
+  });
+}
+
+function renderInput(
+  props: Partial<Parameters<typeof WorkloadImageInput>[0]> = {},
+) {
+  const onChange = vi.fn();
+
+  render(
+    <WorkloadImageInput
+      value="my-workload:v1"
+      onChange={onChange}
+      workspace="default"
+      registry="hub"
+      {...props}
+    />,
+  );
+
+  return { onChange };
+}
+
+describe("WorkloadImageInput", () => {
+  it("stays typeable and reports what was typed", () => {
+    answer([]);
+    const { onChange } = renderInput();
+
+    fireEvent.change(screen.getByDisplayValue("my-workload:v1"), {
+      target: { value: "other/image:v9" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("other/image:v9");
+  });
+
+  it("offers the registry's other tags and applies one to the repository", () => {
+    answer(["v1", "v2"]);
+    const { onChange } = renderInput();
+
+    // The tag already in the value is not offered back.
+    expect(screen.queryByText("v1")).toBeNull();
+
+    fireEvent.click(screen.getByText("v2"));
+
+    expect(onChange).toHaveBeenCalledWith("my-workload:v2");
+  });
+
+  it("shows nothing extra when the registry cannot answer", () => {
+    // A refusing registry means no suggestions, not an error: the field is the
+    // user's to fill in either way.
+    answer(undefined);
+    renderInput();
+
+    expect(screen.queryByTestId("workload-image-tag-suggestions")).toBeNull();
+    expect(screen.getByDisplayValue("my-workload:v1")).toBeTruthy();
+  });
+
+  it("asks for nothing until there is a repository and a registry to ask", () => {
+    answer(undefined);
+    renderInput({ value: "", registry: null });
+
+    expect(useCustom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "",
+        queryOptions: expect.objectContaining({ enabled: false }),
+      }),
+    );
+  });
+
+  it("encodes a repository that contains slashes into one path segment", () => {
+    answer([]);
+    renderInput({ value: "team/inner:v1" });
+
+    expect(useCustom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "/workspaces/default/image_registries/hub/repositories/team%2Finner/tags",
+      }),
+    );
+  });
+});

--- a/src/domains/endpoint/components/WorkloadImageInput.tsx
+++ b/src/domains/endpoint/components/WorkloadImageInput.tsx
@@ -1,0 +1,101 @@
+import { useCustom } from "@refinedev/core";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { useTranslation } from "@/foundation/lib/i18n";
+
+/** Splits `repo:tag` on the last colon, which a digest or a port never occupies
+ * in a value this field accepts. A value with no colon is all repository. */
+function splitReference(value: string): { repository: string; tag: string } {
+  const at = value.lastIndexOf(":");
+
+  if (at < 0) {
+    return { repository: value, tag: "" };
+  }
+
+  return { repository: value.slice(0, at), tag: value.slice(at + 1) };
+}
+
+interface WorkloadImageInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  workspace?: string | null;
+  /** The image registry the endpoint's cluster pulls from. */
+  registry?: string | null;
+}
+
+/**
+ * The workload image for an engine that runs one, typed as `repository:tag` with
+ * the tags the registry actually holds offered underneath.
+ *
+ * A text input rather than a picker, deliberately. The suggestions are an assist
+ * that is not always available -- a registry can refuse the lookup, and an image
+ * that lives somewhere other than the cluster's registry has no lookup to make
+ * at all -- so the field has to stay typeable whether or not any arrive, and a
+ * failed lookup has to mean "no suggestions" rather than an error. Reporting a
+ * fault where there is only an absence of help would be worse than the silence,
+ * which is also why it is never retried.
+ */
+export function WorkloadImageInput({
+  value,
+  onChange,
+  workspace,
+  registry,
+}: WorkloadImageInputProps) {
+  const { t } = useTranslation();
+  const { repository, tag } = splitReference(value);
+
+  const enabled = Boolean(workspace && registry && repository.trim());
+
+  const { data, isFetching } = useCustom<{ tags?: string[] }>({
+    // The repository may contain slashes; encoding keeps it one path segment,
+    // which the router preserves -- the same thing model names rely on.
+    url: enabled
+      ? `/workspaces/${encodeURIComponent(
+          workspace as string,
+        )}/image_registries/${encodeURIComponent(
+          registry as string,
+        )}/repositories/${encodeURIComponent(repository.trim())}/tags`
+      : "",
+    method: "get",
+    queryOptions: { enabled, retry: false, staleTime: 30_000 },
+  });
+
+  const suggestions = (data?.data?.tags ?? []).filter(
+    (candidate) => candidate !== tag,
+  );
+
+  return (
+    <div className="space-y-2">
+      <Input
+        value={value}
+        placeholder={t(
+          "endpoints.placeholders.workloadImage",
+          "repository:tag",
+        )}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {isFetching && (
+        <p className="text-xs text-muted-foreground">
+          {t("endpoints.messages.fetchingImageTags", "Looking up tags…")}
+        </p>
+      )}
+      {suggestions.length > 0 && (
+        <div
+          className="flex flex-wrap gap-1"
+          data-testid="workload-image-tag-suggestions"
+        >
+          {suggestions.map((candidate) => (
+            <Badge
+              key={candidate}
+              variant="outline"
+              className="cursor-pointer"
+              onClick={() => onChange(`${repository}:${candidate}`)}
+            >
+              {candidate}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -23,6 +23,7 @@ import { FeaturePicker } from "@/domains/endpoint/components/FeaturePicker";
 import { formatTaskName } from "@/domains/endpoint/components/ModelTask";
 import { VariantPicker } from "@/domains/endpoint/components/VariantPicker";
 import { VRAMCheckBadge } from "@/domains/endpoint/components/VRAMCheckBadge";
+import { WorkloadImageInput } from "@/domains/endpoint/components/WorkloadImageInput";
 import { useEndpointClusterResources } from "@/domains/endpoint/hooks/use-endpoint-cluster-resources";
 import { useEndpointEngineOptions } from "@/domains/endpoint/hooks/use-endpoint-engine-options";
 import useEndpointResources from "@/domains/endpoint/hooks/use-endpoint-resources";
@@ -2716,6 +2717,25 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
         >
           <VariablesInput
             schema={engineValueSchema?.properties as unknown as Schema}
+            // Recognised by engine name and argument key, the same way the
+            // model fields are hidden for an engine that needs none. Another
+            // engine with an image argument keeps the plain text box until the
+            // console is taught about it: a convenience too few, never a field
+            // too few. Both cases converge on an engine declaration later.
+            valueInputs={
+              engineSpec?.engine === "flex"
+                ? {
+                    image: ({ value, onChange }) => (
+                      <WorkloadImageInput
+                        value={value}
+                        onChange={onChange}
+                        workspace={workspace}
+                        registry={selectedCluster?.spec?.image_registry}
+                      />
+                    ),
+                  }
+                : undefined
+            }
           />
         </FormFieldGroup>
         <FormFieldGroup

--- a/src/domains/endpoint/types.ts
+++ b/src/domains/endpoint/types.ts
@@ -68,6 +68,8 @@ export type EndpointClusterRef = {
   metadata: Metadata;
   spec: {
     type: string;
+    /** The image registry this cluster pulls workload images from. */
+    image_registry?: string;
     accelerator_virtualization?: { enabled?: boolean } | null;
   };
   status: {

--- a/src/foundation/components/VariablesInput.test.tsx
+++ b/src/foundation/components/VariablesInput.test.tsx
@@ -214,3 +214,73 @@ describe("VariablesInput", () => {
     ).toBeTruthy();
   });
 });
+
+const imageSchema = {
+  image: { type: "string", title: "Image" },
+} as unknown as Schema;
+
+function ValueInputForm({
+  valueInputs,
+  onSubmit,
+}: {
+  valueInputs?: Parameters<typeof VariablesInput>[0]["valueInputs"];
+  onSubmit: (values: { args: Record<string, unknown> }) => void;
+}) {
+  const form = useForm<{ args: Record<string, unknown> }>({
+    defaultValues: { args: { image: "my-workload:v1" } },
+  });
+  const args = form.watch("args");
+
+  return (
+    <FormProvider {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <VariablesInput
+          name="args"
+          value={args}
+          onChange={(next) => form.setValue("args", next)}
+          schema={imageSchema}
+          valueInputs={valueInputs}
+        />
+        <button type="submit">Save</button>
+      </form>
+    </FormProvider>
+  );
+}
+
+describe("VariablesInput value inputs", () => {
+  it("hands the value to the input supplied for a key, and takes its answer", () => {
+    render(
+      <ValueInputForm
+        onSubmit={vi.fn()}
+        valueInputs={{
+          image: ({ value, onChange }) => (
+            <button
+              type="button"
+              data-testid="image-widget"
+              onClick={() => onChange("picked:v2")}
+            >
+              {value}
+            </button>
+          ),
+        }}
+      />,
+    );
+
+    // The supplied input was given the current value...
+    expect(screen.getByTestId("image-widget").textContent).toBe(
+      "my-workload:v1",
+    );
+
+    // ...and what it answers becomes the value, which comes back to it.
+    fireEvent.click(screen.getByTestId("image-widget"));
+
+    expect(screen.getByTestId("image-widget").textContent).toBe("picked:v2");
+  });
+
+  it("falls back to the type's own input for a key the caller says nothing about", () => {
+    render(<ValueInputForm onSubmit={vi.fn()} />);
+
+    expect(screen.queryByTestId("image-widget")).toBeNull();
+    expect(screen.getByDisplayValue("my-workload:v1")).not.toBeNull();
+  });
+});

--- a/src/foundation/components/VariablesInput.tsx
+++ b/src/foundation/components/VariablesInput.tsx
@@ -42,12 +42,32 @@ import {
 } from "@/foundation/hooks/use-variables-input";
 import { ResourceFormSubmitContext } from "./resource-form-submit-context";
 
+/** What an overriding input is handed: the current value and a way to replace it. */
+interface VariableValueInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Replacement inputs for particular argument keys.
+ *
+ * Which key deserves which input is the caller's judgement, not this
+ * component's: an input that has to reach an API belongs to whoever knows which
+ * API, and which arguments an engine has is knowledge this generic key/value
+ * editor has no business holding.
+ */
+type VariableValueInputs = Record<
+  string,
+  (props: VariableValueInputProps) => React.ReactNode
+>;
+
 interface VariablesInputProps {
   name?: string;
   value?: Record<string, unknown>;
   onChange?: (value: Record<string, unknown>) => void;
   title?: string;
   schema?: Schema;
+  valueInputs?: VariableValueInputs;
   field?: {
     value?: Record<string, unknown>;
     onChange?: (value: Record<string, unknown>) => void;
@@ -57,7 +77,7 @@ interface VariablesInputProps {
 export const VariablesInput = React.forwardRef<
   HTMLTableElement,
   VariablesInputProps
->(({ name, value, onChange, schema = {}, field }, ref) => {
+>(({ name, value, onChange, schema = {}, valueInputs = {}, field }, ref) => {
   const { t } = useTranslation();
   const form = useFormContext<FieldValues>();
   const submitContext = useContext(ResourceFormSubmitContext);
@@ -271,6 +291,18 @@ export const VariablesInput = React.forwardRef<
   const renderValueInput = (key: string, val: unknown) => {
     if (schema[key]) {
       const { type } = schema[key];
+
+      // An input the caller supplied for this key wins over the type's own.
+      // Anything else falls through, so a key the caller says nothing about
+      // keeps the input its type implies.
+      const override = valueInputs[key];
+
+      if (override) {
+        return override({
+          value: String(formatPrimitiveValue(val) ?? ""),
+          onChange: (next) => handleUpdateValue(key, next),
+        });
+      }
 
       switch (type) {
         case "boolean":

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -896,7 +896,8 @@
 			"selectVersion": "Select A Version",
 			"selectTaskType": "Select A Support Task Type",
 			"selectAccelerator": "Select An Accelerator",
-			"selectSchedulerType": "Select Scheduler Type"
+			"selectSchedulerType": "Select Scheduler Type",
+			"workloadImage": "repository:tag"
 		},
 		"options": {
 			"generic": "Generic",
@@ -961,7 +962,8 @@
 			"vgpuCoreLimitUnlimitedHint": "0 means no limit; compute is shared",
 			"vgpuCoreLimitUnsupportedMode": "Accelerator virtualization mode does not support compute splitting",
 			"runtimeDownloadHint": "Models in a public registry are downloaded when the endpoint starts: the first start takes noticeably longer, and it cannot start at all without access to the registry.",
-			"runtimeDownloadUnknown": "This registry did not report whether it stores its models locally, so whether they are downloaded when the endpoint starts is unknown."
+			"runtimeDownloadUnknown": "This registry did not report whether it stores its models locally, so whether they are downloaded when the endpoint starts is unknown.",
+			"fetchingImageTags": "Looking up tags…"
 		},
 		"tabs": {
 			"playground": "Playground"


### PR DESCRIPTION
## Issue

NEU-634

## Summary

The Flex engine runs a workload image the user types out, so a wrong tag is only discovered when the pod cannot pull. The field now shows the tags the cluster's image registry actually holds for the repository being typed, and clicking one applies it.

## It stays a text input

This is the design point, not a limitation. The suggestions are an assist that is **not always available**:

- a registry can refuse the lookup (`502`);
- the image may live somewhere other than the cluster's registry, so there is nothing to ask;
- Docker Hub answers nothing useful.

So the field is typeable whether or not any tags arrive, and a failed lookup means *no suggestions* — never an error. Reporting a fault where there is only an absence of help would be worse than the silence, which is also why the lookup is never retried.

## How the field is chosen

`VariablesInput` renders engine arguments generically from a flat `{type, title, description}` schema, so there was no way to give one argument something other than a text box. It now takes replacement inputs **keyed by argument name**.

Which key deserves which input is the caller's judgement: an input that reaches an API belongs to whoever knows which API, and which arguments an engine has is knowledge a generic key/value editor has no business holding. A key the caller says nothing about keeps the input its type implies.

The endpoint form supplies one for `image` when the engine is Flex — **recognised by name, exactly as the model fields already are** (#385). Two consequences worth stating:

- it needs nothing from the engine package, so it works against the Flex package already deployed;
- 1.2 ends up with one rule rather than two, and both cases converge on an engine declaration together later.

The trade is the one already accepted: a second engine with an image argument keeps the plain text box until the console is taught about it. A convenience too few, never a field too few.

## Fetching

`useCustom`, as the cluster version listing does for its route. `registry-models` deliberately avoids `useCustom` because its listing carries a total in a `Content-Range` header that `useCustom` discards along with the Response — the tags are in the body, so that reason does not apply here.

Tags come from the read added in neutree#599, which asks the registry with the same credentials and scope that pulls use: a repository the cluster can pull is a repository this can list.

## Test Plan

`yarn build`, biome, knip, dependency-cruiser and both i18n gates pass. Full suite green apart from the two timezone-dependent `Timestamp.render.test.tsx` failures that also fail on a clean `main`.

`VariablesInput`: a supplied input is handed the current value and its answer becomes the new one — asserted by the value coming *back* to it, so the round trip is covered rather than just the call; a key with nothing supplied falls back to its type's input.

`WorkloadImageInput`: typing is reported unchanged; the registry's other tags are offered and clicking one rewrites only the tag (the tag already in the value is not offered back); a registry that cannot answer renders no suggestions and leaves the field intact; nothing is requested until there is both a repository and a registry to ask; and a repository containing a slash is encoded into a single path segment.

## Not in scope

**Repositories are not enumerated, only tags.** That needs the registry's catalog endpoint, which Docker Hub does not implement and which self-hosted registries commonly gate behind a wider scope than pulling — probed against `registry.smtx.io`, `/v2/_catalog` answers `unauthorized to list catalog` for a pull-capable setup. So the user names the repository and the tags come to them.
