### PR TITLE
feat(endpoints): save what an endpoint is running as a new catalog

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -32,8 +32,8 @@
   "src/pages/engines/show.tsx": "beec780e9b600e5537a46d6ac8d6692f",
   "src/pages/endpoints/create.tsx": "80007cdbc2f2ecd902d6485b6774cf2b",
   "src/pages/endpoints/edit.tsx": "f985a843fe494b31594f2291e8bcfee8",
-  "src/pages/endpoints/list.tsx": "99588f5a2ac8fd9ed967190a5019a7dc",
-  "src/pages/endpoints/show.tsx": "81b247031a165fe5933e8457b9ae54a6",
+  "src/pages/endpoints/list.tsx": "7fb9631fe11bfc5db40c61356a362e49",
+  "src/pages/endpoints/show.tsx": "a7a4eb53f1962e15e06e3a1c4f478512",
   "src/pages/dashboard/Dashboard.tsx": "5c949e1cfe926f6538294445610940ce",
   "src/pages/clusters/create.tsx": "fd2b1c7affa795305445f8e307dea099",
   "src/pages/clusters/edit.tsx": "d636f55fd8591fabd56759bf0f46963e",
@@ -315,7 +315,7 @@
   "src/foundation/components/resource-form-submit-context.ts": "7c5c5b5f94416e940786f87a98b3a9f8",
   "src/pages/model-catalogs/edit.tsx": "4b04b40e8e6733b27ebedfa82efc67c0",
   "src/pages/model-catalogs/components/FeaturesList.tsx": "e68a4369a62b564bbbdcfd3c614a4b38",
-  "src/pages/model-catalogs/components/ImportDialog.tsx": "df9db0770bdc496b21291689a43ffd6e",
+  "src/pages/model-catalogs/components/ImportDialog.tsx": "c8b67dba091272b9170ff5ea2f2c6258",
   "src/pages/model-catalogs/components/KeyConfigCard.tsx": "a3e49d8166c2440bfa82b6d6b53cc2e1",
   "src/pages/model-catalogs/components/ModelCatalogCard.tsx": "132f283f4613247531e4a7603d3b6d44",
   "src/pages/model-catalogs/components/VariantTable.tsx": "3cd5dd6edd452daa33e327aaf391a9b7",
@@ -373,7 +373,7 @@
   "src/foundation/lib/model-registry-visibility.ts": "24550d054dd3e6365f09c526b829302a",
   "src/domains/role/lib/format-permission.ts": "9f2b7f7a698e51dc6ba8188a808db44b",
   "src/domains/model-catalog/lib/catalog-import.ts": "0722a4c305e6f4066c9f70aed2e61ed0",
-  "src/foundation/lib/error-message.ts": "2785e4aefa66aa19662cf51d21aa6874",
+  "src/foundation/lib/error-message.ts": "e7845dbba8c0a36698c7775a078a455d",
   "src/domains/endpoint/lib/model-spec.ts": "18639ba24921f56eef631d1cbe1398fe",
   "src/foundation/components/PaginationControls.tsx": "93cfc849b897fe0d688b6dbb000ecc15",
   "src/domains/api-key/lib/create-api-key-error.ts": "f49c61569f3dba4d91247d2f7ad97913",
@@ -395,5 +395,7 @@
   "src/domains/endpoint/lib/engine-cache-args.ts": "4eb64234934587917d3344e88b0c16c2",
   "src/domains/cluster/components/ClusterResourceSummary.tsx": "a6d16b69f0e59757e2435b6a707a0239",
   "src/foundation/components/MetricBar.tsx": "58b87909b5d1371dfdd6f5932adb8408",
-  "src/foundation/components/ResourceUsageLegend.tsx": "c09c3da92d40c1b98d3450f65a7feb10"
+  "src/foundation/components/ResourceUsageLegend.tsx": "c09c3da92d40c1b98d3450f65a7feb10",
+  "src/domains/endpoint/lib/save-as-catalog.ts": "92faeef51fe64fcc065322c760d9443e",
+  "src/domains/endpoint/components/EndpointSaveAsCatalogAction.tsx": "4a5d02cc27df64ef6f134570bdc09f1d"
 }

--- a/src/domains/endpoint/components/EndpointSaveAsCatalogAction.test.tsx
+++ b/src/domains/endpoint/components/EndpointSaveAsCatalogAction.test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { type ReactNode, useState } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Endpoint } from "@/domains/endpoint/types";
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn(),
+  mutateAsync: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@refinedev/core", () => ({
+  useCreate: () => ({ mutateAsync: mocks.mutateAsync, isLoading: false }),
+  useInvalidate: () => mocks.invalidate,
+}));
+
+vi.mock("@/foundation/lib/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess },
+}));
+
+vi.mock("@/foundation/components/Table", () => ({
+  RowAction: ({ onClick, title }: { onClick: () => void; title: string }) => (
+    <button type="button" onClick={onClick}>
+      {title}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+import {
+  EndpointSaveAsCatalogAction,
+  EndpointSaveAsCatalogProvider,
+} from "./EndpointSaveAsCatalogAction";
+
+const endpoint = {
+  metadata: { name: "qwen-chat", workspace: "team-a", labels: {} },
+  spec: {
+    cluster: "prod",
+    model: { registry: "hf", name: "Qwen/Qwen3-8B", version: "v2" },
+    engine: { engine: "vllm", version: "0.24" },
+    resources: { cpu: "4", memory: "16Gi", gpu: "1" },
+    replicas: { num: 2 },
+    deployment_options: null,
+    variables: { engine_args: {} },
+    env: null,
+  },
+} as unknown as Endpoint;
+
+const renderAction = () =>
+  render(
+    <EndpointSaveAsCatalogProvider>
+      <EndpointSaveAsCatalogAction endpoint={endpoint} />
+    </EndpointSaveAsCatalogProvider>,
+  );
+
+const openDialog = () => {
+  fireEvent.click(screen.getByText("endpoints.actions.saveAsCatalog"));
+};
+
+const nameInput = () =>
+  screen.getByLabelText("endpoints.saveAsCatalog.nameLabel");
+
+describe("EndpointSaveAsCatalogAction", () => {
+  beforeEach(() => {
+    mocks.invalidate.mockReset().mockResolvedValue(undefined);
+    mocks.mutateAsync.mockReset().mockResolvedValue({});
+    mocks.toastError.mockReset();
+    mocks.toastSuccess.mockReset();
+  });
+
+  it("offers the endpoint's own name and creates a catalog under it", async () => {
+    renderAction();
+    openDialog();
+
+    expect((nameInput() as HTMLInputElement).value).toBe("qwen-chat");
+
+    fireEvent.click(screen.getByText("endpoints.saveAsCatalog.submit"));
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    const call = mocks.mutateAsync.mock.calls[0][0];
+    expect(call.resource).toBe("model_catalogs");
+    expect(call.values.metadata.name).toBe("qwen-chat");
+    expect(call.values.spec.model.name).toBe("Qwen/Qwen3-8B");
+    expect(call.values.spec).not.toHaveProperty("replicas");
+    expect(mocks.toastSuccess).toHaveBeenCalled();
+  });
+
+  it("creates under the name the user typed", async () => {
+    renderAction();
+    openDialog();
+
+    fireEvent.change(nameInput(), { target: { value: "qwen-tuned" } });
+    fireEvent.click(screen.getByText("endpoints.saveAsCatalog.submit"));
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mocks.mutateAsync.mock.calls[0][0].values.metadata.name).toBe(
+      "qwen-tuned",
+    );
+  });
+
+  // The typed name is the only thing to fix, so it must survive the refusal.
+  it("keeps the dialog open when the name is taken", async () => {
+    mocks.mutateAsync.mockRejectedValue({ code: "23505" });
+
+    renderAction();
+    openDialog();
+    fireEvent.click(screen.getByText("endpoints.saveAsCatalog.submit"));
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "endpoints.messages.saveAsCatalogDuplicate",
+      ),
+    );
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+  });
+
+  it("closes on success", async () => {
+    renderAction();
+    openDialog();
+    fireEvent.click(screen.getByText("endpoints.saveAsCatalog.submit"));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  });
+});
+
+// The action lives inside a dropdown menu, which closes on the very click that
+// opens the dialog. A dialog rendered by the action itself goes with it — the
+// symptom is a dialog that flashes and vanishes. The provider holds it instead.
+describe("dialog placement", () => {
+  function MenuHarness() {
+    const [menuOpen, setMenuOpen] = useState(true);
+
+    return (
+      <EndpointSaveAsCatalogProvider>
+        {menuOpen && (
+          <div>
+            <EndpointSaveAsCatalogAction endpoint={endpoint} />
+            <button type="button" onClick={() => setMenuOpen(false)}>
+              close menu
+            </button>
+          </div>
+        )}
+      </EndpointSaveAsCatalogProvider>
+    );
+  }
+
+  it("survives the menu that opened it going away", () => {
+    render(<MenuHarness />);
+
+    fireEvent.click(screen.getByText("endpoints.actions.saveAsCatalog"));
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+
+    fireEvent.click(screen.getByText("close menu"));
+
+    expect(screen.queryByRole("dialog")).not.toBeNull();
+  });
+
+  it("does nothing without a provider rather than opening a lost dialog", () => {
+    render(<EndpointSaveAsCatalogAction endpoint={endpoint} />);
+
+    fireEvent.click(screen.getByText("endpoints.actions.saveAsCatalog"));
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/src/domains/endpoint/components/EndpointSaveAsCatalogAction.tsx
+++ b/src/domains/endpoint/components/EndpointSaveAsCatalogAction.tsx
@@ -1,0 +1,194 @@
+import { useCreate, useInvalidate } from "@refinedev/core";
+import { BookmarkPlus } from "lucide-react";
+import { createContext, type ReactNode, useContext, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { buildCatalogFromEndpoint } from "@/domains/endpoint/lib/save-as-catalog";
+import type { Endpoint } from "@/domains/endpoint/types";
+import { RowAction, type RowActionProps } from "@/foundation/components/Table";
+import {
+  getErrorMessage,
+  isDuplicateNameError,
+} from "@/foundation/lib/error-message";
+import { useTranslation } from "@/foundation/lib/i18n";
+
+/**
+ * Saves what an endpoint is running as a new model catalog.
+ *
+ * A separate action rather than a step of deploying, so it cannot half-succeed
+ * alongside a deployment, and so a user who may run endpoints but not write
+ * catalogs is refused here rather than mid-deploy. It always creates: writing
+ * back into the catalog an endpoint came from is what this deliberately
+ * replaces — see `buildCatalogFromEndpoint`.
+ */
+
+type SaveAsCatalogContextValue = {
+  openSaveAsCatalog: (endpoint: Endpoint) => void;
+};
+
+const SaveAsCatalogContext = createContext<SaveAsCatalogContextValue | null>(
+  null,
+);
+
+/**
+ * Renders the dialog outside any dropdown. The action itself lives inside the
+ * row/page menu, and a dialog mounted there is dismissed by the same click
+ * that closes the menu — so the state is held here and the dialog rendered as
+ * a sibling of the page. Wrap the list and show pages with this.
+ */
+export function EndpointSaveAsCatalogProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [endpoint, setEndpoint] = useState<Endpoint | null>(null);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <SaveAsCatalogContext.Provider
+      value={{
+        openSaveAsCatalog: (next) => {
+          setEndpoint(next);
+          setOpen(true);
+        },
+      }}
+    >
+      {children}
+      {endpoint && (
+        <SaveAsCatalogDialog
+          // Remounting per endpoint is what re-seeds the name field, so opening
+          // the dialog on a second endpoint does not offer the first one's name.
+          key={endpoint.metadata.name}
+          endpoint={endpoint}
+          open={open}
+          onOpenChange={setOpen}
+        />
+      )}
+    </SaveAsCatalogContext.Provider>
+  );
+}
+
+type EndpointSaveAsCatalogActionProps = RowActionProps & {
+  endpoint: Endpoint;
+};
+
+/** Menu item that opens the dialog through the provider. Safe inside dropdown
+ * content — no dialog lives here. */
+export const EndpointSaveAsCatalogAction = ({
+  endpoint,
+  title,
+  disabled,
+  icon,
+  ...props
+}: EndpointSaveAsCatalogActionProps) => {
+  const { t } = useTranslation();
+  const context = useContext(SaveAsCatalogContext);
+
+  return (
+    <RowAction
+      {...props}
+      icon={icon ?? <BookmarkPlus size={16} />}
+      title={title ?? t("endpoints.actions.saveAsCatalog")}
+      disabled={disabled || !context}
+      onClick={() => context?.openSaveAsCatalog(endpoint)}
+    />
+  );
+};
+
+EndpointSaveAsCatalogAction.displayName = "EndpointSaveAsCatalogAction";
+
+function SaveAsCatalogDialog({
+  endpoint,
+  open,
+  onOpenChange,
+}: {
+  endpoint: Endpoint;
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const invalidate = useInvalidate();
+  const { mutateAsync, isLoading } = useCreate();
+  const [name, setName] = useState(endpoint.metadata.name);
+
+  const handleSave = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || isLoading) return;
+
+    try {
+      await mutateAsync({
+        resource: "model_catalogs",
+        values: buildCatalogFromEndpoint(endpoint, trimmed),
+        meta: {
+          idColumnName: "metadata->name",
+          workspace: endpoint.metadata.workspace ?? "",
+          workspaced: true,
+        },
+        successNotification: false,
+        errorNotification: false,
+      });
+
+      toast.success(
+        t("endpoints.messages.saveAsCatalogSuccess", { name: trimmed }),
+      );
+      onOpenChange(false);
+      await invalidate({ resource: "model_catalogs", invalidates: ["list"] });
+    } catch (error) {
+      // The dialog stays open on every failure: the name is the one thing the
+      // user typed, and a duplicate is fixed by editing it.
+      toast.error(
+        isDuplicateNameError(error)
+          ? t("endpoints.messages.saveAsCatalogDuplicate", { name: trimmed })
+          : getErrorMessage(error, t("endpoints.messages.saveAsCatalogFailed")),
+      );
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent data-testid="endpoint-save-as-catalog-dialog">
+        <DialogHeader>
+          <DialogTitle>{t("endpoints.saveAsCatalog.title")}</DialogTitle>
+          <DialogDescription>
+            {t("endpoints.saveAsCatalog.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="save-as-catalog-name">
+            {t("endpoints.saveAsCatalog.nameLabel")}
+          </Label>
+          <Input
+            id="save-as-catalog-name"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+          />
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isLoading}
+          >
+            {t("buttons.cancel")}
+          </Button>
+          <Button
+            onClick={() => void handleSave()}
+            disabled={isLoading || !name.trim()}
+          >
+            {t("endpoints.saveAsCatalog.submit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/domains/endpoint/lib/save-as-catalog.test.ts
+++ b/src/domains/endpoint/lib/save-as-catalog.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { Endpoint } from "@/domains/endpoint/types";
+import { buildCatalogFromEndpoint } from "./save-as-catalog";
+
+const endpoint = (spec: Partial<Endpoint["spec"]> = {}) =>
+  ({
+    metadata: {
+      name: "qwen-chat",
+      workspace: "team-a",
+      labels: { "neutree.ai/last_replicas": "3" },
+    },
+    spec: {
+      cluster: "prod",
+      model: { registry: "hf", name: "Qwen/Qwen3-8B", version: "v2" },
+      engine: { engine: "vllm", version: "0.24" },
+      resources: { cpu: "4", memory: "16Gi", gpu: "1" },
+      replicas: { num: 0 },
+      deployment_options: { scheduler: { type: "consistent_hash" } },
+      variables: { engine_args: { "max-model-len": 32768 } },
+      env: { HF_TOKEN: "x" },
+      ...spec,
+    },
+  }) as unknown as Endpoint;
+
+describe("buildCatalogFromEndpoint", () => {
+  it("carries the configuration over under the given name", () => {
+    const catalog = buildCatalogFromEndpoint(endpoint(), "qwen-tuned");
+
+    expect(catalog.metadata).toEqual({
+      name: "qwen-tuned",
+      workspace: "team-a",
+      labels: {},
+    });
+    expect(catalog.spec).toEqual({
+      model: { registry: "hf", name: "Qwen/Qwen3-8B", version: "v2" },
+      engine: { engine: "vllm", version: "0.24" },
+      resources: { cpu: "4", memory: "16Gi", gpu: "1" },
+      deployment_options: { scheduler: { type: "consistent_hash" } },
+      variables: { engine_args: { "max-model-len": 32768 } },
+      env: { HF_TOKEN: "x" },
+    });
+  });
+
+  // A catalog has no cluster, and a paused endpoint reports 0 replicas while
+  // the real count waits in a label — saving either would be wrong.
+  it("drops cluster and replicas", () => {
+    const catalog = buildCatalogFromEndpoint(endpoint(), "qwen-tuned");
+
+    expect(catalog.spec).not.toHaveProperty("cluster");
+    expect(catalog.spec).not.toHaveProperty("replicas");
+  });
+
+  it("does not inherit the endpoint's labels", () => {
+    const catalog = buildCatalogFromEndpoint(endpoint(), "qwen-tuned");
+
+    expect((catalog.metadata as { labels: unknown }).labels).toEqual({});
+  });
+
+  // Recipe-deployed endpoints hold the composed engine args; the catalog states
+  // that result and claims nothing about which layer produced it.
+  it("writes the composed engine args flat, with no recipe structure", () => {
+    const catalog = buildCatalogFromEndpoint(endpoint(), "qwen-tuned") as {
+      spec: Record<string, unknown>;
+    };
+
+    expect(catalog.spec.variables).toEqual({
+      engine_args: { "max-model-len": 32768 },
+    });
+    expect(catalog.spec).not.toHaveProperty("variants");
+    expect(catalog.spec).not.toHaveProperty("features");
+    expect(catalog.spec).not.toHaveProperty("base");
+  });
+
+  // Flex endpoints submit empty strings rather than omitting the model, and
+  // that is carried over as-is: an absent model is refused by the catalog's
+  // own spec check.
+  it("carries an all-empty model through untouched", () => {
+    const catalog = buildCatalogFromEndpoint(
+      endpoint({
+        model: { registry: "", name: "", file: "", version: "", task: "" },
+      }),
+      "flex-copy",
+    ) as { spec: Record<string, unknown> };
+
+    expect(catalog.spec.model).toEqual({
+      registry: "",
+      name: "",
+      file: "",
+      version: "",
+      task: "",
+    });
+  });
+});

--- a/src/domains/endpoint/lib/save-as-catalog.ts
+++ b/src/domains/endpoint/lib/save-as-catalog.ts
@@ -1,0 +1,47 @@
+import type { Endpoint } from "@/domains/endpoint/types";
+
+/**
+ * The model catalog an endpoint's current configuration would be saved as.
+ *
+ * The result is a flat catalog: no variants, no features, and no link back to
+ * the catalog the endpoint was deployed from. An endpoint holds the *composed*
+ * result of whatever recipe produced it, and nothing in it says which layer —
+ * base, variant or feature — any one engine arg came from, so a saved catalog
+ * can only state the result. Trying to write those args back into their
+ * original layers is what this deliberately does not do.
+ *
+ * Two fields are dropped rather than carried:
+ *
+ *   - `cluster` — a catalog has no such field; where to deploy is chosen per
+ *     deployment.
+ *   - `replicas` — deployment scale is not part of the template. It also keeps
+ *     a paused endpoint, whose replica count is 0 while the real number waits
+ *     in a label, from saving a catalog that deploys nothing.
+ *
+ * Labels are not inherited either: an endpoint's carry runtime bookkeeping
+ * (the paused replica count among them) that means nothing on a catalog.
+ */
+export function buildCatalogFromEndpoint(
+  endpoint: Endpoint,
+  name: string,
+): Record<string, unknown> {
+  const spec = endpoint.spec;
+
+  return {
+    api_version: "v1",
+    kind: "ModelCatalog",
+    metadata: {
+      name,
+      workspace: endpoint.metadata.workspace,
+      labels: {},
+    },
+    spec: {
+      model: spec.model ?? null,
+      engine: spec.engine ?? null,
+      resources: spec.resources ?? null,
+      deployment_options: spec.deployment_options ?? null,
+      variables: spec.variables ?? null,
+      env: spec.env ?? null,
+    },
+  };
+}

--- a/src/foundation/lib/error-message.ts
+++ b/src/foundation/lib/error-message.ts
@@ -17,3 +17,29 @@ export const getErrorMessage = (error: unknown, fallback: string): string => {
     ? message.trim()
     : fallback;
 };
+
+/**
+ * Whether a failed write was refused because the name is already taken.
+ *
+ * Every resource here is unique on (workspace, name), and PostgREST reports
+ * that as a raw constraint violation. Callers turn it into what actually
+ * happened — "that name is in use" — instead of showing the constraint.
+ *
+ * The shape varies with how far up the stack the failure was wrapped, so all
+ * the forms it arrives in are recognised rather than only the tidiest one.
+ */
+export const isDuplicateNameError = (error: unknown): boolean => {
+  if (!error || typeof error !== "object") return false;
+
+  const e = error as { statusCode?: number; code?: string; message?: string };
+  if (e.statusCode === 409 || e.code === "23505") return true;
+
+  const message = (e.message ?? "").toLowerCase();
+
+  return (
+    message.includes("duplicate key") ||
+    message.includes("already exists") ||
+    message.includes("23505") ||
+    message.includes("unique constraint")
+  );
+};

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -920,6 +920,7 @@
 		"actions": {
 			"openResources": "Open Resources",
 			"pause": "Pause",
+			"saveAsCatalog": "Save as Catalog",
 			"resume": "Resume"
 		},
 		"messages": {
@@ -927,6 +928,9 @@
 			"rayDashboardNotAvailable": "Ray dashboard is not available.",
 			"fetching": "fetching...",
 			"modelNotFoundInRegistry": "Model not found in selected registry",
+			"saveAsCatalogSuccess": "Saved as catalog \"{{name}}\"",
+			"saveAsCatalogFailed": "Failed to save as catalog",
+			"saveAsCatalogDuplicate": "A catalog named \"{{name}}\" already exists in this workspace",
 			"modelRegistryNotInWorkspace": "Model registry \"{{name}}\" does not exist in this workspace",
 			"modelRegistryUnreachable": "Not answering — cannot list models",
 			"modelRegistryDeleted": "Being deleted",
@@ -1139,6 +1143,12 @@
 			"autoConfigured": "Model, engine and resources are auto-configured from the selected variant.",
 			"showAdvanced": "Show all options",
 			"hideAdvanced": "Hide advanced options"
+		},
+		"saveAsCatalog": {
+			"title": "Save as Catalog",
+			"description": "Creates a new catalog from this endpoint's current configuration. It is not linked to the catalog this endpoint was deployed from, and carries no variants or features.",
+			"nameLabel": "Catalog name",
+			"submit": "Save"
 		}
 	},
 	"external_endpoints": {

--- a/src/pages/endpoints/list.tsx
+++ b/src/pages/endpoints/list.tsx
@@ -1,6 +1,10 @@
 import EndpointEngine from "@/domains/endpoint/components/EndpointEngine";
 import EndpointModel from "@/domains/endpoint/components/EndpointModel";
 import { EndpointPauseAction } from "@/domains/endpoint/components/EndpointPauseAction";
+import {
+  EndpointSaveAsCatalogAction,
+  EndpointSaveAsCatalogProvider,
+} from "@/domains/endpoint/components/EndpointSaveAsCatalogAction";
 import EndpointStatus from "@/domains/endpoint/components/EndpointStatus";
 import ModelTask from "@/domains/endpoint/components/ModelTask";
 import { ModelTaskFilter } from "@/domains/endpoint/components/ModelTaskFilter";
@@ -15,97 +19,104 @@ import type { BaseStatus } from "@/foundation/types/basic-types";
 export const EndpointsList = () => {
   const { t } = useTranslation();
   const metadataColumns = useMetadataColumns({
-    extraActions: (row) => <EndpointPauseAction endpoint={row} />,
+    extraActions: (row) => (
+      <>
+        <EndpointPauseAction endpoint={row} />
+        <EndpointSaveAsCatalogAction endpoint={row} />
+      </>
+    ),
   });
 
   return (
-    <ListPage title={t("endpoints.title")} breadcrumb={false}>
-      <Table
-        enableSorting
-        enableFilters
-        enableBatchDelete
-        searchField="metadata->>name"
-        refineCoreProps={{
-          sorters: {
-            initial: [
-              { field: "status_sort_priority", order: "asc" },
-              { field: "metadata->creation_timestamp", order: "desc" },
-            ],
-          },
-        }}
-        filters={({ filters, setFilters }) => (
-          <ModelTaskFilter filters={filters} setFilters={setFilters} />
-        )}
-      >
-        {metadataColumns.name}
-        {metadataColumns.workspace}
-        <Table.Column
-          header={t("common.fields.status")}
-          accessorKey="status"
-          id="status"
-          enableHiding
-          cell={({ getValue }) => {
-            return (
-              <EndpointStatus {...(getValue() as unknown as BaseStatus)} />
-            );
+    <EndpointSaveAsCatalogProvider>
+      <ListPage title={t("endpoints.title")} breadcrumb={false}>
+        <Table
+          enableSorting
+          enableFilters
+          enableBatchDelete
+          searchField="metadata->>name"
+          refineCoreProps={{
+            sorters: {
+              initial: [
+                { field: "status_sort_priority", order: "asc" },
+                { field: "metadata->creation_timestamp", order: "desc" },
+              ],
+            },
           }}
-        />
-        <Table.Column
-          header={t("common.fields.model")}
-          accessorKey="status"
-          id="model"
-          enableHiding
-          cell={({ row }) => {
-            const { model } = row.original.spec;
-            return <EndpointModel model={model} />;
-          }}
-        />
-        <Table.Column
-          header={t("common.fields.task")}
-          accessorKey="spec.model.task"
-          id="task"
-          enableHiding
-          cell={({ row }) => {
-            const { model } = row.original.spec;
-            return <ModelTask task={model.task} />;
-          }}
-        />
-        <Table.Column
-          header={t("common.fields.engine")}
-          accessorKey="spec.engine.engine"
-          id="engine"
-          enableHiding
-          cell={({ row }) => {
-            return <EndpointEngine {...(row.original as Endpoint)} />;
-          }}
-        />
-        <Table.Column
-          header={t("common.fields.cluster")}
-          accessorKey="spec.cluster"
-          id="cluster"
-          enableHiding
-          cell={({ row }) => {
-            const {
-              spec: { cluster },
-              metadata,
-            } = row.original;
-            return (
-              <ShowButton
-                recordItemId={cluster}
-                meta={{
-                  workspace: metadata.workspace,
-                }}
-                variant="link"
-                resource="clusters"
-              >
-                {cluster}
-              </ShowButton>
-            );
-          }}
-        />
-        {metadataColumns.creation_timestamp}
-        {metadataColumns.action}
-      </Table>
-    </ListPage>
+          filters={({ filters, setFilters }) => (
+            <ModelTaskFilter filters={filters} setFilters={setFilters} />
+          )}
+        >
+          {metadataColumns.name}
+          {metadataColumns.workspace}
+          <Table.Column
+            header={t("common.fields.status")}
+            accessorKey="status"
+            id="status"
+            enableHiding
+            cell={({ getValue }) => {
+              return (
+                <EndpointStatus {...(getValue() as unknown as BaseStatus)} />
+              );
+            }}
+          />
+          <Table.Column
+            header={t("common.fields.model")}
+            accessorKey="status"
+            id="model"
+            enableHiding
+            cell={({ row }) => {
+              const { model } = row.original.spec;
+              return <EndpointModel model={model} />;
+            }}
+          />
+          <Table.Column
+            header={t("common.fields.task")}
+            accessorKey="spec.model.task"
+            id="task"
+            enableHiding
+            cell={({ row }) => {
+              const { model } = row.original.spec;
+              return <ModelTask task={model.task} />;
+            }}
+          />
+          <Table.Column
+            header={t("common.fields.engine")}
+            accessorKey="spec.engine.engine"
+            id="engine"
+            enableHiding
+            cell={({ row }) => {
+              return <EndpointEngine {...(row.original as Endpoint)} />;
+            }}
+          />
+          <Table.Column
+            header={t("common.fields.cluster")}
+            accessorKey="spec.cluster"
+            id="cluster"
+            enableHiding
+            cell={({ row }) => {
+              const {
+                spec: { cluster },
+                metadata,
+              } = row.original;
+              return (
+                <ShowButton
+                  recordItemId={cluster}
+                  meta={{
+                    workspace: metadata.workspace,
+                  }}
+                  variant="link"
+                  resource="clusters"
+                >
+                  {cluster}
+                </ShowButton>
+              );
+            }}
+          />
+          {metadataColumns.creation_timestamp}
+          {metadataColumns.action}
+        </Table>
+      </ListPage>
+    </EndpointSaveAsCatalogProvider>
   );
 };

--- a/src/pages/endpoints/show.tsx
+++ b/src/pages/endpoints/show.tsx
@@ -16,6 +16,10 @@ import { EndpointPauseAction } from "@/domains/endpoint/components/EndpointPause
 import EndpointRuntimeResourcesCard, {
   EndpointRuntimeResourcesSummary,
 } from "@/domains/endpoint/components/EndpointRuntimeResourcesCard";
+import {
+  EndpointSaveAsCatalogAction,
+  EndpointSaveAsCatalogProvider,
+} from "@/domains/endpoint/components/EndpointSaveAsCatalogAction";
 import EndpointStatus from "@/domains/endpoint/components/EndpointStatus";
 import ModelTask from "@/domains/endpoint/components/ModelTask";
 import { useEndpointMonitorPanels } from "@/domains/endpoint/hooks/use-endpoint-monitor-panels";
@@ -192,205 +196,224 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
   const playground = resolvePlayground(engineVersion, record.spec.model.task);
 
   return (
-    <ShowPage
-      record={record}
-      showCurrentBreadcrumb={false}
-      extraActions={() => <EndpointPauseAction endpoint={record} />}
-    >
-      <Tabs defaultValue="basic" className="flex h-full flex-col">
-        <ShowPage.ObjectHeader
-          title={record.metadata.name}
-          descriptionClassName="max-w-none"
-          description={
-            <span className="inline-flex flex-wrap items-center gap-x-3 gap-y-0.5">
-              <ShowPage.Meta label={t("common.fields.model")}>
-                <EndpointModel model={record.spec.model} />
-              </ShowPage.Meta>
-              <ShowPage.Meta label={t("common.fields.task")}>
-                <ModelTask task={record.spec.model.task} />
-              </ShowPage.Meta>
-              <ShowPage.Meta label={t("common.fields.engine")}>
-                <EndpointEngine {...record} />
-              </ShowPage.Meta>
-              <ShowPage.Meta label={t("common.fields.cluster")}>
-                <ShowButton
-                  recordItemId={record.spec.cluster}
-                  meta={{
-                    workspace: record.metadata.workspace,
-                  }}
-                  variant="link"
-                  resource="clusters"
-                >
-                  {record.spec.cluster}
-                </ShowButton>
-              </ShowPage.Meta>
-              {url && (
-                <EndpointAccessSummary serviceUrl={url} className="shrink-0" />
-              )}
-              <ShowPage.Meta label={t("endpoints.fields.replicas")}>
-                {replicaCount}
-              </ShowPage.Meta>
-              {shouldShowScheduler && (
-                <ShowPage.Meta label={t("common.fields.scheduler")}>
-                  {schedulerText}
-                </ShowPage.Meta>
-              )}
-              <ShowPage.Meta label={t("common.fields.createdAt")}>
-                <Timestamp
-                  timestamp={record.metadata.creation_timestamp}
-                  relative
-                />
-              </ShowPage.Meta>
-            </span>
-          }
-          status={<EndpointStatus {...record.status} />}
-        />
-        <TabsList className="relative h-11 w-full items-end justify-start gap-8 rounded-none border-0 bg-transparent p-0 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:bg-border">
-          <TabsTrigger value="basic" className={detailTabTriggerClassName}>
-            {t("common.tabs.basic")}
-          </TabsTrigger>
-          {shouldShowRayDashboard && (
-            <TabsTrigger value="ray" className={detailTabTriggerClassName}>
-              {t("common.tabs.rayDashboard")}
-            </TabsTrigger>
-          )}
-          {showMonitorTab && (
-            <TabsTrigger value="monitor" className={detailTabTriggerClassName}>
-              {t("common.tabs.monitor")}
-            </TabsTrigger>
-          )}
-          <TabsTrigger value="logs" className={detailTabTriggerClassName}>
-            {t("common.tabs.logs")}
-          </TabsTrigger>
-          {playground.enabled && (
-            <TabsTrigger
-              value="playground"
-              className={detailTabTriggerClassName}
-            >
-              {t("endpoints.tabs.playground")}
-            </TabsTrigger>
-          )}
-        </TabsList>
-        <TabsContent
-          value="basic"
-          className="mt-0 flex-1 space-y-3 overflow-auto pt-4"
-        >
-          <div className="space-y-3">
-            <ShowPage.Section
-              title={t("endpoints.sections.runtimeAllocation")}
-              actions={
-                <EndpointRuntimeResourcesSummary
-                  resources={record.status?.resources}
-                />
-              }
-            >
-              <div className="space-y-6">
-                <EndpointRuntimeResourcesCard
-                  resources={record.status?.resources}
-                  requestedResources={record.spec.resources}
-                />
-              </div>
-            </ShowPage.Section>
-          </div>
-          <EndpointAdvancedParameters
-            engineParameters={
-              record.spec.variables?.engine_args as
-                | Record<string, unknown>
-                | undefined
-            }
-            environmentVariables={record.spec.env}
-          />
-        </TabsContent>
-        {shouldShowRayDashboard && (
-          <TabsContent value="ray" className="mt-0 flex-1">
-            <RayDashboardTab record={record} cluster={clusterData?.data?.[0]} />
-          </TabsContent>
+    <EndpointSaveAsCatalogProvider>
+      <ShowPage
+        record={record}
+        showCurrentBreadcrumb={false}
+        extraActions={() => (
+          <>
+            <EndpointPauseAction endpoint={record} />
+            <EndpointSaveAsCatalogAction endpoint={record} />
+          </>
         )}
-        <TabsContent
-          value="monitor"
-          className="mt-0 flex-1 overflow-hidden pt-4"
-        >
-          {grafanaUrl ? (
-            <div className="flex flex-col gap-4 h-full">
-              {showSelector && (
-                <div className="flex justify-start pb-2">
-                  <SegmentedControl
-                    ariaLabel={t("common.tabs.monitor")}
+      >
+        <Tabs defaultValue="basic" className="flex h-full flex-col">
+          <ShowPage.ObjectHeader
+            title={record.metadata.name}
+            descriptionClassName="max-w-none"
+            description={
+              <span className="inline-flex flex-wrap items-center gap-x-3 gap-y-0.5">
+                <ShowPage.Meta label={t("common.fields.model")}>
+                  <EndpointModel model={record.spec.model} />
+                </ShowPage.Meta>
+                <ShowPage.Meta label={t("common.fields.task")}>
+                  <ModelTask task={record.spec.model.task} />
+                </ShowPage.Meta>
+                <ShowPage.Meta label={t("common.fields.engine")}>
+                  <EndpointEngine {...record} />
+                </ShowPage.Meta>
+                <ShowPage.Meta label={t("common.fields.cluster")}>
+                  <ShowButton
+                    recordItemId={record.spec.cluster}
+                    meta={{
+                      workspace: record.metadata.workspace,
+                    }}
+                    variant="link"
+                    resource="clusters"
+                  >
+                    {record.spec.cluster}
+                  </ShowButton>
+                </ShowPage.Meta>
+                {url && (
+                  <EndpointAccessSummary
+                    serviceUrl={url}
                     className="shrink-0"
-                    items={panels.map((panel) => ({
-                      value: panel,
-                      description:
-                        panel === "latency"
-                          ? t("endpoints.monitor.latencyDescription")
-                          : panel === "throughput"
-                            ? t("endpoints.monitor.throughputDescription")
-                            : panel === "queue"
-                              ? t("endpoints.monitor.queueDescription")
-                              : panel === "cache"
-                                ? t("endpoints.monitor.cacheDescription")
-                                : t("endpoints.monitor.overviewDescription"),
-                      label:
-                        panel === "overview"
-                          ? t("endpoints.monitor.overviewMetrics")
-                          : panel === "latency"
-                            ? t("endpoints.monitor.latencyMetrics")
-                            : panel === "throughput"
-                              ? t("endpoints.monitor.throughputMetrics")
-                              : panel === "queue"
-                                ? t("endpoints.monitor.queueMetrics")
-                                : t("endpoints.monitor.cacheMetrics"),
-                    }))}
-                    onValueChange={setSelectedPanel}
-                    value={selectedPanel || undefined}
+                  />
+                )}
+                <ShowPage.Meta label={t("endpoints.fields.replicas")}>
+                  {replicaCount}
+                </ShowPage.Meta>
+                {shouldShowScheduler && (
+                  <ShowPage.Meta label={t("common.fields.scheduler")}>
+                    {schedulerText}
+                  </ShowPage.Meta>
+                )}
+                <ShowPage.Meta label={t("common.fields.createdAt")}>
+                  <Timestamp
+                    timestamp={record.metadata.creation_timestamp}
+                    relative
+                  />
+                </ShowPage.Meta>
+              </span>
+            }
+            status={<EndpointStatus {...record.status} />}
+          />
+          <TabsList className="relative h-11 w-full items-end justify-start gap-8 rounded-none border-0 bg-transparent p-0 after:absolute after:bottom-0 after:left-0 after:right-0 after:h-px after:bg-border">
+            <TabsTrigger value="basic" className={detailTabTriggerClassName}>
+              {t("common.tabs.basic")}
+            </TabsTrigger>
+            {shouldShowRayDashboard && (
+              <TabsTrigger value="ray" className={detailTabTriggerClassName}>
+                {t("common.tabs.rayDashboard")}
+              </TabsTrigger>
+            )}
+            {showMonitorTab && (
+              <TabsTrigger
+                value="monitor"
+                className={detailTabTriggerClassName}
+              >
+                {t("common.tabs.monitor")}
+              </TabsTrigger>
+            )}
+            <TabsTrigger value="logs" className={detailTabTriggerClassName}>
+              {t("common.tabs.logs")}
+            </TabsTrigger>
+            {playground.enabled && (
+              <TabsTrigger
+                value="playground"
+                className={detailTabTriggerClassName}
+              >
+                {t("endpoints.tabs.playground")}
+              </TabsTrigger>
+            )}
+          </TabsList>
+          <TabsContent
+            value="basic"
+            className="mt-0 flex-1 space-y-3 overflow-auto pt-4"
+          >
+            <div className="space-y-3">
+              <ShowPage.Section
+                title={t("endpoints.sections.runtimeAllocation")}
+                actions={
+                  <EndpointRuntimeResourcesSummary
+                    resources={record.status?.resources}
+                  />
+                }
+              >
+                <div className="space-y-6">
+                  <EndpointRuntimeResourcesCard
+                    resources={record.status?.resources}
+                    requestedResources={record.spec.resources}
                   />
                 </div>
-              )}
-
-              {selectedPanel ? (
-                <GrafanaDashboard
-                  {...getEndpointSplitDashboardProps(
-                    grafanaUrl,
-                    selectedPanel,
-                    {
-                      clusterName: record.spec.cluster,
-                      endpointName: record.metadata.name,
-                    },
-                  )}
-                  className="flex-1"
-                  hideVariables
-                />
-              ) : null}
+              </ShowPage.Section>
             </div>
-          ) : (
-            <div className="flex items-center justify-center h-full">
-              <p className="text-muted-foreground">
-                {t("common.messages.grafanaNotConfigured")}
-              </p>
-            </div>
+            <EndpointAdvancedParameters
+              engineParameters={
+                record.spec.variables?.engine_args as
+                  | Record<string, unknown>
+                  | undefined
+              }
+              environmentVariables={record.spec.env}
+            />
+          </TabsContent>
+          {shouldShowRayDashboard && (
+            <TabsContent value="ray" className="mt-0 flex-1">
+              <RayDashboardTab
+                record={record}
+                cluster={clusterData?.data?.[0]}
+              />
+            </TabsContent>
           )}
-        </TabsContent>
-        <TabsContent value="logs" className="mt-0 flex-1 overflow-hidden pt-4">
-          <Suspense fallback={<TabLoader />}>
-            <EndpointLogTabs endpoint={record} />
-          </Suspense>
-        </TabsContent>
-        {playground.enabled && (
           <TabsContent
-            value="playground"
-            className="mt-0 flex-1 overflow-hidden"
+            value="monitor"
+            className="mt-0 flex-1 overflow-hidden pt-4"
+          >
+            {grafanaUrl ? (
+              <div className="flex flex-col gap-4 h-full">
+                {showSelector && (
+                  <div className="flex justify-start pb-2">
+                    <SegmentedControl
+                      ariaLabel={t("common.tabs.monitor")}
+                      className="shrink-0"
+                      items={panels.map((panel) => ({
+                        value: panel,
+                        description:
+                          panel === "latency"
+                            ? t("endpoints.monitor.latencyDescription")
+                            : panel === "throughput"
+                              ? t("endpoints.monitor.throughputDescription")
+                              : panel === "queue"
+                                ? t("endpoints.monitor.queueDescription")
+                                : panel === "cache"
+                                  ? t("endpoints.monitor.cacheDescription")
+                                  : t("endpoints.monitor.overviewDescription"),
+                        label:
+                          panel === "overview"
+                            ? t("endpoints.monitor.overviewMetrics")
+                            : panel === "latency"
+                              ? t("endpoints.monitor.latencyMetrics")
+                              : panel === "throughput"
+                                ? t("endpoints.monitor.throughputMetrics")
+                                : panel === "queue"
+                                  ? t("endpoints.monitor.queueMetrics")
+                                  : t("endpoints.monitor.cacheMetrics"),
+                      }))}
+                      onValueChange={setSelectedPanel}
+                      value={selectedPanel || undefined}
+                    />
+                  </div>
+                )}
+
+                {selectedPanel ? (
+                  <GrafanaDashboard
+                    {...getEndpointSplitDashboardProps(
+                      grafanaUrl,
+                      selectedPanel,
+                      {
+                        clusterName: record.spec.cluster,
+                        endpointName: record.metadata.name,
+                      },
+                    )}
+                    className="flex-1"
+                    hideVariables
+                  />
+                ) : null}
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-full">
+                <p className="text-muted-foreground">
+                  {t("common.messages.grafanaNotConfigured")}
+                </p>
+              </div>
+            )}
+          </TabsContent>
+          <TabsContent
+            value="logs"
+            className="mt-0 flex-1 overflow-hidden pt-4"
           >
             <Suspense fallback={<TabLoader />}>
-              {playground.mode === "embedding" ? (
-                <EmbeddingPlayground endpoint={record} />
-              ) : playground.mode === "rerank" ? (
-                <RerankPlayground endpoint={record} />
-              ) : (
-                <ChatPlayground endpoint={record} />
-              )}
+              <EndpointLogTabs endpoint={record} />
             </Suspense>
           </TabsContent>
-        )}
-      </Tabs>
-    </ShowPage>
+          {playground.enabled && (
+            <TabsContent
+              value="playground"
+              className="mt-0 flex-1 overflow-hidden"
+            >
+              <Suspense fallback={<TabLoader />}>
+                {playground.mode === "embedding" ? (
+                  <EmbeddingPlayground endpoint={record} />
+                ) : playground.mode === "rerank" ? (
+                  <RerankPlayground endpoint={record} />
+                ) : (
+                  <ChatPlayground endpoint={record} />
+                )}
+              </Suspense>
+            </TabsContent>
+          )}
+        </Tabs>
+      </ShowPage>
+    </EndpointSaveAsCatalogProvider>
   );
 };

--- a/src/pages/model-catalogs/components/ImportDialog.tsx
+++ b/src/pages/model-catalogs/components/ImportDialog.tsx
@@ -22,7 +22,10 @@ import {
   runCatalogImport,
 } from "@/domains/model-catalog/lib/catalog-import";
 import { ALL_WORKSPACES, useWorkspace } from "@/foundation/hooks/use-workspace";
-import { getErrorMessage } from "@/foundation/lib/error-message";
+import {
+  getErrorMessage,
+  isDuplicateNameError,
+} from "@/foundation/lib/error-message";
 import { useTranslation } from "@/foundation/lib/i18n";
 import {
   isValidYamlResource,
@@ -32,22 +35,6 @@ import {
 import type { RecipeVariant } from "@/foundation/recipe/types";
 
 type Source = "yaml" | "url" | "file";
-
-// Each document is resolved against the store before writing, so a duplicate-name
-// collision means the catalog appeared between that read and the write. The unique
-// index catches it; this turns the raw constraint message into what happened.
-function isDuplicateNameError(err: unknown): boolean {
-  if (!err || typeof err !== "object") return false;
-  const e = err as { statusCode?: number; code?: string; message?: string };
-  if (e.statusCode === 409 || e.code === "23505") return true;
-  const msg = (e.message ?? "").toLowerCase();
-  return (
-    msg.includes("duplicate key") ||
-    msg.includes("already exists") ||
-    msg.includes("23505") ||
-    msg.includes("unique constraint")
-  );
-}
 
 // Per-document result of a client-side import, shown in the results table.
 type ModelCatalogImportItem = {


### PR DESCRIPTION
## Issue

The "save the parameters I changed back to the model catalog" requirement, resolved as **save as a new catalog** rather than write-back.

## Why not write back

An endpoint holds the *composed* result of the recipe that produced it. For `engine_args` that result is `base ← variant ← features[] ← the user's own edits`, merged shallow and last-write-wins, and nothing in the endpoint records which layer any one arg came from. Writing an arg back therefore means guessing a layer, and guessing wrong is not a cosmetic error: an arg parked in a variant survives unchecking the feature that put it there, so the feature can no longer be turned off.

`model`, `resources` and `engine` *are* safely reversible — features never touch them — but those are not the fields users want to keep; the engine args are.

Saving the result as its own flat catalog removes the question. Nothing has to be reversed, so nothing can be reversed wrongly.

## What it does

A **Save as Catalog** action, next to Pause both on the endpoint page and in the list row menu, opens a small dialog with one field, the catalog name, prefilled with the endpoint's. It creates a catalog with no variants and no features, carrying `model`, `engine`, `resources`, `deployment_options`, `variables` and `env` verbatim. The new catalog is not linked back to whatever the endpoint was deployed from — there is no relationship to keep consistent.

Deploying from it offers no variant or feature choices. That is the accepted trade.

**Not carried:**

- `cluster` — a catalog has no such field; where to deploy is chosen per deployment.
- `replicas` — deployment scale, not template. It also matters that Pause sets the replica count to 0 and parks the real number in a label, so carrying it would let a paused endpoint save a catalog that deploys nothing.
- the endpoint's labels — they carry runtime bookkeeping (that parked replica count among it) that means nothing on a catalog.

The dialog is held by `EndpointSaveAsCatalogProvider` rather than by the action itself. The action lives inside a dropdown, and the click that opens the dialog is the same click that closes the menu — a dialog mounted there goes with it, flashing and vanishing. `ClusterUpgradeProvider` already solves this the same way.

## Why a separate action rather than part of deploying

It cannot half-succeed alongside a deployment, so there is no "deployed but did not save" state to explain or recover from. A user who may run endpoints but not write catalogs is refused at the point they asked, not mid-deploy. And it works on an endpoint tuned after the fact, which a deploy-time checkbox would not reach.

## Test Plan

`tsgo`, `biome ci`, knip, dependency-cruiser and both i18n gates pass. Full suite green apart from the two timezone-dependent `Timestamp.render.test.tsx` failures that also fail on a clean `main`.

Eleven tests, each checked against a reverted implementation:

- the built catalog carries the configuration, drops cluster/replicas/labels, stays flat, and passes an all-empty model through untouched (a Flex endpoint submits empty strings rather than omitting the model, and the catalog spec check refuses an absent one);
- the dialog offers the endpoint's name, creates under whatever the user types, closes on success, and **stays open when the name is taken** — the typed name is the only thing to fix;
- the dialog survives the menu that opened it being unmounted, and the action opens nothing at all when no provider is above it.

## Incidental

`isDuplicateNameError` moves from the catalog import dialog to `foundation/lib/error-message`; the import dialog was its only caller and now shares it instead of this adding a second copy.
