### PR TITLE
feat(endpoints): record what a deploy came from, and show it back

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -33,7 +33,7 @@
   "src/pages/endpoints/create.tsx": "80007cdbc2f2ecd902d6485b6774cf2b",
   "src/pages/endpoints/edit.tsx": "f985a843fe494b31594f2291e8bcfee8",
   "src/pages/endpoints/list.tsx": "1433e09de8bd43a223233018926e7dd8",
-  "src/pages/endpoints/show.tsx": "7050394fbaaf070aecbd9926c0a0cf1a",
+  "src/pages/endpoints/show.tsx": "e7b1e4e660eac15cab2dfd8ee6a97537",
   "src/pages/dashboard/Dashboard.tsx": "5c949e1cfe926f6538294445610940ce",
   "src/pages/clusters/create.tsx": "fd2b1c7affa795305445f8e307dea099",
   "src/pages/clusters/edit.tsx": "d636f55fd8591fabd56759bf0f46963e",
@@ -236,7 +236,7 @@
   "src/foundation/components/VariablesInput.tsx": "1d43ebad87c1dcbb3053798477ab3722",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "96dd43a88bc38afa4c23c811b457fcce",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "be5475a36d13c26d08e53033bc861090",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "3d278e9aeecf43b5acd93e3c79180fcc",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "7fc5186989f74eb21ecf621ac24e5ee4",
   "src/pages/external-endpoints/create.tsx": "b5439551b4bedc80ab76a86ddf68dc75",
@@ -397,5 +397,7 @@
   "src/domains/endpoint/components/EndpointSaveAsCatalogAction.tsx": "4a5d02cc27df64ef6f134570bdc09f1d",
   "src/domains/model-catalog/lib/catalog-model-slots.ts": "c147dc9b9985074a4c093cc3f86e6a5b",
   "src/domains/model-catalog/components/CatalogModelSlots.tsx": "d118ba5007506fd7ccb56fb72ccee216",
-  "src/foundation/components/EndpointStatus.tsx": "ec48c1610372339234ef6b849c5040c6"
+  "src/foundation/components/EndpointStatus.tsx": "ec48c1610372339234ef6b849c5040c6",
+  "src/domains/endpoint/lib/catalog-origin.ts": "10d2d40c7e5cd6e84454dbdd56ebec53",
+  "src/domains/endpoint/components/EndpointCatalogOrigin.tsx": "4274ff735abe2e28e0a2bf05c26faab6"
 }

--- a/src/domains/endpoint/components/EndpointCatalogOrigin.test.tsx
+++ b/src/domains/endpoint/components/EndpointCatalogOrigin.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/foundation/lib/i18n", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { buildCatalogOriginAnnotations } from "@/domains/endpoint/lib/catalog-origin";
+import { EndpointCatalogOrigin } from "./EndpointCatalogOrigin";
+
+const renderOrigin = (annotations: Record<string, string> | null) =>
+  render(<EndpointCatalogOrigin annotations={annotations} />);
+
+describe("EndpointCatalogOrigin", () => {
+  it("names the catalog, the profile and each option", () => {
+    renderOrigin(
+      buildCatalogOriginAnnotations({
+        catalog: "qwen3.6-35b",
+        variant: "fp8",
+        features: [{ name: "max-model-len", value: "32768" }, { name: "cp" }],
+      }),
+    );
+
+    const block = screen.getByTestId("endpoint-catalog-origin");
+    expect(within(block).getByText("qwen3.6-35b")).toBeDefined();
+    expect(within(block).getByText("fp8")).toBeDefined();
+    expect(within(block).getByText("max-model-len: 32768")).toBeDefined();
+    expect(within(block).getByText("cp")).toBeDefined();
+  });
+
+  it("renders nothing for an endpoint that names no catalog", () => {
+    renderOrigin(null);
+
+    expect(screen.queryByTestId("endpoint-catalog-origin")).toBeNull();
+  });
+
+  // Best effort: the catalog and the profile still read correctly, and the
+  // gap is stated rather than shown as "no options chosen".
+  it("says so when the recorded options cannot be read", () => {
+    renderOrigin({
+      "neutree.ai/model-catalog": "qwen3.6-35b",
+      "neutree.ai/model-catalog-variant": "fp8",
+      "neutree.ai/model-catalog-features": "{not json",
+    });
+
+    const block = screen.getByTestId("endpoint-catalog-origin");
+    expect(within(block).getByText("qwen3.6-35b")).toBeDefined();
+    expect(
+      within(block).getByText("endpoints.origin.featuresUnreadable"),
+    ).toBeDefined();
+  });
+});

--- a/src/domains/endpoint/components/EndpointCatalogOrigin.tsx
+++ b/src/domains/endpoint/components/EndpointCatalogOrigin.tsx
@@ -1,0 +1,63 @@
+import { Badge } from "@/components/ui/badge";
+import {
+  type CatalogOrigin,
+  readCatalogOrigin,
+} from "@/domains/endpoint/lib/catalog-origin";
+import { useTranslation } from "@/foundation/lib/i18n";
+
+/**
+ * What an endpoint was deployed from, read back off the endpoint itself.
+ *
+ * Read-only, and deliberately so: the catalog it names may have changed or
+ * been deleted since, so this states what happened rather than offering to
+ * re-derive anything from it. Nothing here fetches the catalog — a record that
+ * still reads correctly after the catalog is gone is the point.
+ */
+export const EndpointCatalogOrigin = ({
+  annotations,
+}: {
+  annotations: Record<string, string> | null | undefined;
+}) => {
+  const { t } = useTranslation();
+  const origin: CatalogOrigin | null = readCatalogOrigin(annotations);
+
+  if (!origin) return null;
+
+  return (
+    <div data-testid="endpoint-catalog-origin" className="space-y-1">
+      <div className="text-xs text-muted-foreground">
+        {t("endpoints.fields.modelCatalog")}
+      </div>
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+        <span className="font-medium break-all">{origin.catalog}</span>
+        {origin.variant && (
+          <Badge variant="secondary" className="font-mono">
+            {origin.variant}
+          </Badge>
+        )}
+        {origin.features.map((feature) => (
+          <Badge
+            key={feature.name}
+            variant="outline"
+            className="font-mono"
+            data-feature={feature.name}
+          >
+            {feature.value === undefined
+              ? feature.name
+              : `${feature.name}: ${feature.value}`}
+          </Badge>
+        ))}
+        {origin.featuresUnreadable && (
+          <span className="text-xs text-muted-foreground">
+            {t("endpoints.origin.featuresUnreadable")}
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {t("endpoints.origin.hint")}
+      </p>
+    </div>
+  );
+};
+
+EndpointCatalogOrigin.displayName = "EndpointCatalogOrigin";

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -6331,3 +6331,50 @@ describe("a catalog naming a registry this workspace does not have", () => {
     expect(await registryError("mine")).toBeUndefined();
   });
 });
+
+// An endpoint holds the composed result and nothing that says what produced
+// it, so the deployment records that on itself. Read back on the endpoint's own
+// pages; never followed back to the catalog.
+describe("what a deploy came from is recorded on the endpoint", () => {
+  const submitted = () => refineCoreOnFinishMock.mock.calls[0]?.[0];
+  const annotations = () => submitted()?.metadata?.annotations ?? {};
+
+  const deployFrom = async (name: string) => {
+    render(<CreateForm />);
+    selectCatalog(name);
+    await act(async () => {
+      await formInstance?.refineCore.onFinish(formInstance.getValues());
+    });
+  };
+
+  beforeEach(() => {
+    refineCoreOnFinishMock.mockClear();
+  });
+
+  it("names the catalog, the variant and the chosen features", async () => {
+    setupMocks([catalogA, recipeCatalog], [plainKubernetesCluster]);
+    await deployFrom("recipe-mc");
+
+    expect(annotations()["neutree.ai/model-catalog"]).toBe("recipe-mc");
+    expect(annotations()["neutree.ai/model-catalog-variant"]).toBe("default");
+  });
+
+  // A plain catalog has no variants to choose between.
+  it("names only the catalog for a plain one", async () => {
+    setupMocks([catalogA, recipeCatalog], [plainKubernetesCluster]);
+    await deployFrom("vllm-llama");
+
+    expect(annotations()["neutree.ai/model-catalog"]).toBe("vllm-llama");
+    expect(annotations()["neutree.ai/model-catalog-variant"]).toBeUndefined();
+  });
+
+  it("records nothing when the endpoint was not deployed from a catalog", async () => {
+    setupMocks([catalogA], [plainKubernetesCluster]);
+    render(<CreateForm />);
+    await act(async () => {
+      await formInstance?.refineCore.onFinish(formInstance.getValues());
+    });
+
+    expect(annotations()["neutree.ai/model-catalog"]).toBeUndefined();
+  });
+});

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -18,6 +18,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ComposePreview } from "@/domains/endpoint/components/ComposePreview";
+import { EndpointCatalogOrigin } from "@/domains/endpoint/components/EndpointCatalogOrigin";
 import { EndpointClusterGpuResourcesPanel } from "@/domains/endpoint/components/EndpointClusterGpuResourcesPanel";
 import { FeaturePicker } from "@/domains/endpoint/components/FeaturePicker";
 import { KVCacheEstimate } from "@/domains/endpoint/components/KVCacheEstimate";
@@ -28,6 +29,7 @@ import { WorkloadImageInput } from "@/domains/endpoint/components/WorkloadImageI
 import { useEndpointClusterResources } from "@/domains/endpoint/hooks/use-endpoint-cluster-resources";
 import { useEndpointEngineOptions } from "@/domains/endpoint/hooks/use-endpoint-engine-options";
 import useEndpointResources from "@/domains/endpoint/hooks/use-endpoint-resources";
+import { buildCatalogOriginAnnotations } from "@/domains/endpoint/lib/catalog-origin";
 import {
   buildCatalogMergedSpec,
   defaultEndpointSpec,
@@ -1663,6 +1665,32 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
             ? structuredClone(values)
             : JSON.parse(JSON.stringify(values));
         transformEndpointValues((transformedValues as Endpoint).spec);
+
+        // Record what this was deployed from, while the answer is still in
+        // hand: the spec about to be submitted is the composed result, and
+        // nothing in it says which catalog, variant or features produced it.
+        // Create only — an edit is not a new deployment, and rewriting the
+        // record would claim the endpoint came from wherever it happens to
+        // point today.
+        if (!isEdit && selectedCatalog) {
+          const endpoint = transformedValues as Endpoint;
+          endpoint.metadata = {
+            ...endpoint.metadata,
+            annotations: {
+              ...endpoint.metadata?.annotations,
+              ...buildCatalogOriginAnnotations({
+                catalog: selectedCatalog.metadata.name,
+                // Composition reads "" as the default profile, so the record
+                // names it rather than leaving the field empty.
+                variant: isRecipeCatalog
+                  ? selectedVariant || DEFAULT_VARIANT
+                  : undefined,
+                features: isRecipeCatalog ? featureSelections : undefined,
+              }),
+            },
+          };
+        }
+
         return form.refineCore.onFinish(transformedValues);
       },
     },
@@ -1708,6 +1736,17 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
           title={t("endpoints.sections.modelAndReplicas")}
           variant={sectionVariant}
         >
+          {/* Edit mode has no catalog picker — the deployment already happened
+          — but it renders what that deployment came from in the same place, so
+          the endpoint does not read as two different things depending on which
+          page you are on. */}
+          {isEdit && (
+            <div className="col-span-4">
+              <EndpointCatalogOrigin
+                annotations={queryEndpoint?.metadata?.annotations}
+              />
+            </div>
+          )}
           {!isEdit && (
             <div
               data-testid="model-catalog-row"

--- a/src/domains/endpoint/lib/catalog-origin.test.ts
+++ b/src/domains/endpoint/lib/catalog-origin.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCatalogOriginAnnotations,
+  CATALOG_ORIGIN_ANNOTATION,
+  CATALOG_ORIGIN_FEATURES_ANNOTATION,
+  CATALOG_ORIGIN_VARIANT_ANNOTATION,
+  readCatalogOrigin,
+} from "./catalog-origin";
+
+describe("buildCatalogOriginAnnotations", () => {
+  it("records the catalog, the variant and the features", () => {
+    expect(
+      buildCatalogOriginAnnotations({
+        catalog: "qwen3.6-35b",
+        variant: "fp8",
+        features: [{ name: "max-model-len", value: "32768" }, { name: "cp" }],
+      }),
+    ).toEqual({
+      [CATALOG_ORIGIN_ANNOTATION]: "qwen3.6-35b",
+      [CATALOG_ORIGIN_VARIANT_ANNOTATION]: "fp8",
+      [CATALOG_ORIGIN_FEATURES_ANNOTATION]:
+        '[{"name":"max-model-len","value":"32768"},{"name":"cp"}]',
+    });
+  });
+
+  // Composition applies features in order and later ones overwrite earlier
+  // ones, so a set would lose meaning.
+  it("keeps the feature order", () => {
+    const annotations = buildCatalogOriginAnnotations({
+      catalog: "c",
+      features: [{ name: "b" }, { name: "a" }],
+    });
+
+    expect(readCatalogOrigin(annotations)?.features.map((f) => f.name)).toEqual(
+      ["b", "a"],
+    );
+  });
+
+  // A plain catalog has no variants to choose between, and writing an empty
+  // one would read as "some variant, unnamed".
+  it("writes only the catalog when there is nothing else to say", () => {
+    expect(buildCatalogOriginAnnotations({ catalog: "plain" })).toEqual({
+      [CATALOG_ORIGIN_ANNOTATION]: "plain",
+    });
+  });
+});
+
+describe("readCatalogOrigin", () => {
+  it("round-trips what was written", () => {
+    const origin = {
+      catalog: "qwen3.6-35b",
+      variant: "fp8",
+      features: [{ name: "max-model-len", value: "32768" }],
+    };
+
+    expect(readCatalogOrigin(buildCatalogOriginAnnotations(origin))).toEqual({
+      ...origin,
+      featuresUnreadable: false,
+    });
+  });
+
+  it("reads nothing off an endpoint that names no catalog", () => {
+    expect(readCatalogOrigin(null)).toBeNull();
+    expect(readCatalogOrigin({})).toBeNull();
+    expect(
+      readCatalogOrigin({ [CATALOG_ORIGIN_VARIANT_ANNOTATION]: "fp8" }),
+    ).toBeNull();
+  });
+
+  // Best effort: an unreadable feature list must not take the catalog and the
+  // variant down with it, and must not be shown as "no features" either.
+  it("keeps the catalog and variant when the feature list cannot be read", () => {
+    const origin = readCatalogOrigin({
+      [CATALOG_ORIGIN_ANNOTATION]: "qwen3.6-35b",
+      [CATALOG_ORIGIN_VARIANT_ANNOTATION]: "fp8",
+      [CATALOG_ORIGIN_FEATURES_ANNOTATION]: "{not json",
+    });
+
+    expect(origin).toEqual({
+      catalog: "qwen3.6-35b",
+      variant: "fp8",
+      features: [],
+      featuresUnreadable: true,
+    });
+  });
+
+  it("rejects a feature list of the wrong shape rather than half-reading it", () => {
+    for (const raw of ['{"name":"a"}', '["a"]', '[{"value":"1"}]', "[null]"]) {
+      const origin = readCatalogOrigin({
+        [CATALOG_ORIGIN_ANNOTATION]: "c",
+        [CATALOG_ORIGIN_FEATURES_ANNOTATION]: raw,
+      });
+      expect(origin?.featuresUnreadable).toBe(true);
+      expect(origin?.features).toEqual([]);
+    }
+  });
+
+  it("distinguishes no features from unreadable features", () => {
+    const none = readCatalogOrigin({ [CATALOG_ORIGIN_ANNOTATION]: "c" });
+
+    expect(none).toEqual({
+      catalog: "c",
+      features: [],
+      featuresUnreadable: false,
+    });
+  });
+});

--- a/src/domains/endpoint/lib/catalog-origin.ts
+++ b/src/domains/endpoint/lib/catalog-origin.ts
@@ -1,0 +1,127 @@
+import type { FeatureSelection } from "@/foundation/recipe/types";
+
+/**
+ * Where an endpoint was deployed from, recorded on the endpoint itself.
+ *
+ * An endpoint holds the *composed* result of the catalog that produced it, and
+ * nothing in its spec says which catalog, which variant or which features that
+ * was. So the same endpoint reads as "the fp8 profile of qwen3.6-35b with a 32K
+ * context" while it is being created and as a flat list of engine args ever
+ * after.
+ *
+ * This is a record of what happened, not a reference that is followed: the
+ * catalog it names may since have changed or been deleted, and nothing here
+ * re-derives anything from it. Everything is read defensively — a value that
+ * cannot be understood is dropped rather than allowed to hide the parts that
+ * can.
+ *
+ * It lives in annotations rather than in the spec because it says nothing about
+ * how to run the endpoint; the control plane neither writes nor reads it, the
+ * same way the paused replica count is a label.
+ */
+
+/** Split across three keys rather than one blob so the catalog and the variant
+ * stay queryable — PostgREST can filter on an annotation, which is what makes
+ * "what did this catalog deploy" answerable — and so an unreadable feature list
+ * cannot take the rest down with it. */
+export const CATALOG_ORIGIN_ANNOTATION = "neutree.ai/model-catalog";
+export const CATALOG_ORIGIN_VARIANT_ANNOTATION =
+  "neutree.ai/model-catalog-variant";
+export const CATALOG_ORIGIN_FEATURES_ANNOTATION =
+  "neutree.ai/model-catalog-features";
+
+export type CatalogOrigin = {
+  /** The catalog's name. Endpoints and catalogs are looked up by
+   * (workspace, name) everywhere, and an endpoint is always deployed from a
+   * catalog in its own workspace. */
+  catalog: string;
+  /** Absent for a plain catalog, which has no variants to choose between. */
+  variant?: string;
+  features: FeatureSelection[];
+  /** The feature list was recorded but could not be read back. Said out loud
+   * rather than shown as "no features", which is a different fact. */
+  featuresUnreadable: boolean;
+};
+
+type Annotations = Record<string, string> | null | undefined;
+
+export function buildCatalogOriginAnnotations(origin: {
+  catalog: string;
+  variant?: string;
+  features?: ReadonlyArray<FeatureSelection>;
+}): Record<string, string> {
+  const annotations: Record<string, string> = {
+    [CATALOG_ORIGIN_ANNOTATION]: origin.catalog,
+  };
+
+  if (origin.variant) {
+    annotations[CATALOG_ORIGIN_VARIANT_ANNOTATION] = origin.variant;
+  }
+
+  // Order is part of the record: composition applies features in selection
+  // order and later ones overwrite earlier ones, so a set would lose meaning.
+  if (origin.features && origin.features.length > 0) {
+    annotations[CATALOG_ORIGIN_FEATURES_ANNOTATION] = JSON.stringify(
+      origin.features.map((feature) =>
+        feature.value === undefined
+          ? { name: feature.name }
+          : { name: feature.name, value: feature.value },
+      ),
+    );
+  }
+
+  return annotations;
+}
+
+export function readCatalogOrigin(
+  annotations: Annotations,
+): CatalogOrigin | null {
+  const catalog = annotations?.[CATALOG_ORIGIN_ANNOTATION];
+  if (!catalog) return null;
+
+  const variant = annotations?.[CATALOG_ORIGIN_VARIANT_ANNOTATION];
+  const raw = annotations?.[CATALOG_ORIGIN_FEATURES_ANNOTATION];
+
+  if (!raw) {
+    return {
+      catalog,
+      ...(variant ? { variant } : {}),
+      features: [],
+      featuresUnreadable: false,
+    };
+  }
+
+  const features = parseFeatures(raw);
+
+  return {
+    catalog,
+    ...(variant ? { variant } : {}),
+    features: features ?? [],
+    featuresUnreadable: features === null,
+  };
+}
+
+function parseFeatures(raw: string): FeatureSelection[] | null {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!Array.isArray(parsed)) return null;
+
+  const features: FeatureSelection[] = [];
+
+  for (const entry of parsed) {
+    if (!entry || typeof entry !== "object") return null;
+
+    const { name, value } = entry as { name?: unknown; value?: unknown };
+    if (typeof name !== "string" || !name) return null;
+
+    features.push(typeof value === "string" ? { name, value } : { name });
+  }
+
+  return features;
+}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1167,6 +1167,10 @@
 			"description": "Creates a new catalog from this endpoint's current configuration. It is not linked to the catalog this endpoint was deployed from, and carries no variants or features.",
 			"nameLabel": "Catalog name",
 			"submit": "Save"
+		},
+		"origin": {
+			"hint": "What this endpoint was deployed from. Its settings are edited below; changing them here does not change the catalog.",
+			"featuresUnreadable": "the recorded options could not be read"
 		}
 	},
 	"external_endpoints": {

--- a/src/pages/endpoints/show.tsx
+++ b/src/pages/endpoints/show.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/domains/endpoint/components/EndpointSaveAsCatalogAction";
 import ModelTask from "@/domains/endpoint/components/ModelTask";
 import { useEndpointMonitorPanels } from "@/domains/endpoint/hooks/use-endpoint-monitor-panels";
+import { readCatalogOrigin } from "@/domains/endpoint/lib/catalog-origin";
 import type { Endpoint } from "@/domains/endpoint/types";
 import { resolvePlayground } from "@/domains/engine/lib/resolve-capabilities";
 import type { Engine } from "@/domains/engine/types";
@@ -194,6 +195,9 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
     (v) => v.version === record.spec.engine.version,
   );
   const playground = resolvePlayground(engineVersion, record.spec.model.task);
+  // Read off the endpoint, never fetched: a record that still reads correctly
+  // after its catalog is gone is the point of keeping it here.
+  const catalogOrigin = readCatalogOrigin(record.metadata.annotations);
 
   return (
     <EndpointSaveAsCatalogProvider>
@@ -222,6 +226,15 @@ export const EndpointsShow: React.FC<IResourceComponentsProps> = () => {
                 <ShowPage.Meta label={t("common.fields.engine")}>
                   <EndpointEngine {...record} />
                 </ShowPage.Meta>
+                {catalogOrigin && (
+                  <ShowPage.Meta label={t("endpoints.fields.modelCatalog")}>
+                    <span data-testid="endpoint-origin-summary">
+                      {catalogOrigin.variant
+                        ? `${catalogOrigin.catalog} · ${catalogOrigin.variant}`
+                        : catalogOrigin.catalog}
+                    </span>
+                  </ShowPage.Meta>
+                )}
                 <ShowPage.Meta label={t("common.fields.cluster")}>
                   <ShowButton
                     recordItemId={record.spec.cluster}


### PR DESCRIPTION
## Issue

An endpoint holds the *composed* result of the catalog that produced it, and nothing in its spec says which catalog, which variant or which features that was — `EndpointSpec` is `cluster / model / engine / resources / replicas / deployment_options / variables / env`, and the form's catalog field is a `-` prefixed virtual field that never reaches it.

So the same endpoint reads as "the fp8 profile of qwen3.6-35b with a 32K context window" while it is being created, and as a flat list of a dozen engine args ever after. Nothing on the endpoint's own pages can answer "which profile did I pick?".

This is step one of two: **record it, and show it back.** Offering the variant and feature *controls* when editing needs a guard this does not build yet — see the end.

## What is recorded

Deploying from a catalog writes onto the endpoint:

```yaml
metadata:
  annotations:
    neutree.ai/model-catalog: qwen3.6-35b
    neutree.ai/model-catalog-variant: fp8
    neutree.ai/model-catalog-features: '[{"name":"max-model-len","value":"32768"},{"name":"cp"}]'
```

**Annotations rather than spec**, because it says nothing about how to run the endpoint: the control plane neither writes nor reads it, the same way the paused replica count is a label. No Go type, no migration, no controller involvement.

**Three keys rather than one blob**, for two reasons. The catalog and the variant stay queryable — PostgREST can filter on an annotation, so "what did this catalog deploy" becomes a server-side question rather than a client-side scan. And an unreadable feature list cannot take the rest down with it.

**Feature order is preserved.** Composition applies features in selection order and later ones overwrite earlier ones, so a set would lose meaning.

**Written on create only.** An edit is not a new deployment, and rewriting the record would claim the endpoint came from wherever it happens to point today. A plain catalog gets the first key alone — it has no variants to choose between, and an empty one would read as "some variant, unnamed".

## What is shown

Read back on the endpoint's own pages: in the **edit form**, in the same place the catalog picker sits when creating, so the endpoint stops reading as two different things depending on which page you are on; and beside model / engine / cluster on the **detail page**.

Neither one fetches the catalog. That is deliberate: a record that still reads correctly after its catalog has been deleted is the point of keeping it on the endpoint.

Reading is best-effort throughout. A feature list that cannot be parsed leaves the catalog and the variant intact and says the options could not be read — which is a different fact from no options, and is shown as such. A malformed list is rejected whole rather than half-read.

## Not built here

**The variant and feature controls in edit mode.** They would need to recompose and overwrite the endpoint's engine args, and that is only safe when `compose(current catalog, variant, features)` still reproduces what the endpoint holds. One predicate covers four ways it can stop holding: the catalog changed (re-import replaces a spec wholesale, so this is the designed update path), the catalog was deleted, the variant or a feature is gone, or **the user hand-edited the args after deploying** — where recomposing would silently discard their edits.

The split is deliberate: display is best-effort, writing has to be provable. This PR is the display half, and stands on its own.

## Test Plan

`tsgo`, `biome ci`, knip, dependency-cruiser and both i18n gates pass. Full suite green apart from the two timezone-dependent `Timestamp.render.test.tsx` failures that also fail on a clean `main`.

14 tests. Reading and writing the record (8): catalog, variant and features round-trip; feature order survives; a plain catalog writes only its name; an endpoint naming no catalog reads as nothing; an unparseable feature list keeps the catalog and variant and is flagged; a list of the wrong shape is rejected rather than half-read; no features and unreadable features stay distinguishable.

The form (3, each checked against a reverted implementation): a recipe deploy records the catalog and the variant; a plain catalog records only the catalog; a deploy with no catalog records nothing.

The display (3): the catalog, profile and each option are named; nothing renders without a record; the unreadable case says so while still naming the catalog.

## Note for whoever merges

Branched from `main` while #398 is open. Both touch `use-endpoint-form.tsx` and its test file, so whichever lands second will need a rebase — they are separate concerns and this one does not depend on that one.
