### PR TITLE
fix(i18n): stop the image explorer namespace note showing literal backticks

### DIFF
--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1190,7 +1190,7 @@
 			"foreignRegistry": "This is not the registry this cluster pulls with. The pull uses the credentials in {{name}}, so an image found here may not be pullable.",
 			"namespaceLabel": "Namespace",
 			"selectNamespace": "Select or type a namespace",
-			"namespaceNote": "Docker Hub cannot list namespaces, so this is not the full set — `{{official}}` holds its official images, and the rest are namespaces this deployment already uses. Type any other.",
+			"namespaceNote": "Docker Hub cannot list namespaces, so this is not the full set — \"{{official}}\" holds its official images, and the rest are namespaces this deployment already uses. Type any other.",
 			"chooseNamespaceFirst": "Choose a namespace above and its images will be listed here.",
 			"imageLabel": "Image",
 			"selectImage": "Select or type an image",


### PR DESCRIPTION
`endpoints.imageExplorer.namespaceNote` wraps `{{official}}` in backticks, but nothing in the render path turns them into code styling, so users see the backticks themselves.

`ImageRegistryExplorerDialog.tsx` renders the string as plain text:

```tsx
<p
  className="text-xs text-muted-foreground"
  data-testid="image-explorer-namespace-note"
>
  {t("endpoints.imageExplorer.namespaceNote", {
    official: DOCKER_HUB_OFFICIAL_NAMESPACE,
  })}
</p>
```

No `<code>`, no Markdown renderer. With `DOCKER_HUB_OFFICIAL_NAMESPACE = "library"`, the namespace hint under the Docker Hub picker currently reads:

> …so this is not the full set — \`library\` holds its official images, and the rest are…

### The fix

Use double quotes, matching the nine other entries that quote an interpolated value — `model_catalogs.card.deleteDescription`, `model_catalogs.wrongKind`, `endpoints.messages.saveAsCatalogDuplicate`, and so on. After this change the locale file contains no backticks at all; this entry was the only one.

The backticks look like they came from the JSDoc in `src/domains/endpoint/lib/image-namespaces.ts`, where `` `library` `` is real Markdown and renders correctly.

An alternative would be to split the string and wrap the value in `<code>`, keeping the code styling the backticks were reaching for. That needs `<Trans>` or a restructured string, so it seemed out of proportion for one hint line — happy to do it that way instead if you would rather keep the styling.

### Checks

- `node tools/i18n-tracker.cjs` — clean (locale JSON is not tracked, and no `.ts`/`.tsx` file is touched)
- `node tools/check-i18n-keys.cjs` — clean (the key is unchanged, only its value)
- JSON parses; 48 top-level sections unchanged; the diff is one line

### Downstream

The zh-CN translation copied the backticks verbatim to stay faithful to the source. It will follow this wording on the next locale sync rather than diverging now.
