### PR TITLE
Feat/model catalog UI optimization

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -301,7 +301,7 @@
   "src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx": "62fbdbf9a4721d412ba2844bc81ec87f",
   "src/domains/cluster/lib/resource-status.ts": "9e759f014c4589740efe23ebdaf8bf74",
   "src/foundation/lib/gpu-device-resources.ts": "b2449b3d0582b4064aba2f0359c097a7",
-  "src/foundation/components/GpuDeviceResourcesView.tsx": "52134949d3e9bf2d80e24d36d7dcbccc",
+  "src/foundation/components/GpuDeviceResourcesView.tsx": "b8263294748683b0fc404e1971731c20",
   "src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.tsx": "b35c3309802ff13df367f98445724d2d",
   "src/domains/cluster/lib/accelerator-virtualization.ts": "d6ef94dfc840b468601b67e640b0c7bd",
   "src/domains/api-key/components/ApiKeyLimitsCard.tsx": "c8f42bfd6aa811f613952762c32fa83b",
@@ -311,7 +311,7 @@
   "src/domains/api-key/components/ModelMultiSelect.tsx": "6068a1c19a7048cf190ef4bbe964faf7",
   "src/domains/api-key/hooks/use-api-key-policy.ts": "3c22ef4f4f09707dfce3d76f5a594686",
   "src/foundation/components/resource-form-submit-context.ts": "7c5c5b5f94416e940786f87a98b3a9f8",
-  "src/pages/model-catalogs/edit.tsx": "1dc6fa82492ba18315dae5d86f340201",
+  "src/pages/model-catalogs/edit.tsx": "a64fdc003da2f38f5da03d87f05772a9",
   "src/pages/model-catalogs/components/FeaturesList.tsx": "e68a4369a62b564bbbdcfd3c614a4b38",
   "src/pages/model-catalogs/components/ImportDialog.tsx": "c8b67dba091272b9170ff5ea2f2c6258",
   "src/pages/model-catalogs/components/KeyConfigCard.tsx": "a3e49d8166c2440bfa82b6d6b53cc2e1",
@@ -321,7 +321,7 @@
   "src/foundation/recipe/normalize.ts": "37973e33217df534c07c56a63d07c1ed",
   "src/foundation/recipe/types.ts": "6b11c3319d89fc7158795a4dc2bfe661",
   "src/foundation/recipe/vram.ts": "f88e860dfad69d93ddf339f47e663faa",
-  "src/domains/model-catalog/components/ModelInfoBadges.tsx": "1ef833f925784ef7f13335bb27a5d30a",
+  "src/domains/model-catalog/components/ModelInfoBadges.tsx": "99b234b612959b53508ccc6487bce8c3",
   "src/domains/endpoint/components/ComposePreview.tsx": "46c02bdd098aca320703bbad27578a6b",
   "src/domains/endpoint/components/FeaturePicker.tsx": "870ad4d4f2b1a435c52a2bd377437448",
   "src/domains/endpoint/components/VRAMCheckBadge.tsx": "8669ff213df55b49535f2134db420d66",
@@ -410,6 +410,6 @@
   "src/foundation/components/BreakableReference.tsx": "fa3ac0ab1cbd99466faac427cf695346",
   "src/domains/model-registry/components/ModelDetailDrawer.tsx": "378c22f5bcfe54e585d1f4bc6c8f837b",
   "src/domains/endpoint/components/EndpointWeightsEstimate.tsx": "731ea242a685f560c31515348e52c359",
-  "src/domains/model-catalog/lib/model-info-display.ts": "4a1cba7539c39275a8c9198cf0ba7c9a",
-  "src/domains/model-catalog/components/CatalogYamlEditor.tsx": "e485c20af3907fc9cbc203a9be559bb2"
+  "src/domains/model-catalog/lib/model-info-display.ts": "5fbbf46d0c5708e51ce35f46c75c5e38",
+  "src/domains/model-catalog/components/CatalogYamlEditor.tsx": "fb11382e48877cbfa38d200ed2513633"
 }

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -311,7 +311,7 @@
   "src/domains/api-key/components/ModelMultiSelect.tsx": "6068a1c19a7048cf190ef4bbe964faf7",
   "src/domains/api-key/hooks/use-api-key-policy.ts": "3c22ef4f4f09707dfce3d76f5a594686",
   "src/foundation/components/resource-form-submit-context.ts": "7c5c5b5f94416e940786f87a98b3a9f8",
-  "src/pages/model-catalogs/edit.tsx": "94de5b536bbce3e7ebeae4f17decd835",
+  "src/pages/model-catalogs/edit.tsx": "1dc6fa82492ba18315dae5d86f340201",
   "src/pages/model-catalogs/components/FeaturesList.tsx": "e68a4369a62b564bbbdcfd3c614a4b38",
   "src/pages/model-catalogs/components/ImportDialog.tsx": "c8b67dba091272b9170ff5ea2f2c6258",
   "src/pages/model-catalogs/components/KeyConfigCard.tsx": "a3e49d8166c2440bfa82b6d6b53cc2e1",
@@ -321,7 +321,7 @@
   "src/foundation/recipe/normalize.ts": "37973e33217df534c07c56a63d07c1ed",
   "src/foundation/recipe/types.ts": "6b11c3319d89fc7158795a4dc2bfe661",
   "src/foundation/recipe/vram.ts": "f88e860dfad69d93ddf339f47e663faa",
-  "src/domains/model-catalog/components/ModelInfoBadges.tsx": "1608ced09a1c2236d30ee644f974dda2",
+  "src/domains/model-catalog/components/ModelInfoBadges.tsx": "1ef833f925784ef7f13335bb27a5d30a",
   "src/domains/endpoint/components/ComposePreview.tsx": "46c02bdd098aca320703bbad27578a6b",
   "src/domains/endpoint/components/FeaturePicker.tsx": "870ad4d4f2b1a435c52a2bd377437448",
   "src/domains/endpoint/components/VRAMCheckBadge.tsx": "8669ff213df55b49535f2134db420d66",
@@ -395,7 +395,7 @@
   "src/domains/endpoint/lib/save-as-catalog.ts": "92faeef51fe64fcc065322c760d9443e",
   "src/domains/endpoint/components/EndpointSaveAsCatalogAction.tsx": "4a5d02cc27df64ef6f134570bdc09f1d",
   "src/domains/model-catalog/lib/catalog-model-slots.ts": "c147dc9b9985074a4c093cc3f86e6a5b",
-  "src/domains/model-catalog/components/CatalogModelSlots.tsx": "d118ba5007506fd7ccb56fb72ccee216",
+  "src/domains/model-catalog/components/CatalogModelSlots.tsx": "6d455860b9eb42089cc8f3387d926795",
   "src/foundation/components/EndpointStatus.tsx": "ec48c1610372339234ef6b849c5040c6",
   "src/domains/endpoint/lib/catalog-origin.ts": "10d2d40c7e5cd6e84454dbdd56ebec53",
   "src/domains/endpoint/components/EndpointCatalogOrigin.tsx": "4274ff735abe2e28e0a2bf05c26faab6",
@@ -409,5 +409,7 @@
   "src/foundation/lib/image-reference.ts": "8200f52a33e48a24b0d355fb856ff946",
   "src/foundation/components/BreakableReference.tsx": "fa3ac0ab1cbd99466faac427cf695346",
   "src/domains/model-registry/components/ModelDetailDrawer.tsx": "378c22f5bcfe54e585d1f4bc6c8f837b",
-  "src/domains/endpoint/components/EndpointWeightsEstimate.tsx": "731ea242a685f560c31515348e52c359"
+  "src/domains/endpoint/components/EndpointWeightsEstimate.tsx": "731ea242a685f560c31515348e52c359",
+  "src/domains/model-catalog/lib/model-info-display.ts": "4a1cba7539c39275a8c9198cf0ba7c9a",
+  "src/domains/model-catalog/components/CatalogYamlEditor.tsx": "e485c20af3907fc9cbc203a9be559bb2"
 }

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -301,7 +301,7 @@
   "src/domains/endpoint/components/EndpointRuntimeResourcesCard.tsx": "62fbdbf9a4721d412ba2844bc81ec87f",
   "src/domains/cluster/lib/resource-status.ts": "9e759f014c4589740efe23ebdaf8bf74",
   "src/foundation/lib/gpu-device-resources.ts": "b2449b3d0582b4064aba2f0359c097a7",
-  "src/foundation/components/GpuDeviceResourcesView.tsx": "dbf2b05bc2e78d705123044cc6d3583c",
+  "src/foundation/components/GpuDeviceResourcesView.tsx": "52134949d3e9bf2d80e24d36d7dcbccc",
   "src/domains/endpoint/components/EndpointClusterGpuResourcesPanel.tsx": "b35c3309802ff13df367f98445724d2d",
   "src/domains/cluster/lib/accelerator-virtualization.ts": "d6ef94dfc840b468601b67e640b0c7bd",
   "src/domains/api-key/components/ApiKeyLimitsCard.tsx": "c8f42bfd6aa811f613952762c32fa83b",

--- a/src/domains/model-catalog/components/CatalogModelSlots.tsx
+++ b/src/domains/model-catalog/components/CatalogModelSlots.tsx
@@ -27,7 +27,7 @@ const MODEL_PAGE_SIZE = 20;
  * narrow screen instead of overflowing.
  */
 const SLOT_ROW =
-  "grid grid-cols-[minmax(0,22rem)_minmax(0,32rem)] items-center gap-3";
+  "grid grid-cols-1 items-start gap-1.5 sm:grid-cols-[minmax(0,22rem)_minmax(0,32rem)] sm:items-center sm:gap-3";
 /** A registry's listing does not change under the user mid-edit, and every slot
  * reads the same one. */
 const MODEL_STALE_TIME = 30_000;
@@ -223,8 +223,8 @@ export function CatalogModelSlots({
 
   return (
     <div className="space-y-3" data-testid="catalog-model-slots">
-      <div className="max-w-[32rem] space-y-1.5">
-        <div className="text-xs text-muted-foreground">
+      <div className={SLOT_ROW}>
+        <div className="text-sm">
           {t("model_catalogs.models.registryLabel")}
         </div>
         <Combobox

--- a/src/domains/model-catalog/components/CatalogYamlEditor.css
+++ b/src/domains/model-catalog/components/CatalogYamlEditor.css
@@ -1,0 +1,22 @@
+.catalog-yaml-editor .hljs-attr,
+.catalog-yaml-editor .hljs-attribute {
+	color: var(--nt-text-colorful-outstanding);
+}
+
+.catalog-yaml-editor .hljs-string {
+	color: var(--nt-text-colorful-positive);
+}
+
+.catalog-yaml-editor .hljs-number,
+.catalog-yaml-editor .hljs-literal {
+	color: var(--nt-text-colorful-purple);
+}
+
+.catalog-yaml-editor .hljs-comment {
+	color: var(--nt-text-neutral-tertiary);
+}
+
+.catalog-yaml-editor .hljs-bullet,
+.catalog-yaml-editor .hljs-meta {
+	color: var(--nt-text-colorful-notice);
+}

--- a/src/domains/model-catalog/components/CatalogYamlEditor.test.tsx
+++ b/src/domains/model-catalog/components/CatalogYamlEditor.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { CatalogYamlEditor } from "./CatalogYamlEditor";
+
+describe("CatalogYamlEditor", () => {
+  it("renders highlighted YAML behind the editable textarea", () => {
+    const { container } = render(
+      <CatalogYamlEditor
+        value={'kind: ModelCatalog\nname: "qwen"'}
+        onChange={vi.fn()}
+        ariaLabel="Catalog YAML"
+        className="custom-editor"
+      />,
+    );
+
+    expect(container.firstElementChild?.className).toContain("custom-editor");
+    expect(
+      (screen.getByLabelText("Catalog YAML") as HTMLTextAreaElement).value,
+    ).toBe('kind: ModelCatalog\nname: "qwen"');
+    expect(container.querySelector("pre code")?.textContent).toContain(
+      "ModelCatalog",
+    );
+    expect(container.querySelector(".hljs-attr")).not.toBeNull();
+  });
+
+  it("keeps the empty editor editable and reports text changes", () => {
+    const onChange = vi.fn();
+    render(
+      <CatalogYamlEditor
+        value=""
+        onChange={onChange}
+        ariaLabel="Catalog YAML"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Catalog YAML"), {
+      target: { value: "kind: ModelCatalog" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith("kind: ModelCatalog");
+  });
+
+  it("synchronizes the highlight layer with textarea scrolling", () => {
+    const { container } = render(
+      <CatalogYamlEditor
+        value="kind: ModelCatalog"
+        onChange={vi.fn()}
+        ariaLabel="Catalog YAML"
+      />,
+    );
+    const textarea = screen.getByLabelText("Catalog YAML");
+    const highlight = container.querySelector("pre");
+    if (!highlight) throw new Error("highlight layer was not rendered");
+
+    Object.defineProperties(textarea, {
+      scrollTop: { configurable: true, value: 120 },
+      scrollLeft: { configurable: true, value: 36 },
+    });
+    fireEvent.scroll(textarea);
+
+    expect(highlight.scrollTop).toBe(120);
+    expect(highlight.scrollLeft).toBe(36);
+  });
+});

--- a/src/domains/model-catalog/components/CatalogYamlEditor.tsx
+++ b/src/domains/model-catalog/components/CatalogYamlEditor.tsx
@@ -1,0 +1,89 @@
+import yamlLanguage from "highlight.js/lib/languages/yaml";
+import { createLowlight } from "lowlight";
+import {
+  type ChangeEvent,
+  createElement,
+  type ReactNode,
+  type UIEvent,
+  useMemo,
+  useRef,
+} from "react";
+import { cn } from "@/foundation/lib/utils";
+import "./CatalogYamlEditor.css";
+
+const lowlight = createLowlight({ yaml: yamlLanguage });
+type HighlightNode = ReturnType<typeof lowlight.highlight>["children"][number];
+
+function renderHighlightedNode(node: HighlightNode, key: string): ReactNode {
+  if (node.type === "text") return node.value;
+  if (node.type !== "element") return null;
+
+  const className = Array.isArray(node.properties.className)
+    ? node.properties.className.join(" ")
+    : undefined;
+  return createElement(
+    node.tagName,
+    { className, key },
+    node.children.map((child, index) =>
+      renderHighlightedNode(child, `${key}-${index}`),
+    ),
+  );
+}
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  ariaLabel: string;
+  className?: string;
+};
+
+export function CatalogYamlEditor({
+  value,
+  onChange,
+  ariaLabel,
+  className,
+}: Props) {
+  const highlightRef = useRef<HTMLPreElement>(null);
+  const highlighted = useMemo(() => {
+    const tree = lowlight.highlight("yaml", value || "\n");
+    return tree.children.map((node, index) =>
+      renderHighlightedNode(node, String(index)),
+    );
+  }, [value]);
+
+  const syncScroll = (event: UIEvent<HTMLTextAreaElement>) => {
+    if (!highlightRef.current) return;
+    highlightRef.current.scrollTop = event.currentTarget.scrollTop;
+    highlightRef.current.scrollLeft = event.currentTarget.scrollLeft;
+  };
+
+  return (
+    <div
+      className={cn(
+        "catalog-yaml-editor relative h-[28rem] overflow-hidden rounded-[var(--nt-radius-input)] border border-[var(--nt-stroke-neutral-trans-3)] bg-[var(--nt-fill-neutral-white)] shadow-[var(--nt-effect-button-shadow-push-button-ordinary)] transition-colors hover:border-[var(--nt-stroke-neutral-trans-4)] focus-within:border-[var(--nt-stroke-outstanding-base)] focus-within:[box-shadow:var(--nt-outline-active-focus)]",
+        className,
+      )}
+    >
+      <pre
+        ref={highlightRef}
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre p-3 font-mono text-xs leading-5 text-[var(--nt-text-neutral-primary)]"
+      >
+        <code>{highlighted}</code>
+        {"\n"}
+      </pre>
+      <textarea
+        data-testid="catalog-spec-yaml"
+        aria-label={ariaLabel}
+        className="absolute inset-0 size-full resize-none overflow-auto whitespace-pre border-0 bg-transparent p-3 font-mono text-xs leading-5 text-transparent caret-[var(--nt-text-neutral-primary)] outline-none [text-shadow:none] selection:bg-[var(--nt-fill-outstanding-light)]"
+        style={{ WebkitTextFillColor: "transparent" }}
+        value={value}
+        onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>
+          onChange(event.target.value)
+        }
+        onScroll={syncScroll}
+        spellCheck={false}
+      />
+    </div>
+  );
+}

--- a/src/domains/model-catalog/components/CatalogYamlEditor.tsx
+++ b/src/domains/model-catalog/components/CatalogYamlEditor.tsx
@@ -60,7 +60,7 @@ export function CatalogYamlEditor({
   return (
     <div
       className={cn(
-        "catalog-yaml-editor relative h-[28rem] overflow-hidden rounded-[var(--nt-radius-input)] border border-[var(--nt-stroke-neutral-trans-3)] bg-[var(--nt-fill-neutral-white)] shadow-[var(--nt-effect-button-shadow-push-button-ordinary)] transition-colors hover:border-[var(--nt-stroke-neutral-trans-4)] focus-within:border-[var(--nt-stroke-outstanding-base)] focus-within:[box-shadow:var(--nt-outline-active-focus)]",
+        "catalog-yaml-editor relative h-[28rem] min-h-[10rem] resize-y overflow-hidden rounded-[var(--nt-radius-input)] border border-[var(--nt-stroke-neutral-trans-3)] bg-[var(--nt-fill-neutral-white)] shadow-[var(--nt-effect-button-shadow-push-button-ordinary)] transition-colors hover:border-[var(--nt-stroke-neutral-trans-4)] focus-within:border-[var(--nt-stroke-outstanding-base)] focus-within:[box-shadow:var(--nt-outline-active-focus)]",
         className,
       )}
     >
@@ -70,12 +70,11 @@ export function CatalogYamlEditor({
         className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre p-3 font-mono text-xs leading-5 text-[var(--nt-text-neutral-primary)]"
       >
         <code>{highlighted}</code>
-        {"\n"}
       </pre>
       <textarea
         data-testid="catalog-spec-yaml"
         aria-label={ariaLabel}
-        className="absolute inset-0 size-full resize-none overflow-auto whitespace-pre border-0 bg-transparent p-3 font-mono text-xs leading-5 text-transparent caret-[var(--nt-text-neutral-primary)] outline-none [text-shadow:none] selection:bg-[var(--nt-fill-outstanding-light)]"
+        className="absolute inset-0 size-full overflow-auto whitespace-pre border-0 bg-transparent p-3 font-mono text-xs leading-5 text-transparent caret-[var(--nt-text-neutral-primary)] outline-none [text-shadow:none] selection:bg-[var(--nt-fill-outstanding-light)]"
         style={{ WebkitTextFillColor: "transparent" }}
         value={value}
         onChange={(event: ChangeEvent<HTMLTextAreaElement>) =>

--- a/src/domains/model-catalog/components/ModelInfoBadges.test.tsx
+++ b/src/domains/model-catalog/components/ModelInfoBadges.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ModelInfoBadges } from "./ModelInfoBadges";
+
+vi.mock("@/foundation/lib/i18n", () => ({
+  useTranslation: () => ({ t: (_key: string, fallback: string) => fallback }),
+}));
+
+describe("ModelInfoBadges", () => {
+  it("renders nothing without displayable model information", () => {
+    const { container, rerender } = render(<ModelInfoBadges />);
+    expect(container.firstChild).toBeNull();
+
+    rerender(<ModelInfoBadges info={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("formats metadata and renders architecture inline", () => {
+    render(
+      <ModelInfoBadges
+        variant="inline"
+        className="inline-metadata"
+        info={{
+          parameter_count: "27000000000",
+          quantization: "BF16",
+          context_length: "131072",
+          architecture: "Qwen3ForCausalLM",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("27B")).toBeTruthy();
+    expect(screen.getByText("BF16")).toBeTruthy();
+    expect(screen.getByText("131K")).toBeTruthy();
+    expect(screen.getByText("Qwen3ForCausalLM")).toBeTruthy();
+    expect(document.querySelector(".inline-metadata")).not.toBeNull();
+  });
+
+  it("shows the complete architecture in a keyboard-accessible tooltip", async () => {
+    const architecture =
+      "Qwen3MoeForConditionalGenerationWithAnIntentionallyLongArchitectureName";
+    render(
+      <TooltipProvider delayDuration={0}>
+        <ModelInfoBadges
+          className="catalog-info"
+          info={{ architecture, parameter_count: "6000000000" }}
+        />
+      </TooltipProvider>,
+    );
+
+    expect(screen.getByText("6B")).toBeTruthy();
+    const triggerValue = screen.getByText(architecture);
+    const trigger = triggerValue.closest("div[tabindex='0']");
+    if (!trigger)
+      throw new Error("architecture tooltip trigger was not rendered");
+
+    expect(triggerValue.className).toContain("truncate");
+    fireEvent.focus(trigger);
+
+    expect((await screen.findByRole("tooltip")).textContent).toBe(architecture);
+  });
+});

--- a/src/domains/model-catalog/components/ModelInfoBadges.tsx
+++ b/src/domains/model-catalog/components/ModelInfoBadges.tsx
@@ -57,7 +57,7 @@ export const ModelInfoBadges = ({
         {architecture ? (
           <span className="inline-flex max-w-full whitespace-nowrap text-xs text-muted-foreground mr-3">
             {t("model_catalogs.modelInfo.architecture", "Architecture")}:{" "}
-            <span className="truncate font-mono text-foreground">
+            <span className="min-w-0 truncate font-mono text-foreground">
               {architecture}
             </span>
           </span>

--- a/src/domains/model-catalog/components/ModelInfoBadges.tsx
+++ b/src/domains/model-catalog/components/ModelInfoBadges.tsx
@@ -1,4 +1,10 @@
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { formatModelInfoNumber } from "@/domains/model-catalog/lib/model-info-display";
 import { useTranslation } from "@/foundation/lib/i18n";
 import type { ModelInfo } from "@/foundation/types/serving-types";
 
@@ -25,7 +31,7 @@ export const ModelInfoBadges = ({
   if (info.parameter_count)
     items.push({
       label: t("model_catalogs.modelInfo.parameterCount", "Parameters"),
-      value: info.parameter_count,
+      value: formatModelInfoNumber(info.parameter_count),
     });
   if (info.quantization)
     items.push({
@@ -35,15 +41,10 @@ export const ModelInfoBadges = ({
   if (info.context_length)
     items.push({
       label: t("model_catalogs.modelInfo.contextLength", "Context"),
-      value: info.context_length,
+      value: formatModelInfoNumber(info.context_length),
     });
-  if (info.architecture)
-    items.push({
-      label: t("model_catalogs.modelInfo.architecture", "Architecture"),
-      value: info.architecture,
-    });
-
-  if (items.length === 0) return null;
+  const architecture = info.architecture;
+  if (items.length === 0 && !architecture) return null;
 
   if (variant === "inline") {
     return (
@@ -53,18 +54,49 @@ export const ModelInfoBadges = ({
             {it.label}: <span className="text-foreground">{it.value}</span>
           </span>
         ))}
+        {architecture ? (
+          <span className="inline-flex max-w-full whitespace-nowrap text-xs text-muted-foreground mr-3">
+            {t("model_catalogs.modelInfo.architecture", "Architecture")}:{" "}
+            <span className="truncate font-mono text-foreground">
+              {architecture}
+            </span>
+          </span>
+        ) : null}
       </div>
     );
   }
 
   return (
     <div className={`flex flex-wrap gap-1.5 ${className ?? ""}`}>
-      {items.map((it) => (
-        <Badge key={it.label} variant="secondary" className="font-normal">
-          <span className="text-muted-foreground mr-1">{it.label}</span>
-          {it.value}
-        </Badge>
-      ))}
+      <div className="flex flex-wrap gap-1.5">
+        {items.map((it) => (
+          <Badge key={it.label} variant="secondary" className="font-normal">
+            <span className="text-muted-foreground mr-1">{it.label}</span>
+            {it.value}
+          </Badge>
+        ))}
+      </div>
+      {architecture ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge
+              variant="secondary"
+              tabIndex={0}
+              className="flex w-fit max-w-full min-w-0 cursor-help font-normal"
+            >
+              <span className="mr-1 shrink-0 whitespace-nowrap text-muted-foreground">
+                {t("model_catalogs.modelInfo.architecture", "Architecture")}
+              </span>
+              <span className="min-w-0 truncate whitespace-nowrap font-mono">
+                {architecture}
+              </span>
+            </Badge>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-md break-all font-mono">
+            {architecture}
+          </TooltipContent>
+        </Tooltip>
+      ) : null}
     </div>
   );
 };

--- a/src/domains/model-catalog/lib/model-info-display.test.ts
+++ b/src/domains/model-catalog/lib/model-info-display.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { formatModelInfoNumber } from "./model-info-display";
+
+describe("formatModelInfoNumber", () => {
+  it.each([
+    ["27781427952", "27.8B"],
+    ["262144", "262K"],
+    ["1000000", "1M"],
+    ["999", "999"],
+  ])("formats %s as %s", (value, expected) => {
+    expect(formatModelInfoNumber(value)).toBe(expected);
+  });
+
+  it.each(["27B", "262k tokens", "unknown", ""])(
+    "preserves registry-provided value %j",
+    (value) => {
+      expect(formatModelInfoNumber(value)).toBe(value);
+    },
+  );
+});

--- a/src/domains/model-catalog/lib/model-info-display.ts
+++ b/src/domains/model-catalog/lib/model-info-display.ts
@@ -1,0 +1,22 @@
+const COMPACT_UNITS = [
+  { threshold: 1_000_000_000_000, suffix: "T" },
+  { threshold: 1_000_000_000, suffix: "B" },
+  { threshold: 1_000_000, suffix: "M" },
+  { threshold: 1_000, suffix: "K" },
+] as const;
+
+/** Keeps registry-provided labels intact and abbreviates plain numeric values. */
+export function formatModelInfoNumber(value: string): string {
+  const normalized = value.trim();
+  if (!/^\d+(?:\.\d+)?$/.test(normalized)) return value;
+
+  const number = Number(normalized);
+  if (!Number.isFinite(number)) return value;
+
+  const unit = COMPACT_UNITS.find(({ threshold }) => number >= threshold);
+  if (!unit) return normalized;
+
+  const compact = number / unit.threshold;
+  const digits = compact >= 100 || Number.isInteger(compact) ? 0 : 1;
+  return `${compact.toFixed(digits).replace(/\.0$/, "")}${unit.suffix}`;
+}

--- a/src/domains/model-catalog/lib/model-info-display.ts
+++ b/src/domains/model-catalog/lib/model-info-display.ts
@@ -1,9 +1,7 @@
-const COMPACT_UNITS = [
-  { threshold: 1_000_000_000_000, suffix: "T" },
-  { threshold: 1_000_000_000, suffix: "B" },
-  { threshold: 1_000_000, suffix: "M" },
-  { threshold: 1_000, suffix: "K" },
-] as const;
+const compactFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumSignificantDigits: 3,
+});
 
 /** Keeps registry-provided labels intact and abbreviates plain numeric values. */
 export function formatModelInfoNumber(value: string): string {
@@ -12,11 +10,7 @@ export function formatModelInfoNumber(value: string): string {
 
   const number = Number(normalized);
   if (!Number.isFinite(number)) return value;
+  if (number < 1000) return normalized;
 
-  const unit = COMPACT_UNITS.find(({ threshold }) => number >= threshold);
-  if (!unit) return normalized;
-
-  const compact = number / unit.threshold;
-  const digits = compact >= 100 || Number.isInteger(compact) ? 0 : 1;
-  return `${compact.toFixed(digits).replace(/\.0$/, "")}${unit.suffix}`;
+  return compactFormatter.format(number);
 }

--- a/src/foundation/components/GpuDeviceResourcesView.test.tsx
+++ b/src/foundation/components/GpuDeviceResourcesView.test.tsx
@@ -401,7 +401,7 @@ describe("GpuDeviceResourcesView", () => {
     // reading at all, so both metrics show a dash.
     expect(screen.queryByText("0.0 / 0.0 GiB")).toBeNull();
     expect(screen.queryByText("0 / 0")).toBeNull();
-    expect(screen.getAllByText("\u2014")).toHaveLength(2);
+    expect(screen.getAllByText("\u2014")).toHaveLength(6);
 
     // Bars carry no fill and use the dashed no-reading track.
     const bars = screen.getAllByTestId("progress");
@@ -439,6 +439,10 @@ describe("GpuDeviceResourcesView", () => {
     expect(screen.getByText("Healthy")).toBeTruthy();
     expect(screen.getByText("7.5 / 15.0 GiB")).toBeTruthy();
     expect(screen.getByText("50 / 100")).toBeTruthy();
+    expect(screen.getAllByText("50%")).toHaveLength(2);
+    expect(screen.getAllByText("Remaining")).toHaveLength(2);
+    expect(screen.getByText("7.5 GiB")).toBeTruthy();
+    expect(screen.getByText("50")).toBeTruthy();
     expect(screen.getAllByTestId("progress")).toHaveLength(2);
     expect(screen.queryByText("Tesla-T4")).toBeNull();
 

--- a/src/foundation/components/GpuDeviceResourcesView.tsx
+++ b/src/foundation/components/GpuDeviceResourcesView.tsx
@@ -286,13 +286,30 @@ const GridResourceUsage = ({
     )}
   >
     <div className="flex min-w-0 items-center gap-2">
-      <span className="shrink-0 font-medium text-foreground">{label}</span>
-      <span className="ml-auto min-w-0 truncate text-right font-medium tabular-nums text-foreground">
+      <span
+        className={cn(
+          "shrink-0 font-medium",
+          unavailable ? undefined : "text-foreground",
+        )}
+      >
+        {label}
+      </span>
+      <span
+        className={cn(
+          "ml-auto min-w-0 truncate text-right font-medium tabular-nums",
+          unavailable ? undefined : "text-foreground",
+        )}
+      >
         {/* An unhealthy card reports zeroed pools. Printing "0 / 0" says the
             card is idle and available; the reading simply does not exist. */}
         {unavailable ? "—" : formatUsage(pool, unit, valueScale, precision)}
       </span>
-      <span className="w-9 shrink-0 text-right font-semibold tabular-nums text-foreground">
+      <span
+        className={cn(
+          "w-9 shrink-0 text-right font-semibold tabular-nums",
+          unavailable ? undefined : "text-foreground",
+        )}
+      >
         {unavailable ? "—" : `${pool.percent}%`}
       </span>
     </div>

--- a/src/foundation/components/GpuDeviceResourcesView.tsx
+++ b/src/foundation/components/GpuDeviceResourcesView.tsx
@@ -260,6 +260,7 @@ const ResourceUsageCard = ({
 
 const GridResourceUsage = ({
   label,
+  remainingLabel,
   pool,
   unit,
   valueScale,
@@ -268,6 +269,7 @@ const GridResourceUsage = ({
   unavailable = false,
 }: {
   label: string;
+  remainingLabel: string;
   pool: GpuDeviceResourceRow["memory"];
   unit?: string;
   valueScale?: number;
@@ -278,17 +280,20 @@ const GridResourceUsage = ({
 }) => (
   <div
     className={cn(
-      "mt-2 grid min-w-0 gap-1",
+      "mt-2 grid min-w-0 gap-1.5",
       GPU_USAGE_TEXT_CLASS,
       unavailable ? undefined : "text-muted-foreground",
     )}
   >
-    <div className="flex items-center justify-between gap-3">
-      <span>{label}</span>
-      <span className="min-w-0 truncate font-medium tabular-nums">
+    <div className="flex min-w-0 items-center gap-2">
+      <span className="shrink-0 font-medium text-foreground">{label}</span>
+      <span className="ml-auto min-w-0 truncate text-right font-medium tabular-nums text-foreground">
         {/* An unhealthy card reports zeroed pools. Printing "0 / 0" says the
             card is idle and available; the reading simply does not exist. */}
         {unavailable ? "—" : formatUsage(pool, unit, valueScale, precision)}
+      </span>
+      <span className="w-9 shrink-0 text-right font-semibold tabular-nums text-foreground">
+        {unavailable ? "—" : `${pool.percent}%`}
       </span>
     </div>
     <MetricBar
@@ -296,6 +301,12 @@ const GridResourceUsage = ({
       series={series}
       track={unavailable ? "unavailable" : "outlined"}
     />
+    <div className="flex min-w-0 items-center gap-2 tabular-nums">
+      <span className="shrink-0">{remainingLabel}</span>
+      <span className="min-w-0 truncate">
+        {unavailable ? "—" : formatAvailable(pool, unit, valueScale, precision)}
+      </span>
+    </div>
   </div>
 );
 
@@ -668,6 +679,7 @@ export function GpuDeviceResourcesView({
                 </div>
                 <GridResourceUsage
                   label={labels.memoryUsage}
+                  remainingLabel={labels.remaining}
                   pool={row.memory}
                   unit="GiB"
                   valueScale={VRAM_VALUE_SCALE}
@@ -677,6 +689,7 @@ export function GpuDeviceResourcesView({
                 />
                 <GridResourceUsage
                   label={labels.coreUsage}
+                  remainingLabel={labels.remaining}
                   pool={row.core}
                   // Core keeps its own fill: this cell carries two bars, and the
                   // Nodes legend colour-codes which is which. The endpoint cell

--- a/src/pages/model-catalogs/edit.tsx
+++ b/src/pages/model-catalogs/edit.tsx
@@ -1,7 +1,7 @@
 import { useShow, useUpdate } from "@refinedev/core";
 import yaml from "js-yaml";
 import { CircleHelp, Loader2 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -12,7 +12,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { CatalogModelSlots } from "@/domains/model-catalog/components/CatalogModelSlots";
-import { CatalogYamlEditor } from "@/domains/model-catalog/components/CatalogYamlEditor";
 import {
   type ParseCatalogSpecError,
   parseCatalogSpecYaml,
@@ -27,6 +26,16 @@ import {
   serializeToYaml,
   transformEntityForExport,
 } from "@/foundation/lib/yaml-transform";
+
+// Lazy load the YAML editor: it pulls in lowlight/highlight.js for syntax
+// highlighting, which this page shouldn't pay for until it actually renders.
+const CatalogYamlEditor = lazy(() =>
+  import("@/domains/model-catalog/components/CatalogYamlEditor").then(
+    (module) => ({
+      default: module.CatalogYamlEditor,
+    }),
+  ),
+);
 
 type Translate = ReturnType<typeof useTranslation>["t"];
 
@@ -204,7 +213,6 @@ export const ModelCatalogsEdit = () => {
                       type="button"
                       className="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                       aria-label={t("model_catalogs.models.hint")}
-                      title={t("model_catalogs.models.hint")}
                     >
                       <CircleHelp className="size-3.5" aria-hidden="true" />
                     </button>
@@ -239,11 +247,20 @@ export const ModelCatalogsEdit = () => {
                   "Edit the catalog, or paste a whole ModelCatalog document over it. Spec, labels and annotations are applied; name and workspace cannot change. Invalid recipes surface as a Failed status after saving.",
                 )}
               </p>
-              <CatalogYamlEditor
-                value={specYaml}
-                onChange={setSpecYaml}
-                ariaLabel={t("model_catalogs.edit.specLabel", "Catalog (YAML)")}
-              />
+              <Suspense
+                fallback={
+                  <div className="h-[28rem] animate-pulse rounded-[var(--nt-radius-input)] border border-[var(--nt-stroke-neutral-trans-3)] bg-muted/40" />
+                }
+              >
+                <CatalogYamlEditor
+                  value={specYaml}
+                  onChange={setSpecYaml}
+                  ariaLabel={t(
+                    "model_catalogs.edit.specLabel",
+                    "Catalog (YAML)",
+                  )}
+                />
+              </Suspense>
               {error && <p className="text-xs text-destructive">{error}</p>}
             </div>
 

--- a/src/pages/model-catalogs/edit.tsx
+++ b/src/pages/model-catalogs/edit.tsx
@@ -1,13 +1,18 @@
 import { useShow, useUpdate } from "@refinedev/core";
 import yaml from "js-yaml";
-import { Loader2 } from "lucide-react";
+import { CircleHelp, Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { CatalogModelSlots } from "@/domains/model-catalog/components/CatalogModelSlots";
+import { CatalogYamlEditor } from "@/domains/model-catalog/components/CatalogYamlEditor";
 import {
   type ParseCatalogSpecError,
   parseCatalogSpecYaml,
@@ -189,12 +194,30 @@ export const ModelCatalogsEdit = () => {
             registries. It rewrites the text below rather than holding a copy,
             so hand-editing and using the panel stay interchangeable. */}
             <div className="space-y-1.5">
-              <div className="text-sm font-medium">
-                {t("model_catalogs.models.title")}
+              <div className="flex items-center gap-1.5">
+                <div className="text-sm font-medium">
+                  {t("model_catalogs.models.title")}
+                </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                      aria-label={t("model_catalogs.models.hint")}
+                      title={t("model_catalogs.models.hint")}
+                    >
+                      <CircleHelp className="size-3.5" aria-hidden="true" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="top"
+                    align="start"
+                    className="max-w-md leading-5"
+                  >
+                    {t("model_catalogs.models.hint")}
+                  </TooltipContent>
+                </Tooltip>
               </div>
-              <p className="text-xs text-muted-foreground">
-                {t("model_catalogs.models.hint")}
-              </p>
               <CatalogModelSlots
                 doc={parsedDoc}
                 onChange={(nextDoc) =>
@@ -216,12 +239,10 @@ export const ModelCatalogsEdit = () => {
                   "Edit the catalog, or paste a whole ModelCatalog document over it. Spec, labels and annotations are applied; name and workspace cannot change. Invalid recipes surface as a Failed status after saving.",
                 )}
               </p>
-              <Textarea
-                data-testid="catalog-spec-yaml"
-                className="font-mono text-xs h-[28rem]"
+              <CatalogYamlEditor
                 value={specYaml}
-                onChange={(e) => setSpecYaml(e.target.value)}
-                spellCheck={false}
+                onChange={setSpecYaml}
+                ariaLabel={t("model_catalogs.edit.specLabel", "Catalog (YAML)")}
               />
               {error && <p className="text-xs text-destructive">{error}</p>}
             </div>


### PR DESCRIPTION
## Summary

- Refine model catalog metadata badges while keeping architecture values compact and accessible through tooltips.
- Move model description guidance into contextual help and improve YAML editor metadata handling.
- Expand Cluster GPU device metrics to show used, total, remaining, and usage percentage for both VRAM and compute capacity.
- Reuse the shared `MetricBar` component and preserve existing GPU card structure.
- Display missing GPU availability as unavailable instead of treating it as free capacity.

## Validation

- `yarn vitest run src/foundation/components/GpuDeviceResourcesView.test.tsx`
- TypeScript typecheck
- Dependency Cruiser and Knip checks
- Biome formatting and lint checks
- i18n validation
- Mock preview production build