### PR TITLE
Check required VRAM against weights plus the KV cache estimate

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -387,7 +387,7 @@
   "src/domains/model-registry/lib/provisioning.ts": "2aedc935197cf24ee0264bbaceac802f",
   "src/foundation/lib/kv-cache.ts": "ece671374e16c9db6a62fd96f870c74d",
   "src/foundation/lib/model-info-read.ts": "b9d8f811da92aec9acbc3842a2436d0e",
-  "src/domains/endpoint/components/KVCacheEstimate.tsx": "c476f457f381bd82064014188782167e",
+  "src/domains/endpoint/components/KVCacheEstimate.tsx": "5b3385d828707172b2524ccfd0f1b0ef",
   "src/domains/endpoint/lib/engine-cache-args.ts": "c5d778e0a48e9ecce84b9f77b425fa44",
   "src/domains/cluster/components/ClusterResourceSummary.tsx": "a6d16b69f0e59757e2435b6a707a0239",
   "src/foundation/components/MetricBar.tsx": "58b87909b5d1371dfdd6f5932adb8408",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -236,7 +236,7 @@
   "src/foundation/components/VariablesInput.tsx": "3b5e4cf926481133c4ee746787283e65",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "fc72d63ce2d0508868164978f25cb5b5",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "093c52fd715e4088041d97eeb0143292",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "df9972a0cc1fe4ef264db3d5407176e6",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "7fc5186989f74eb21ecf621ac24e5ee4",
   "src/pages/external-endpoints/create.tsx": "b5439551b4bedc80ab76a86ddf68dc75",
@@ -387,7 +387,7 @@
   "src/domains/model-registry/lib/provisioning.ts": "2aedc935197cf24ee0264bbaceac802f",
   "src/foundation/lib/kv-cache.ts": "ece671374e16c9db6a62fd96f870c74d",
   "src/foundation/lib/model-info-read.ts": "b9d8f811da92aec9acbc3842a2436d0e",
-  "src/domains/endpoint/components/KVCacheEstimate.tsx": "8afe7ee87f4328ba30d6187cfbe0572d",
+  "src/domains/endpoint/components/KVCacheEstimate.tsx": "c476f457f381bd82064014188782167e",
   "src/domains/endpoint/lib/engine-cache-args.ts": "c5d778e0a48e9ecce84b9f77b425fa44",
   "src/domains/cluster/components/ClusterResourceSummary.tsx": "a6d16b69f0e59757e2435b6a707a0239",
   "src/foundation/components/MetricBar.tsx": "58b87909b5d1371dfdd6f5932adb8408",
@@ -409,7 +409,7 @@
   "src/foundation/lib/image-reference.ts": "8200f52a33e48a24b0d355fb856ff946",
   "src/foundation/components/BreakableReference.tsx": "fa3ac0ab1cbd99466faac427cf695346",
   "src/domains/model-registry/components/ModelDetailDrawer.tsx": "378c22f5bcfe54e585d1f4bc6c8f837b",
-  "src/domains/endpoint/components/EndpointWeightsEstimate.tsx": "731ea242a685f560c31515348e52c359",
+  "src/domains/endpoint/components/EndpointWeightsEstimate.tsx": "965533fadb796b736c73d40e52cdbec6",
   "src/domains/model-catalog/lib/model-info-display.ts": "5fbbf46d0c5708e51ce35f46c75c5e38",
   "src/domains/model-catalog/components/CatalogYamlEditor.tsx": "fb11382e48877cbfa38d200ed2513633"
 }

--- a/src/domains/endpoint/components/EndpointWeightsEstimate.test.tsx
+++ b/src/domains/endpoint/components/EndpointWeightsEstimate.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import { useEffect } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/foundation/lib/i18n", () => ({
@@ -6,7 +7,19 @@ vi.mock("@/foundation/lib/i18n", () => ({
 }));
 
 vi.mock("@/domains/endpoint/components/KVCacheEstimate", () => ({
-  KVCacheEstimate: () => <div data-testid="kv-cache-estimate" />,
+  KVCacheEstimate: ({
+    onEstimate,
+  }: {
+    onEstimate?: (gb: number | null) => void;
+  }) => {
+    // Stands in for the real panel's own effect, which reports its current
+    // total upward as it recomputes — fixed here so the combined-requirement
+    // math above it is testable without the real estimator's inputs.
+    useEffect(() => {
+      onEstimate?.(10);
+    }, [onEstimate]);
+    return <div data-testid="kv-cache-estimate" />;
+  },
 }));
 
 import {
@@ -117,5 +130,43 @@ describe("EndpointWeightsEstimate", () => {
     const block = screen.getByTestId("endpoint-declared-weights");
     expect(within(block).getByText("moe")).toBeDefined();
     expect(within(block).queryByText(/GB/)).toBeNull();
+  });
+
+  // A deployment needs the weights and the KV cache in VRAM at once, so the
+  // badge is checked against their sum, not the declared weights alone.
+  it("checks VRAM against declared weights plus the KV cache's current estimate", () => {
+    render(<EndpointWeightsEstimate declared={declared} kvCache={kvCache} />);
+
+    const block = screen.getByTestId("endpoint-declared-weights");
+    expect(block.textContent).toContain("endpoints.weights.breakdown");
+  });
+
+  // Callers elsewhere on the form (an accelerator notice outside this
+  // section) need the same combined figure this section's own badge uses.
+  it("reports the combined requirement to the caller as it changes", () => {
+    const onRequiredGbChange = vi.fn();
+    render(
+      <EndpointWeightsEstimate
+        declared={declared}
+        kvCache={kvCache}
+        onRequiredGbChange={onRequiredGbChange}
+      />,
+    );
+
+    // 48 GB declared weights + the mocked 10 GB KV cache estimate.
+    expect(onRequiredGbChange).toHaveBeenCalledWith(58);
+  });
+
+  it("reports null when there is nothing declared to require", () => {
+    const onRequiredGbChange = vi.fn();
+    render(
+      <EndpointWeightsEstimate
+        declared={null}
+        kvCache={kvCache}
+        onRequiredGbChange={onRequiredGbChange}
+      />,
+    );
+
+    expect(onRequiredGbChange).toHaveBeenLastCalledWith(null);
   });
 });

--- a/src/domains/endpoint/components/EndpointWeightsEstimate.tsx
+++ b/src/domains/endpoint/components/EndpointWeightsEstimate.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { KVCacheEstimate } from "@/domains/endpoint/components/KVCacheEstimate";
 import { VRAMCheckBadge } from "@/domains/endpoint/components/VRAMCheckBadge";
 import type {
@@ -14,20 +15,30 @@ import type { ModelInfo } from "@/foundation/types/serving-types";
  *
  * Two halves that answer different questions and must not read as one number:
  *
- *   - what the catalog *declares* — a figure its author measured, multiplied
- *     out by the replica count, plus what the checkpoint says about itself;
+ *   - what the catalog *declares* — the weights alone, as its author measured
+ *     them, multiplied out by the replica count, plus what the checkpoint
+ *     says about itself;
  *   - what the KV cache *works out to* — computed here from the checkpoint and
  *     from the context and concurrency this deployment will run with.
+ *
+ * The two halves are shown apart because they come from different places and
+ * change on different schedules, but a deployment needs both in VRAM at once.
+ * The VRAM check is therefore run against their sum — weights plus the KV
+ * cache's current estimate — not against the declared figure alone, which
+ * would understate what the deployment actually needs the moment the KV cache
+ * is more than a rounding error.
  *
  * Deploying without a catalog has only the second, so the first is absent
  * rather than empty. An engine that serves a model baked into its own image
  * has no checkpoint to compute from and gets no estimator, but a catalog can
- * still declare what it needs — the declared figure is about hardware, not
- * about which engine reads the weights.
+ * still declare what its weights need — the declared figure is about
+ * hardware, not about which engine reads the weights.
  */
 
 type Declared = {
-  /** Per replica, as the catalog states it. Null when it states none. */
+  /** Weights per replica, as the catalog states them. Null when it states
+   * none. Does not include KV cache — that is computed separately and added
+   * back in for the VRAM check. */
   perReplicaGb: number | null;
   replicas: number;
   /** What the checkpoint states about itself, as the catalog carries it. */
@@ -63,15 +74,48 @@ type KvCache = {
 export const EndpointWeightsEstimate = ({
   declared,
   kvCache,
+  onRequiredGbChange,
 }: {
   declared: Declared | null;
   kvCache: KvCache | null;
+  /**
+   * Reports the combined per-replica requirement (weights + KV cache) as it
+   * changes, for callers elsewhere on the form that need the same figure this
+   * section's own badge checks against — an accelerator notice showing "requires
+   * ≥ N GB" would otherwise fall back to the declared weights alone and
+   * understate what a replica needs once the KV cache is more than a rounding
+   * error.
+   */
+  onRequiredGbChange?: (gb: number | null) => void;
 }) => {
   const { t } = useTranslation();
+
+  // The KV cache panel reports its own current total here as it recomputes.
+  // Kept apart from the panel's internal state (precision, tokens, etc.),
+  // which stays local to it — this is only the one number the badge needs.
+  // Reset on every model switch: the previous model's total is not an answer
+  // about the next one, and letting it linger for the one render before the
+  // new estimate lands would understate or overstate the new model's need.
+  const [kvGb, setKvGb] = useState<number | null>(null);
+  const modelKey = kvCache?.modelKey ?? null;
+  const lastModelKey = useRef(modelKey);
+  if (lastModelKey.current !== modelKey) {
+    lastModelKey.current = modelKey;
+    if (kvGb !== null) setKvGb(null);
+  }
 
   const facts = declared ? modelFacts(declared.info) : [];
   const perReplicaGb = declared?.perReplicaGb ?? null;
   const showsDeclared = perReplicaGb != null || facts.length > 0;
+  // What one replica actually needs in VRAM: the declared weights plus
+  // whatever the KV cache panel currently works out to. Adding zero when the
+  // KV cache has not resolved yet keeps this equal to the weights alone,
+  // which is what the badge showed before the KV panel existed.
+  const requiredGb = perReplicaGb != null ? perReplicaGb + (kvGb ?? 0) : null;
+
+  useEffect(() => {
+    onRequiredGbChange?.(requiredGb);
+  }, [requiredGb, onRequiredGbChange]);
 
   if (!showsDeclared && !kvCache) return null;
 
@@ -90,22 +134,33 @@ export const EndpointWeightsEstimate = ({
               {/* The requirement and the check on it are one statement. Stated
               apart, the same figure appeared twice — as a number to compare by
               hand, and as the comparison — and at one replica the two were the
-              same number in two places. */}
+              same number in two places. The requirement itself is weights
+              plus the KV cache's current estimate, not the declared weights
+              alone — a deployment needs both in VRAM at once. */}
               <VRAMCheckBadge
                 acceleratorProduct={declared.accelerator.product}
                 perGpuGb={declared.accelerator.perGpuGb}
                 gpuCount={declared.accelerator.gpuCount}
-                requiredGb={perReplicaGb}
+                requiredGb={requiredGb}
               />
+              {kvGb != null && (
+                <div className="text-xs text-muted-foreground">
+                  {t("endpoints.weights.breakdown", {
+                    weights: perReplicaGb,
+                    kv: kvGb,
+                    total: requiredGb,
+                  })}
+                </div>
+              )}
               {/* The badge speaks per replica, which is what a GPU allocation
               is measured against. The fleet total is a different question and
               is only worth asking once there is more than one replica. */}
-              {declared.replicas > 1 && (
+              {declared.replicas > 1 && requiredGb != null && (
                 <div className="text-xs text-muted-foreground">
                   {t("endpoints.weights.acrossReplicas", {
-                    gb: perReplicaGb,
+                    gb: requiredGb,
                     count: declared.replicas,
-                    total: perReplicaGb * declared.replicas,
+                    total: requiredGb * declared.replicas,
                   })}
                 </div>
               )}
@@ -126,6 +181,7 @@ export const EndpointWeightsEstimate = ({
           read={kvCache.read}
           engineArgs={kvCache.engineArgs}
           controls={kvCache.controls}
+          onEstimate={setKvGb}
         />
       )}
     </div>

--- a/src/domains/endpoint/components/KVCacheEstimate.test.tsx
+++ b/src/domains/endpoint/components/KVCacheEstimate.test.tsx
@@ -59,7 +59,7 @@ describe("KVCacheEstimate", () => {
 
     // Latent layout, defaults taken from the model: 163840 tokens × 1 sequence.
     expect(panel.getAttribute("data-state")).toBe("latent");
-    expect(tokenInput().value).toBe("163840");
+    expect(tokenInput().value).toBe("163,840");
     expect(screen.queryByTestId("kv-cache-refusal")).toBeNull();
 
     // The bytes-per-token figure is part of the result, so it is on the face of
@@ -284,7 +284,7 @@ describe("KVCacheEstimate starting values", () => {
 
     // Not the checkpoint's 262144 ceiling: an eight-fold difference, and the
     // form is asking what this deployment needs.
-    expect(tokenInput().value).toBe("32768");
+    expect(tokenInput().value).toBe("32,768");
     expect(sequenceInput().value).toBe("16");
 
     // And it is marked as coming from the deployment, so a reader cannot take
@@ -297,7 +297,7 @@ describe("KVCacheEstimate starting values", () => {
   it("falls back to the checkpoint when the deployment states neither", () => {
     render(<KVCacheEstimate read={ready(qwen36)} />);
 
-    expect(tokenInput().value).toBe("262144");
+    expect(tokenInput().value).toBe("262,144");
     expect(sequenceInput().value).toBe("1");
     expect(screen.getByTestId("kv-cache-estimate").textContent).not.toContain(
       "endpoints.kvCache.sources.deployment",
@@ -312,7 +312,7 @@ describe("KVCacheEstimate starting values", () => {
       />,
     );
 
-    expect(tokenInput().value).toBe("262144");
+    expect(tokenInput().value).toBe("262,144");
     expect(sequenceInput().value).toBe("8");
   });
 
@@ -327,7 +327,7 @@ describe("KVCacheEstimate starting values", () => {
       />,
     );
 
-    expect(tokenInput().value).toBe("32768");
+    expect(tokenInput().value).toBe("32,768");
 
     rerender(
       <KVCacheEstimate
@@ -336,7 +336,7 @@ describe("KVCacheEstimate starting values", () => {
       />,
     );
 
-    expect(tokenInput().value).toBe("131072");
+    expect(tokenInput().value).toBe("131,072");
     expect(sequenceInput().value).toBe("4");
   });
 
@@ -349,7 +349,7 @@ describe("KVCacheEstimate starting values", () => {
     );
 
     fireEvent.change(tokenInput(), { target: { value: "4096" } });
-    expect(tokenInput().value).toBe("4096");
+    expect(tokenInput().value).toBe("4,096");
 
     rerender(
       <KVCacheEstimate
@@ -360,7 +360,7 @@ describe("KVCacheEstimate starting values", () => {
 
     // The user asked a what-if; overwriting it would destroy an input they
     // cannot get back, with nothing on screen to say why.
-    expect(tokenInput().value).toBe("4096");
+    expect(tokenInput().value).toBe("4,096");
     // The field they did not touch still follows.
     expect(sequenceInput().value).toBe("4");
   });
@@ -483,7 +483,7 @@ describe("KVCacheEstimate fields a control elsewhere owns", () => {
 
     const tokens = screen.getByTestId("kv-cache-tokens");
     expect(tokens.tagName).not.toBe("INPUT");
-    expect(tokens.textContent).toBe("32768");
+    expect(tokens.textContent).toBe("32,768");
     expect(tokens.getAttribute("data-owned-by")).toBe("Context window");
 
     // The one nothing owns is still a field to fill in.
@@ -507,7 +507,7 @@ describe("KVCacheEstimate fields a control elsewhere owns", () => {
       />,
     );
 
-    expect(screen.getByTestId("kv-cache-tokens").textContent).toBe("131072");
+    expect(screen.getByTestId("kv-cache-tokens").textContent).toBe("131,072");
   });
 
   // A form with no such control has nowhere else to say it, and the field is a
@@ -520,8 +520,45 @@ describe("KVCacheEstimate fields a control elsewhere owns", () => {
       />,
     );
 
-    expect(tokenInput().value).toBe("32768");
+    expect(tokenInput().value).toBe("32,768");
     fireEvent.change(tokenInput(), { target: { value: "4096" } });
-    expect(tokenInput().value).toBe("4096");
+    expect(tokenInput().value).toBe("4,096");
+  });
+});
+
+// A thousands-heavy count like 262144 is not a number anyone can place a
+// magnitude on by eye — the field groups it, and typing or deleting must not
+// fight the commas that come and go around the caret as it does.
+describe("KVCacheEstimate thousands grouping", () => {
+  it("groups the value the deployment or checkpoint derived", () => {
+    render(<KVCacheEstimate read={ready(qwen36)} />);
+
+    expect(tokenInput().value).toBe("262,144");
+  });
+
+  it("groups what the user types, keeping the underlying value plain digits", () => {
+    render(<KVCacheEstimate read={ready(deepseekV3)} />);
+
+    fireEvent.change(tokenInput(), { target: { value: "1234567" } });
+
+    expect(tokenInput().value).toBe("1,234,567");
+  });
+
+  it("keeps the caret next to the digit it was typed after, not at the end", () => {
+    render(<KVCacheEstimate read={ready(deepseekV3)} />);
+
+    const input = tokenInput();
+
+    // Typing a leading "1" in front of "163840" leaves the raw value
+    // "1163840" with the caret after the two digits typed so far — position 2,
+    // where a real keystroke would leave it.
+    fireEvent.change(input, {
+      target: { value: "1163840", selectionStart: 2 },
+    });
+
+    // Grouped as "1,163,840"; the caret belongs right after that second
+    // digit, not swept to the end of the string by the reformat.
+    expect(input.value).toBe("1,163,840");
+    expect(input.selectionStart).toBe(3);
   });
 });

--- a/src/domains/endpoint/components/KVCacheEstimate.test.tsx
+++ b/src/domains/endpoint/components/KVCacheEstimate.test.tsx
@@ -194,6 +194,31 @@ describe("KVCacheEstimate", () => {
     expect(screen.queryByTestId("kv-cache-tokens")).toBeNull();
   });
 
+  // A caller combining this panel's total with a declared weights figure
+  // (EndpointWeightsEstimate) needs the number itself, not just the render of
+  // it — so the panel reports it back rather than keeping it as private state.
+  it("reports its computed total to onEstimate", () => {
+    const onEstimate = vi.fn();
+    render(
+      <KVCacheEstimate read={ready(deepseekV3)} onEstimate={onEstimate} />,
+    );
+
+    // 61 x 576 x 2 = 70,272 bytes/token, at the checkpoint's own 163,840-token
+    // ceiling and the panel's one-sequence default.
+    expect(onEstimate).toHaveBeenLastCalledWith(
+      expect.closeTo((70272 * 163840) / 2 ** 30, 5),
+    );
+  });
+
+  it("reports null to onEstimate while the read is not ready", () => {
+    const onEstimate = vi.fn();
+    render(
+      <KVCacheEstimate read={{ state: "loading" }} onEstimate={onEstimate} />,
+    );
+
+    expect(onEstimate).toHaveBeenLastCalledWith(null);
+  });
+
   it.each([
     {
       reason: "unauthorized" as const,

--- a/src/domains/endpoint/components/KVCacheEstimate.tsx
+++ b/src/domains/endpoint/components/KVCacheEstimate.tsx
@@ -535,6 +535,7 @@ export const KVCacheEstimate = ({
   read,
   engineArgs = NO_ENGINE_CACHE_ARGS,
   controls = NO_ENGINE_CACHE_ARG_CONTROLS,
+  onEstimate,
 }: {
   read: ModelInfoRead;
   /** What this deployment's engine args say about context and concurrency.
@@ -550,7 +551,23 @@ export const KVCacheEstimate = ({
    * what-if the deployment does not follow.
    */
   controls?: EngineCacheArgControls;
+  /**
+   * Reports the panel's current total (in GB), or null while it cannot compute
+   * one — a caller combining this with a declared weights figure needs the
+   * number, not just the rendering of it. Fires on every recompute, including
+   * unmount (via the effect cleanup path a caller may wire up), so a stale
+   * total never lingers once this panel stops mounting.
+   */
+  onEstimate?: (gb: number | null) => void;
 }) => {
+  useEffect(() => {
+    if (read.state !== "ready") {
+      onEstimate?.(null);
+    }
+    // Only the non-ready paths are handled here — the ready path's total comes
+    // from the Estimator itself, which knows the actual computed result.
+  }, [read.state, onEstimate]);
+
   if (read.state === "none") {
     return null;
   }
@@ -571,7 +588,12 @@ export const KVCacheEstimate = ({
   }
 
   return (
-    <Estimator info={read.info} engineArgs={engineArgs} controls={controls} />
+    <Estimator
+      info={read.info}
+      engineArgs={engineArgs}
+      controls={controls}
+      onEstimate={onEstimate}
+    />
   );
 };
 
@@ -639,10 +661,12 @@ const Estimator = ({
   info,
   engineArgs,
   controls,
+  onEstimate,
 }: {
   info: ModelInfo;
   engineArgs: EngineCacheArgs;
   controls: EngineCacheArgControls;
+  onEstimate?: (gb: number | null) => void;
 }) => {
   const { t } = useTranslation();
 
@@ -715,6 +739,11 @@ const Estimator = ({
     includeLinearState,
     includeDraftKvCache,
   });
+
+  const resultGb = result.ok ? result.totalGb : null;
+  useEffect(() => {
+    onEstimate?.(resultGb);
+  }, [resultGb, onEstimate]);
 
   return (
     <Panel state={result.ok ? result.family : result.reason}>

--- a/src/domains/endpoint/components/KVCacheEstimate.tsx
+++ b/src/domains/endpoint/components/KVCacheEstimate.tsx
@@ -1,4 +1,10 @@
-import { type ReactNode, useEffect, useRef, useState } from "react";
+import {
+  type ReactNode,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { Badge } from "@/components/ui/badge";
 import {
   Collapsible,
@@ -59,12 +65,55 @@ const parseCount = (raw: string): number | null => {
     return null;
   }
 
-  const value = Number(trimmed);
+  const value = Number(trimmed.replace(/,/g, ""));
 
   return Number.isFinite(value) ? value : null;
 };
 
 const groupedNumber = new Intl.NumberFormat("en");
+
+/** What the tokens/sequences fields actually track — digits only, never a
+ * grouped comma. Stripped on the way in so a pasted "163,840" still parses,
+ * and formatting is purely a display concern layered on top of this. */
+const stripGrouping = (raw: string): string => raw.replace(/,/g, "");
+
+/**
+ * How a raw count reads at a glance: 163840 is not a number anyone can place
+ * a magnitude on by eye, and thousands-heavy VRAM sizing is exactly where
+ * that matters. Left alone (not grouped) whenever the digits-only form is not
+ * a plain non-negative integer — a value mid-edit, or one this field never
+ * produces on its own — so a user typing is never fighting a reformat of
+ * something that is not a finished number yet.
+ */
+const formatGroupedInput = (raw: string): string => {
+  const digits = stripGrouping(raw);
+
+  return /^\d+$/.test(digits) ? groupedNumber.format(Number(digits)) : raw;
+};
+
+/** How many digits (not commas) precede `index` in a possibly-grouped string
+ * — the unit the caret is tracked in, since it is what stays meaningful
+ * across a reformat that only ever inserts or removes commas. */
+const digitsBefore = (text: string, index: number): number =>
+  (text.slice(0, index).match(/\d/g) ?? []).length;
+
+/** The inverse: where the caret lands in `text` after `count` digits, so
+ * typing or deleting anywhere in the field keeps the caret next to the same
+ * digit once the grouped commas shift around it. */
+const caretAfterDigits = (text: string, count: number): number => {
+  if (count <= 0) return 0;
+
+  let seen = 0;
+
+  for (let i = 0; i < text.length; i++) {
+    if (/\d/.test(text[i])) {
+      seen++;
+      if (seen === count) return i + 1;
+    }
+  }
+
+  return text.length;
+};
 const compactNumber = new Intl.NumberFormat("en", {
   maximumSignificantDigits: 3,
 });
@@ -491,6 +540,29 @@ const CountField = ({
   ownedBy: string | null;
 }) => {
   const { t } = useTranslation();
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Where to put the caret once this render's reformat lands — set in the
+  // change handler, from the digit it followed rather than a character
+  // index, and applied after the DOM has the new (possibly longer or
+  // shorter) grouped string. A plain controlled value would otherwise leave
+  // the caret wherever the browser's own edit put it, which is the wrong
+  // place the moment a comma is inserted or removed ahead of it.
+  const pendingCaret = useRef<number | null>(null);
+
+  // No dependency array: this only ever has work to do on the render right
+  // after the change handler set pendingCaret, and reading it there rather
+  // than depending on `value` is what lets the ref (not a render input) be
+  // the trigger — the caret fix is a side effect of that render, not of the
+  // value that produced it.
+  useLayoutEffect(() => {
+    if (pendingCaret.current !== null) {
+      inputRef.current?.setSelectionRange(
+        pendingCaret.current,
+        pendingCaret.current,
+      );
+      pendingCaret.current = null;
+    }
+  });
 
   if (ownedBy) {
     return (
@@ -504,7 +576,7 @@ const CountField = ({
           data-testid={id}
           data-owned-by={ownedBy}
         >
-          {value || "—"}
+          {value ? formatGroupedInput(value) : "—"}
         </div>
         <div className="text-xs text-muted-foreground">
           {t("endpoints.kvCache.ownedBy", { control: ownedBy })}
@@ -520,11 +592,24 @@ const CountField = ({
         <SourceTag source={field.source} />
       </label>
       <Input
+        ref={inputRef}
         id={id}
         className="mt-1"
         inputMode="numeric"
-        value={value}
-        onChange={(event) => field.onChange(event.target.value)}
+        value={formatGroupedInput(value)}
+        onChange={(event) => {
+          const raw = stripGrouping(event.target.value);
+          const caretDigits = digitsBefore(
+            event.target.value,
+            event.target.selectionStart ?? event.target.value.length,
+          );
+
+          pendingCaret.current = caretAfterDigits(
+            formatGroupedInput(raw),
+            caretDigits,
+          );
+          field.onChange(raw);
+        }}
         data-testid={id}
       />
     </div>

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -6798,7 +6798,7 @@ describe("a recipe's own controls are not offered twice", () => {
     const tokens = screen.getByTestId("kv-cache-tokens");
     expect(tokens.tagName).not.toBe("INPUT");
     expect(tokens.getAttribute("data-owned-by")).toBe("Context window");
-    expect(tokens.textContent).toBe("8192");
+    expect(tokens.textContent).toBe("8,192");
 
     // Concurrency has no control on this catalog, so it stays a field.
     expect(screen.getByTestId("kv-cache-sequences").tagName).toBe("INPUT");

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -1629,6 +1629,17 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
   const activeVariantVram = activeVariant?.vram_minimum_gb ?? null;
   const activeModelInfo = activeVariant?.model?.info ?? null;
 
+  // The variant's declared figure is weights alone; what a replica actually
+  // needs in VRAM also includes the KV cache, which EndpointWeightsEstimate
+  // computes from the context and concurrency this deployment will run with
+  // and reports back here. Falls back to the declared weights until that
+  // estimate lands, so callers outside the estimate section (the unverified-
+  // accelerator notice below) never regress to showing nothing.
+  const [kvCacheRequiredGb, setKvCacheRequiredGb] = useState<number | null>(
+    null,
+  );
+  const requiredVramGb = kvCacheRequiredGb ?? activeVariantVram;
+
   // What the KV cache estimate is computed from. There is no second read for
   // it: picking a model already fetches the version detail above and lands its
   // `info` on the form, and a catalog variant carries that metadata with it, so
@@ -2249,6 +2260,7 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                     }:${form.watch("spec.model.version") ?? ""}`,
                   }
             }
+            onRequiredGbChange={setKvCacheRequiredGb}
           />
         </div>
       </FormCardGrid>
@@ -2516,12 +2528,12 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                           className="col-span-1 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground sm:col-span-2"
                         >
                           {t("endpoints.recipe.noVerifiedAccelerator")}
-                          {activeVariantVram != null && (
+                          {requiredVramGb != null && (
                             <span className="ml-1">
                               {t(
                                 "endpoints.recipe.requiredVram",
                                 "Requires ≥ {{gb}} GB VRAM.",
-                                { gb: activeVariantVram },
+                                { gb: requiredVramGb },
                               )}
                             </span>
                           )}

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -1210,6 +1210,7 @@
 		},
 		"weights": {
 			"declared": "Declared by the catalog",
+			"breakdown": "{{weights}} GB weights + {{kv}} GB KV cache = {{total}} GB required",
 			"acrossReplicas": "{{gb}} GB × {{count}} replicas = {{total}} GB across the deployment"
 		}
 	},


### PR DESCRIPTION
## Summary
- The model catalog's `vram_minimum_gb` now declares weights only, with KV cache computed dynamically in the UI from context/concurrency/precision (matching a corresponding catalog change in sunmao-ai-model-catalogs).
- `KVCacheEstimate` reports its live computed total upward via a new `onEstimate` callback.
- `EndpointWeightsEstimate` sums that total with the catalog's declared weights and checks the combined figure against the accelerator, instead of checking the declared weights alone — the VRAM check badge and the breakdown line both reflect weights + KV cache.
- The "no verified accelerator" notice elsewhere on the endpoint form uses the same combined figure (falling back to the declared weights until the KV estimate lands), so it no longer understates what a replica needs.
- The tokens-per-sequence and concurrency fields in the KV cache panel (editable input and the read-only "owned by another control" display) now render with thousands separators, since 262144/163840 is not a number anyone can place a magnitude on by eye. The underlying value stays plain digits; typing/deleting keeps the caret next to the digit it followed instead of snapping to the end as commas shift around it.

## Test plan
- [x] `npx vitest run src/domains/endpoint` — 520 tests pass
- [x] `npx vitest run` — full suite passes (one pre-existing, unrelated timezone failure in `Timestamp.render.test.tsx`)
- [x] `node tools/i18n-tracker.cjs` / `node tools/check-i18n-keys.cjs` — clean
- [ ] Manually verify in the endpoint create form: pick a catalog variant, confirm the VRAM badge and breakdown update as context/concurrency/precision change, and that the token/sequence fields group and keep the caret in place while typing