### PR TITLE
Follow-ups from the KV-Cache UX review: variant segment control, catalog re-compose

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -325,7 +325,7 @@
   "src/domains/endpoint/components/ComposePreview.tsx": "46c02bdd098aca320703bbad27578a6b",
   "src/domains/endpoint/components/FeaturePicker.tsx": "870ad4d4f2b1a435c52a2bd377437448",
   "src/domains/endpoint/components/VRAMCheckBadge.tsx": "8669ff213df55b49535f2134db420d66",
-  "src/domains/endpoint/components/VariantPicker.tsx": "b3b3a2b57bc5652c21577a59b3dab38e",
+  "src/domains/endpoint/components/VariantPicker.tsx": "b9e5bff55ac2faa9b90c8fb8be33595c",
   "src/components/ui/switch.tsx": "62081204adcbf21dca9b67f40a677901",
   "src/foundation/lib/touched-fields.ts": "8bb21e569f8f08090d42f67df8e1e702",
   "src/foundation/lib/batch-delete.ts": "5f39355873017d5c1adbfaca77a09da7",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -236,7 +236,7 @@
   "src/foundation/components/VariablesInput.tsx": "3b5e4cf926481133c4ee746787283e65",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "fc72d63ce2d0508868164978f25cb5b5",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "df9972a0cc1fe4ef264db3d5407176e6",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "1e8b2044020643af47218c27225faa08",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "faa9a8e7dfade8a200eb601d021b1814",
   "src/pages/external-endpoints/create.tsx": "b5439551b4bedc80ab76a86ddf68dc75",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -236,7 +236,7 @@
   "src/foundation/components/VariablesInput.tsx": "3b5e4cf926481133c4ee746787283e65",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "fc72d63ce2d0508868164978f25cb5b5",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "1e8b2044020643af47218c27225faa08",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "22228afc628b9e9815af02644ba0ff91",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "faa9a8e7dfade8a200eb601d021b1814",
   "src/pages/external-endpoints/create.tsx": "b5439551b4bedc80ab76a86ddf68dc75",
@@ -387,7 +387,7 @@
   "src/domains/model-registry/lib/provisioning.ts": "2aedc935197cf24ee0264bbaceac802f",
   "src/foundation/lib/kv-cache.ts": "ece671374e16c9db6a62fd96f870c74d",
   "src/foundation/lib/model-info-read.ts": "b9d8f811da92aec9acbc3842a2436d0e",
-  "src/domains/endpoint/components/KVCacheEstimate.tsx": "5b3385d828707172b2524ccfd0f1b0ef",
+  "src/domains/endpoint/components/KVCacheEstimate.tsx": "555c5af6a673de8ddaaa89d41acd8ec8",
   "src/domains/endpoint/lib/engine-cache-args.ts": "c5d778e0a48e9ecce84b9f77b425fa44",
   "src/domains/cluster/components/ClusterResourceSummary.tsx": "2fb7857b33a274d49a472bc4d5909307",
   "src/foundation/components/MetricBar.tsx": "58b87909b5d1371dfdd6f5932adb8408",
@@ -409,7 +409,8 @@
   "src/foundation/lib/image-reference.ts": "8200f52a33e48a24b0d355fb856ff946",
   "src/foundation/components/BreakableReference.tsx": "fa3ac0ab1cbd99466faac427cf695346",
   "src/domains/model-registry/components/ModelDetailDrawer.tsx": "378c22f5bcfe54e585d1f4bc6c8f837b",
-  "src/domains/endpoint/components/EndpointWeightsEstimate.tsx": "965533fadb796b736c73d40e52cdbec6",
+  "src/domains/endpoint/components/EndpointWeightsEstimate.tsx": "cecb104b6ee8b8254259cc33a0a1ccb4",
   "src/domains/model-catalog/lib/model-info-display.ts": "5fbbf46d0c5708e51ce35f46c75c5e38",
-  "src/domains/model-catalog/components/CatalogYamlEditor.tsx": "fb11382e48877cbfa38d200ed2513633"
+  "src/domains/model-catalog/components/CatalogYamlEditor.tsx": "fb11382e48877cbfa38d200ed2513633",
+  "src/foundation/components/InfoHint.tsx": "8e904dedae4bc761cc4c7bcbad2705ba"
 }

--- a/src/domains/endpoint/components/EndpointWeightsEstimate.test.tsx
+++ b/src/domains/endpoint/components/EndpointWeightsEstimate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { useEffect } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -112,6 +112,36 @@ describe("EndpointWeightsEstimate", () => {
     );
 
     expect(screen.queryByTestId("endpoint-weights-estimate")).toBeNull();
+  });
+
+  // A checkpoint's architecture is a class name, not a number, and can run
+  // well past what a fact box in a 4-up grid row can show — truncated, with
+  // the full string reachable by keyboard through a tooltip, the same
+  // treatment ModelInfoBadges gives the same field elsewhere.
+  it("truncates a long architecture value and offers it in full via tooltip", async () => {
+    const architecture =
+      "Qwen3MoeForConditionalGenerationWithAnIntentionallyLongArchitectureName";
+    render(
+      <EndpointWeightsEstimate
+        declared={{
+          perReplicaGb: null,
+          replicas: 1,
+          info: { architecture },
+          accelerator: {},
+        }}
+        kvCache={null}
+      />,
+    );
+
+    const triggerValue = screen.getByText(architecture);
+    const trigger = triggerValue.closest("button");
+    if (!trigger)
+      throw new Error("architecture tooltip trigger was not rendered");
+
+    expect(triggerValue.className).toContain("truncate");
+    fireEvent.focus(trigger);
+
+    expect((await screen.findByRole("tooltip")).textContent).toBe(architecture);
   });
 
   it("states the declared metadata a catalog carries without a VRAM figure", () => {

--- a/src/domains/endpoint/components/EndpointWeightsEstimate.tsx
+++ b/src/domains/endpoint/components/EndpointWeightsEstimate.tsx
@@ -1,12 +1,20 @@
 import { useEffect, useRef, useState } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { KVCacheEstimate } from "@/domains/endpoint/components/KVCacheEstimate";
 import { VRAMCheckBadge } from "@/domains/endpoint/components/VRAMCheckBadge";
 import type {
   EngineCacheArgControls,
   EngineCacheArgs,
 } from "@/domains/endpoint/lib/engine-cache-args";
+import { InfoHint } from "@/foundation/components/InfoHint";
 import { useTranslation } from "@/foundation/lib/i18n";
 import type { ModelInfoRead } from "@/foundation/lib/model-info-read";
+import { formatGb } from "@/foundation/recipe/vram";
 import type { ModelInfo } from "@/foundation/types/serving-types";
 
 /**
@@ -120,80 +128,106 @@ export const EndpointWeightsEstimate = ({
   if (!showsDeclared && !kvCache) return null;
 
   return (
-    <div className="space-y-3" data-testid="endpoint-weights-estimate">
-      {showsDeclared && (
-        <div
-          className="rounded-lg border bg-muted/20 p-3"
-          data-testid="endpoint-declared-weights"
-        >
-          <div className="mb-2 text-sm font-medium">
-            {t("endpoints.weights.declared")}
-          </div>
-          {perReplicaGb != null && declared && (
-            <div className="mb-3 space-y-1">
-              {/* The requirement and the check on it are one statement. Stated
+    <TooltipProvider delayDuration={0}>
+      <div className="space-y-3" data-testid="endpoint-weights-estimate">
+        {showsDeclared && (
+          <div
+            className="rounded-lg border bg-muted/20 p-3"
+            data-testid="endpoint-declared-weights"
+          >
+            <div className="mb-2 flex items-center gap-1.5 text-sm font-medium">
+              {t("endpoints.weights.declared")}
+              <InfoHint label={t("endpoints.descriptions.declaredWeights")} />
+            </div>
+            {perReplicaGb != null && declared && (
+              <div className="mb-3 space-y-1">
+                {/* The requirement and the check on it are one statement. Stated
               apart, the same figure appeared twice — as a number to compare by
               hand, and as the comparison — and at one replica the two were the
               same number in two places. The requirement itself is weights
               plus the KV cache's current estimate, not the declared weights
               alone — a deployment needs both in VRAM at once. */}
-              <VRAMCheckBadge
-                acceleratorProduct={declared.accelerator.product}
-                perGpuGb={declared.accelerator.perGpuGb}
-                gpuCount={declared.accelerator.gpuCount}
-                requiredGb={requiredGb}
-              />
-              {kvGb != null && (
-                <div className="text-xs text-muted-foreground">
-                  {t("endpoints.weights.breakdown", {
-                    weights: perReplicaGb,
-                    kv: kvGb,
-                    total: requiredGb,
-                  })}
-                </div>
-              )}
-              {/* The badge speaks per replica, which is what a GPU allocation
+                <VRAMCheckBadge
+                  acceleratorProduct={declared.accelerator.product}
+                  perGpuGb={declared.accelerator.perGpuGb}
+                  gpuCount={declared.accelerator.gpuCount}
+                  requiredGb={requiredGb}
+                />
+                {/* Rounded to the same display precision as every other GB
+              figure on this form (formatGb, one decimal) — the underlying
+              KV-cache estimate carries far more precision than that (a
+              binary fraction of a byte-per-token count multiplied out), and
+              showing it unrounded here read as a different, more exact
+              number than the one the badge above it just checked. */}
+                {kvGb != null && (
+                  <div className="text-xs text-muted-foreground">
+                    {t("endpoints.weights.breakdown", {
+                      weights: formatGb(perReplicaGb),
+                      kv: formatGb(kvGb),
+                      total: formatGb(requiredGb ?? 0),
+                    })}
+                  </div>
+                )}
+                {/* The badge speaks per replica, which is what a GPU allocation
               is measured against. The fleet total is a different question and
               is only worth asking once there is more than one replica. */}
-              {declared.replicas > 1 && requiredGb != null && (
-                <div className="text-xs text-muted-foreground">
-                  {t("endpoints.weights.acrossReplicas", {
-                    gb: requiredGb,
-                    count: declared.replicas,
-                    total: requiredGb * declared.replicas,
-                  })}
-                </div>
-              )}
-            </div>
-          )}
-          {facts.length > 0 && (
-            <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
-              {facts.map((fact) => (
-                <Fact key={fact.key} label={t(fact.key)} value={fact.value} />
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-      {kvCache && (
-        <KVCacheEstimate
-          key={kvCache.modelKey}
-          read={kvCache.read}
-          engineArgs={kvCache.engineArgs}
-          controls={kvCache.controls}
-          onEstimate={setKvGb}
-        />
-      )}
-    </div>
+                {declared.replicas > 1 && requiredGb != null && (
+                  <div className="text-xs text-muted-foreground">
+                    {t("endpoints.weights.acrossReplicas", {
+                      gb: formatGb(requiredGb),
+                      count: declared.replicas,
+                      total: formatGb(requiredGb * declared.replicas),
+                    })}
+                  </div>
+                )}
+              </div>
+            )}
+            {facts.length > 0 && (
+              <div className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+                {facts.map((fact) => (
+                  <Fact key={fact.key} label={t(fact.key)} value={fact.value} />
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {kvCache && (
+          <KVCacheEstimate
+            key={kvCache.modelKey}
+            read={kvCache.read}
+            engineArgs={kvCache.engineArgs}
+            controls={kvCache.controls}
+            onEstimate={setKvGb}
+          />
+        )}
+      </div>
+    </TooltipProvider>
   );
 };
 
 EndpointWeightsEstimate.displayName = "EndpointWeightsEstimate";
 
+// A checkpoint's architecture is a class name, not a number — Qwen3.6's is
+// over 30 characters — and this box is one of a 2-to-4-up grid row, so
+// nothing here can assume the value is short. Truncated with a tooltip
+// carrying the untruncated string, the same treatment ModelInfoBadges already
+// gives the same field elsewhere.
 const Fact = ({ label, value }: { label: string; value: string }) => (
-  <div className="rounded-md border bg-background px-3 py-2">
+  <div className="min-w-0 rounded-md border bg-background px-3 py-2">
     <div className="text-xs font-medium text-muted-foreground">{label}</div>
-    <div className="mt-1 font-semibold tabular-nums">{value}</div>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="mt-1 block w-full min-w-0 cursor-help truncate text-left font-semibold tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {value}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-md break-all">
+        {value}
+      </TooltipContent>
+    </Tooltip>
   </div>
 );
 

--- a/src/domains/endpoint/components/KVCacheEstimate.tsx
+++ b/src/domains/endpoint/components/KVCacheEstimate.tsx
@@ -26,6 +26,7 @@ import {
   NO_ENGINE_CACHE_ARG_CONTROLS,
   NO_ENGINE_CACHE_ARGS,
 } from "@/domains/endpoint/lib/engine-cache-args";
+import { InfoHint } from "@/foundation/components/InfoHint";
 import { useTranslation } from "@/foundation/lib/i18n";
 import {
   BYTES_PER_GB,
@@ -509,8 +510,9 @@ const Panel = ({ state, children }: { state: string; children: ReactNode }) => {
       data-testid="kv-cache-estimate"
       data-state={state}
     >
-      <div className="mb-2 text-sm font-medium">
+      <div className="mb-2 flex items-center gap-1.5 text-sm font-medium">
         {t("endpoints.kvCache.title", "KV cache estimate")}
+        <InfoHint label={t("endpoints.kvCache.titleHint")} />
       </div>
       {children}
     </div>

--- a/src/domains/endpoint/components/VariantPicker.test.tsx
+++ b/src/domains/endpoint/components/VariantPicker.test.tsx
@@ -10,7 +10,7 @@ vi.mock("@/foundation/lib/i18n", () => ({
 }));
 
 describe("VariantPicker", () => {
-  it("renders variants as radio options and emits the selected value", () => {
+  it("renders variants as a single-line segment control and emits the selected value", () => {
     const onChange = vi.fn();
 
     render(
@@ -31,16 +31,16 @@ describe("VariantPicker", () => {
     );
 
     expect(
-      screen.getByRole("radiogroup", { name: "Select a variant" }),
+      screen.getByRole("group", { name: "Select a variant" }),
     ).toBeTruthy();
 
-    const radios = screen.getAllByRole("radio");
-    const defaultRadio = radios[0];
-    const throughputRadio = radios[1];
-    expect((defaultRadio as HTMLInputElement).checked).toBe(true);
-    expect((throughputRadio as HTMLInputElement).checked).toBe(false);
+    const buttons = screen.getAllByRole("button");
+    const defaultButton = buttons[0];
+    const throughputButton = buttons[1];
+    expect(defaultButton.getAttribute("aria-pressed")).toBe("true");
+    expect(throughputButton.getAttribute("aria-pressed")).toBe("false");
 
-    fireEvent.click(throughputRadio);
+    fireEvent.click(throughputButton);
 
     expect(onChange).toHaveBeenCalledWith("throughput");
   });

--- a/src/domains/endpoint/components/VariantPicker.tsx
+++ b/src/domains/endpoint/components/VariantPicker.tsx
@@ -1,6 +1,6 @@
 import { Star } from "lucide-react";
+import { SegmentedControl } from "@/foundation/components/SegmentedControl";
 import { useTranslation } from "@/foundation/lib/i18n";
-import { cn } from "@/foundation/lib/utils";
 import { DEFAULT_VARIANT } from "@/foundation/recipe/normalize";
 import type { RecipeVariant } from "@/foundation/recipe/types";
 
@@ -11,8 +11,10 @@ type Props = {
   disabled?: boolean;
 };
 
-// VariantPicker renders variants as native radio rows so the form choice is
-// semantically a single-select input while keeping descriptions comparable.
+// A single-line segment control: each variant is a compact button naming
+// itself and its VRAM floor, with the fuller description held in a tooltip
+// rather than always on screen — the same information a card list showed,
+// without the vertical space a card list costs when a recipe has several.
 export const VariantPicker = ({
   variants,
   value,
@@ -23,79 +25,35 @@ export const VariantPicker = ({
   const entries = Object.entries(variants);
   if (entries.length === 0) return null;
 
-  const radioName = "endpoint-variant";
-
   return (
-    <div
-      role="radiogroup"
-      aria-label={t("endpoints.recipe.selectVariant", "Select a variant")}
-      className="space-y-2"
-    >
-      {entries.map(([key, v]) => {
-        const isSelected = value === key;
-        return (
-          <label
-            key={key}
-            className={cn(
-              "flex cursor-pointer items-start gap-3 rounded-[var(--nt-radius-card)] border px-3 py-3 text-sm transition-colors",
-              isSelected
-                ? "border-[var(--nt-stroke-outstanding-base)] bg-[var(--nt-fill-outstanding-thin)] ring-1 ring-[var(--nt-stroke-outstanding-light)]"
-                : "border-[var(--nt-stroke-neutral-trans-2)] bg-[var(--nt-fill-neutral-white)] hover:border-[var(--nt-stroke-neutral-trans-4)] hover:bg-[var(--nt-fill-neutral-opaque-1)]",
-              disabled && "cursor-not-allowed opacity-50",
+    <SegmentedControl
+      ariaLabel={t("endpoints.recipe.selectVariant", "Select a variant")}
+      value={value}
+      onValueChange={onChange}
+      items={entries.map(([key, v]) => ({
+        value: key,
+        disabled,
+        description: v.description,
+        label: (
+          <span className="inline-flex items-center gap-1.5">
+            <span className="font-mono">{key}</span>
+            {key === DEFAULT_VARIANT && (
+              <Star
+                aria-label={t(
+                  "endpoints.recipe.defaultVariant",
+                  "Default variant",
+                )}
+                className="size-3 shrink-0 fill-[var(--nt-fill-outstanding-base)] text-[var(--nt-fill-outstanding-base)]"
+              />
             )}
-          >
-            <input
-              checked={isSelected}
-              className="mt-0.5 size-4 shrink-0 cursor-pointer accent-[var(--nt-fill-outstanding-base)] focus-visible:outline-none focus-visible:shadow-[var(--nt-outline-active-focus)]"
-              disabled={disabled}
-              name={radioName}
-              onChange={() => onChange(key)}
-              type="radio"
-              value={key}
-            />
-            <span className="min-w-0 flex-1">
-              <span className="flex flex-wrap items-center gap-1.5">
-                <span
-                  className={cn(
-                    "font-mono text-sm font-medium",
-                    isSelected
-                      ? "text-[var(--nt-text-neutral-primary)]"
-                      : "text-[var(--nt-text-neutral-super)]",
-                  )}
-                >
-                  {key}
-                </span>
-                {key === DEFAULT_VARIANT && (
-                  <Star
-                    aria-label={t(
-                      "endpoints.recipe.defaultVariant",
-                      "Default variant",
-                    )}
-                    className="size-3 shrink-0 fill-[var(--nt-fill-outstanding-base)] text-[var(--nt-fill-outstanding-base)]"
-                  />
-                )}
-                {v.vram_minimum_gb != null && (
-                  <span
-                    className={cn(
-                      "rounded border px-1.5 py-0.5 text-[10px] font-medium",
-                      isSelected
-                        ? "border-[var(--nt-stroke-outstanding-light)] text-[var(--nt-text-colorful-outstanding)]"
-                        : "border-[var(--nt-stroke-neutral-trans-3)] text-[var(--nt-text-neutral-tertiary)]",
-                    )}
-                  >
-                    ≥{v.vram_minimum_gb} GB
-                  </span>
-                )}
+            {v.vram_minimum_gb != null && (
+              <span className="text-[10px] text-[var(--nt-text-neutral-tertiary)]">
+                ≥{v.vram_minimum_gb} GB
               </span>
-              {v.description && (
-                <span className="mt-1 block text-xs leading-5 text-[var(--nt-text-neutral-tertiary)]">
-                  {v.description}
-                </span>
-              )}
-            </span>
-          </label>
-        );
-      })}
-    </div>
+            )}
+          </span>
+        ),
+      }))}
+    />
   );
 };

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -6381,6 +6381,44 @@ describe("what a deploy came from is recorded on the endpoint", () => {
   });
 });
 
+// The composed model address must track the selected catalog's own data, not
+// just the events (variant/feature change) that used to re-derive it. Editing
+// the catalog's underlying model elsewhere and having the catalog list
+// refetch is exactly such a change with no variant/feature event attached.
+describe("a recipe catalog's own data changing re-composes the form", () => {
+  it("updates the model address once the selected catalog refetches, without a variant switch", () => {
+    setupMocks([catalogA, recipeCatalog], [plainKubernetesCluster]);
+    const { rerender } = render(<CreateForm />);
+    selectCatalog("recipe-mc");
+
+    expect(formInstance?.getValues("spec.model.name")).toBe("org/recipe-model");
+
+    const editedRecipeCatalog = {
+      ...recipeCatalog,
+      spec: {
+        ...recipeCatalog.spec,
+        variants: {
+          default: {
+            model: {
+              ...recipeCatalog.spec.variants.default.model,
+              name: "org/local-recipe-model",
+              registry: "local",
+            },
+          },
+        },
+      },
+    };
+
+    setupMocks([catalogA, editedRecipeCatalog], [plainKubernetesCluster]);
+    rerender(<CreateForm />);
+
+    expect(formInstance?.getValues("spec.model.name")).toBe(
+      "org/local-recipe-model",
+    );
+    expect(formInstance?.getValues("spec.model.registry")).toBe("local");
+  });
+});
+
 // The shared CreateForm harness leaves out the recipe slots; the real page
 // (pages/endpoints/create.tsx) renders them all, and these tests are about
 // what that page shows.

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -1461,8 +1461,23 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
     }
   };
 
+  // Keep the form in sync with composeResult itself, rather than re-applying
+  // it only at the handful of call sites that change variant/features. That
+  // covers those same triggers (composeResult depends on selectedVariant and
+  // featureSelections) *and* the case those call sites missed: the selected
+  // catalog's own data changing under it — e.g. its model repository gets
+  // edited elsewhere and the catalog list refetches — which used to leave the
+  // form showing stale fields until the user happened to touch the variant.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: applyComposedToForm is recreated every render and not itself a dependency of what it does — only composeResult's identity should trigger a re-apply.
+  useEffect(() => {
+    if (composeResult?.ok) {
+      applyComposedToForm(composeResult.spec);
+    }
+  }, [composeResult]);
+
   // Handle model catalog selection with merge logic. Trivial MCs go through
-  // the original `applyCatalogSpec` path; Recipe MCs go through the composer.
+  // the original `applyCatalogSpec` path; Recipe MCs go through the composer,
+  // driven by the effect above once selectedVariant/featureSelections land.
   const handleModelCatalogSelect = (catalogId: string) => {
     setSelectedModelCatalog(catalogId);
 
@@ -1479,7 +1494,8 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
     if (!catalog) return;
 
     if (isRecipeShape(catalog.spec)) {
-      // Recipe path — initialize variant/features defaults, then compose.
+      // Recipe path — initialize variant/features defaults; the effect above
+      // composes and applies once these land.
       const variants = Object.keys(catalog.spec.variants ?? {});
       const initialVariant = variants.includes(DEFAULT_VARIANT)
         ? DEFAULT_VARIANT
@@ -1489,14 +1505,6 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
       );
       setSelectedVariant(initialVariant);
       setFeatureSelections(initialFeatures);
-      const result = composeEndpointSpec(
-        catalog.spec as RecipeInputSpec,
-        initialVariant,
-        initialFeatures,
-      );
-      if (result.ok) {
-        applyComposedToForm(result.spec);
-      }
     } else {
       // Trivial path — current behavior, unchanged.
       applyCatalogSpec(catalog.spec as Record<string, unknown>);
@@ -1556,31 +1564,14 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
     });
   }, [form, modelRegistryNames, preselectRegistryModel, workspace]);
 
-  // When user changes variant or features, re-apply the composed result.
+  // When user changes variant or features, the effect above re-composes and
+  // re-applies from the new selection.
   const handleVariantChange = (v: string) => {
     setSelectedVariant(v);
-    if (!selectedCatalog) return;
-    const result = composeEndpointSpec(
-      selectedCatalog.spec as RecipeInputSpec,
-      v,
-      featureSelections,
-    );
-    if (result.ok) {
-      applyComposedToForm(result.spec);
-    }
   };
 
   const handleFeaturesChange = (next: FeatureSelection[]) => {
     setFeatureSelections(next);
-    if (!selectedCatalog) return;
-    const result = composeEndpointSpec(
-      selectedCatalog.spec as RecipeInputSpec,
-      selectedVariant,
-      next,
-    );
-    if (result.ok) {
-      applyComposedToForm(result.spec);
-    }
   };
 
   const clusterGpuResourcesPanel = currentCluster ? (

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -1,6 +1,6 @@
 import { useSelect } from "@refinedev/core";
 import { useForm } from "@refinedev/react-hook-form";
-import { ChevronDown, CircleHelp, Sparkles } from "lucide-react";
+import { ChevronDown, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Path, PathValue } from "react-hook-form";
 import { useTranslation } from "react-i18next";
@@ -11,12 +11,6 @@ import { Button } from "@/components/ui/button";
 import { Combobox as AsyncCombobox } from "@/components/ui/combobox";
 import { CommandLoading } from "@/components/ui/command";
 import { Input } from "@/components/ui/input";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { ComposePreview } from "@/domains/endpoint/components/ComposePreview";
 import { EndpointCatalogOrigin } from "@/domains/endpoint/components/EndpointCatalogOrigin";
 import { EndpointClusterGpuResourcesPanel } from "@/domains/endpoint/components/EndpointClusterGpuResourcesPanel";
@@ -64,6 +58,7 @@ import type {
 import FormCardGrid from "@/foundation/components/FormCardGrid";
 import { FormCombobox } from "@/foundation/components/FormCombobox";
 import { FormFieldGroup } from "@/foundation/components/FormFieldGroup";
+import { InfoHint } from "@/foundation/components/InfoHint";
 import { NumberInput } from "@/foundation/components/NumberInput";
 import { VariablesInput } from "@/foundation/components/VariablesInput";
 import WorkspaceField from "@/foundation/components/WorkspaceField";
@@ -2276,31 +2271,9 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                   <h3 className="text-sm font-semibold">
                     {t("endpoints.sections.schedulingTarget")}
                   </h3>
-                  <TooltipProvider delayDuration={0}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <button
-                          type="button"
-                          className="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-                          aria-label={t(
-                            "endpoints.descriptions.clusterSchedulingTarget",
-                          )}
-                          title={t(
-                            "endpoints.descriptions.clusterSchedulingTarget",
-                          )}
-                        >
-                          <CircleHelp className="size-3.5" aria-hidden="true" />
-                        </button>
-                      </TooltipTrigger>
-                      <TooltipContent
-                        side="top"
-                        align="start"
-                        className="max-w-xs leading-5"
-                      >
-                        {t("endpoints.descriptions.clusterSchedulingTarget")}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
+                  <InfoHint
+                    label={t("endpoints.descriptions.clusterSchedulingTarget")}
+                  />
                 </div>
               </div>
               <div className="grid min-w-0 grid-cols-1 items-end justify-start gap-3 sm:grid-cols-[minmax(220px,280px)_max-content]">

--- a/src/foundation/components/InfoHint.tsx
+++ b/src/foundation/components/InfoHint.tsx
@@ -1,0 +1,30 @@
+import { CircleHelp } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+// A `?`-in-a-circle button that reveals `label` on hover or focus — the
+// explanation for a section title that would otherwise crowd the title
+// itself. Self-contained (owns its own TooltipProvider) so a caller never
+// has to wrap it, the same way SegmentedControl owns its own.
+export const InfoHint = ({ label }: { label: string }) => (
+  <TooltipProvider delayDuration={0}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label={label}
+        >
+          <CircleHelp className="size-3.5" aria-hidden="true" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" align="start" className="max-w-xs leading-5">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/src/locales/en-US.json
+++ b/src/locales/en-US.json
@@ -937,7 +937,8 @@
 		"descriptions": {
 			"clusterSchedulingTarget": "The current product supports cluster-level scheduling targets. Resource availability is summarized from the selected cluster.",
 			"basicResources": "Capacity shared with the selected cluster.",
-			"vgpuCorePercentZero": "Optional. Leave disabled or set 0 to share the remaining compute capacity on the assigned card."
+			"vgpuCorePercentZero": "Optional. Leave disabled or set 0 to share the remaining compute capacity on the assigned card.",
+			"declaredWeights": "What the catalog's author measured for the model weights alone, per replica — it does not include the KV cache, which is estimated separately below from this deployment's context and concurrency."
 		},
 		"actions": {
 			"openResources": "Open Resources",
@@ -1031,6 +1032,7 @@
 		},
 		"kvCache": {
 			"title": "KV cache estimate",
+			"titleHint": "Computed from this checkpoint's cache layout, the tokens and sequences below, and the KV precision you pick — not a value the catalog states.",
 			"tokensPerSequence": "Tokens per sequence",
 			"sequences": "Concurrent sequences",
 			"precision": "KV precision",


### PR DESCRIPTION
## Summary
- `VariantPicker` renders recipe variants as a single-line segment control instead of a card list — key, default star and VRAM floor stay inline, the longer description moves into the existing hover tooltip.
- Fix: a selected recipe catalog's own data changing (e.g. its underlying model gets swapped to a local one and the catalog list refetches) now re-composes and re-applies onto the form. Previously `applyComposedToForm` only ran from the three events that change `selectedVariant`/`featureSelections`, so a catalog edit left the form showing a stale model address until the user happened to touch the variant — which recomposed almost by accident since it read the now-fresh catalog data.
- `EndpointWeightsEstimate`'s declared-info facts (parameter count, context, architecture) now truncate a long value (e.g. a raw checkpoint class name) with the full string in a tooltip, matching how `ModelInfoBadges` already handles the same field.
- The weights/KV-cache breakdown text now rounds through the same `formatGb` helper `VRAMCheckBadge` already uses, instead of printing raw floats like `175.3515625 GB`.
- Added a `?`-icon-with-tooltip hint next to "Declared weights" and "KV cache estimate", reusing the same affordance already used for "Scheduling Target" — factored into a shared `InfoHint` component used at all three sites.

## Test plan
- [x] `use-endpoint-form.test.tsx` — regression test reproducing the stale-address bug on a catalog refetch (verified it fails without the fix, passes with it)
- [x] `VariantPicker.test.tsx` — updated for the segment-control markup
- [x] `EndpointWeightsEstimate.test.tsx` — new test for the truncate+tooltip treatment
- [x] `vitest run src/domains/endpoint` — 41 files / 526 tests pass
- [x] biome check, tsgo, depcruise, knip all clean; i18n tracker lock up to date