### PR TITLE
fix(endpoints): keep the model picker's search term out of the model name

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -236,7 +236,7 @@
   "src/foundation/components/VariablesInput.tsx": "3b5e4cf926481133c4ee746787283e65",
   "src/domains/endpoint/lib/cluster-resources.ts": "f3f80199d815d8ee43452637669008f1",
   "src/domains/endpoint/lib/endpoint-form-helpers.ts": "fc72d63ce2d0508868164978f25cb5b5",
-  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "22228afc628b9e9815af02644ba0ff91",
+  "src/domains/endpoint/hooks/use-endpoint-form.tsx": "ff3bb71b598e5ac9a907c48038c825ef",
   "src/domains/endpoint/hooks/use-endpoint-cluster-resources.ts": "1e1cfe7ad811875f9a8b101c39edb45b",
   "src/domains/endpoint/hooks/use-endpoint-engine-options.ts": "faa9a8e7dfade8a200eb601d021b1814",
   "src/pages/external-endpoints/create.tsx": "b5439551b4bedc80ab76a86ddf68dc75",

--- a/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.test.tsx
@@ -6141,6 +6141,70 @@ describe("model picker", () => {
     expect(formInstance?.getValues().spec.model.name).toBe("Qwen/Qwen3-8B");
     expect(formInstance?.getValues().spec.model.version).toBe("v2");
   });
+
+  // The controller's field belongs to the combobox alone: a wrapper around it
+  // takes the search box's keystrokes as changes to the model name.
+  it("keeps the search term out of the model name when picking a model that is not on the first page", async () => {
+    setupMocks([], [], [{ metadata: { name: "reg" } }]);
+    const deepModel = {
+      name: "tc6-a-24-20260830230732",
+      versions: [{ name: "v1", creation_time: "" }],
+    };
+    const firstPage = Array.from({ length: 20 }, (_, index) => ({
+      name: `tc6-a-${String(index).padStart(2, "0")}-20260830230732`,
+      versions: [{ name: "v1", creation_time: "" }],
+    }));
+    vi.mocked(useRegistryModels).mockImplementation(((opts: {
+      search?: string;
+    }) => {
+      const models = opts.search
+        ? [deepModel, ...firstPage].filter((model) =>
+            model.name.includes(opts.search as string),
+          )
+        : firstPage;
+      return {
+        page: { models, total: models.length, limit: 20, freshness: null },
+        models,
+        total: models.length,
+        isLoading: false,
+        isFetching: false,
+        error: null,
+        refetch: vi.fn(),
+      };
+    }) as unknown as typeof useRegistryModels);
+
+    render(<CreateForm />);
+
+    await act(async () => {
+      formInstance?.setValue("spec.model.registry", "reg");
+    });
+
+    const field = screen.getByTestId("field-spec.model.name");
+    const trigger = field.querySelector('button[role="combobox"]');
+    if (!trigger) throw new Error("model combobox trigger not found");
+
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+
+    // Searching by the exact name is what makes this bite: with it in the
+    // field, the option reads as the current value and clicking it unselects.
+    const search = document.querySelector(
+      "input[cmdk-input]",
+    ) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(search, { target: { value: deepModel.name } });
+    });
+
+    expect(formInstance?.getValues().spec.model.name).toBe("");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("option", { name: deepModel.name }));
+    });
+
+    expect(formInstance?.getValues().spec.model.name).toBe(deepModel.name);
+    expect(formInstance?.getValues().spec.model.version).toBe("v1");
+  });
 });
 
 describe("model static parameters", () => {

--- a/src/domains/endpoint/hooks/use-endpoint-form.tsx
+++ b/src/domains/endpoint/hooks/use-endpoint-form.tsx
@@ -1903,12 +1903,16 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                   }}
                 />
               </FormFieldGroup>
-              <FormFieldGroup
-                {...form}
-                name="spec.model.name"
-                label={t("endpoints.fields.modelName")}
-              >
-                <div className="space-y-2">
+              {/* The hints sit beside the field rather than inside it:
+              FormFieldGroup clones the controller's `field` onto its child, so
+              a wrapper around the combobox would take the keystrokes typed in
+              its search box as changes to the model name. */}
+              <div className="space-y-2">
+                <FormFieldGroup
+                  {...form}
+                  name="spec.model.name"
+                  label={t("endpoints.fields.modelName")}
+                >
                   <AsyncCombobox
                     placeholder={t("endpoints.placeholders.selectModel")}
                     loading={
@@ -1961,35 +1965,35 @@ export const useEndpointForm = ({ action }: { action: "create" | "edit" }) => {
                       );
                     }}
                   />
-                  {/* Said here rather than in release notes: a model that is not on
-                  local storage is fetched when the endpoint starts, so the first
-                  start is slow and an air-gapped site cannot start it at all.
-                  Keyed off the registry's stated capability, so a second public
-                  provider inherits the warning without being named. */}
-                  {selectedModelDelivery === "at-deploy-time" && (
-                    <Alert data-testid="endpoint-runtime-download-hint">
-                      <AlertDescription>
-                        {t("endpoints.messages.runtimeDownloadHint")}
-                      </AlertDescription>
-                    </Alert>
-                  )}
-                  {/* The registry answered without saying which kind it is, which
-                  only happens when a request here drops MODEL_REGISTRY_SELECT.
-                  Rendering nothing would take the warning above away with no
-                  symptom at all; this makes the omission visible to whoever is
-                  looking at the screen. */}
-                  {selectedModelDelivery === "unknown" && (
-                    <Alert
-                      variant="warning"
-                      data-testid="endpoint-runtime-download-unknown"
-                    >
-                      <AlertDescription>
-                        {t("endpoints.messages.runtimeDownloadUnknown")}
-                      </AlertDescription>
-                    </Alert>
-                  )}
-                </div>
-              </FormFieldGroup>
+                </FormFieldGroup>
+                {/* Said here rather than in release notes: a model that is not
+                on local storage is fetched when the endpoint starts, so the
+                first start is slow and an air-gapped site cannot start it at
+                all. Keyed off the registry's stated capability, so a second
+                public provider inherits the warning without being named. */}
+                {selectedModelDelivery === "at-deploy-time" && (
+                  <Alert data-testid="endpoint-runtime-download-hint">
+                    <AlertDescription>
+                      {t("endpoints.messages.runtimeDownloadHint")}
+                    </AlertDescription>
+                  </Alert>
+                )}
+                {/* The registry answered without saying which kind it is,
+                which only happens when a request here drops
+                MODEL_REGISTRY_SELECT. Rendering nothing would take the warning
+                above away with no symptom at all; this makes the omission
+                visible to whoever is looking at the screen. */}
+                {selectedModelDelivery === "unknown" && (
+                  <Alert
+                    variant="warning"
+                    data-testid="endpoint-runtime-download-unknown"
+                  >
+                    <AlertDescription>
+                      {t("endpoints.messages.runtimeDownloadUnknown")}
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </div>
             </>
           )}
           {showFull && !hidesModelFields && (


### PR DESCRIPTION
## Problem

Searching a model registry by a model's exact name in the endpoint form's model picker and then selecting it left `Model Version` empty (NEU-729).

`FormFieldGroup` clones the controller's `field` onto whatever child it is given. The model name field wrapped its combobox in a `div` so the runtime-download hints could sit under it, so the `div` — not the combobox — held the field's `onChange`. React's change event is delegated, so every keystroke typed into the picker's own search box bubbled into that `div` and wrote the search term straight into `spec.model.name`.

With the exact name typed, the field already held that name, so the option read as the current value and clicking it unselected the model instead of picking it. The selection handler that reads the registry's version and fills `spec.model.version` in never ran.

A partial search term did not hit this — the value differed from the option, so the pick went through normally — which is why it only showed up when searching for a model outside the first page by its full name.

## Change

The hints now sit beside the field rather than inside it, so only the combobox carries the controller's field. This is the only place in the repo where a `FormFieldGroup` child is a layout element.

## Test

Regression test covering the deep-page flow: open the picker, type the exact model name, pick it, and assert the name is not written by the search box and the version is filled in from the registry. It fails on the current code and passes with the change.