### PR TITLE
fix(api-keys): translate the ungrouped Project heading

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -39,7 +39,7 @@
   "src/pages/clusters/edit.tsx": "d636f55fd8591fabd56759bf0f46963e",
   "src/pages/clusters/list.tsx": "a88abe3e58e703a05a721908632646ad",
   "src/pages/clusters/show.tsx": "e1fea5f7a3958cc5303a8020386df4fc",
-  "src/pages/api-keys/list.tsx": "39ac3d1714a00667b012f7bd03ff625f",
+  "src/pages/api-keys/list.tsx": "9544a58d3d2ba58e613e094f3b8b49db",
   "src/pages/api-keys/show.tsx": "2253cb7910f077c483304a13a1601328",
   "src/components/ui/alert-dialog.tsx": "70af8c8b7632a7cc58b311f65ecd1309",
   "src/components/ui/alert.tsx": "b5ab1fbae82a800cb260c244c4065da3",

--- a/src/pages/api-keys/list.tsx
+++ b/src/pages/api-keys/list.tsx
@@ -192,6 +192,12 @@ function ModelsCell({
 
 export const ApiKeysList = () => {
   const { t } = useTranslation();
+  // The ungrouped bucket is synthesised by the RPC, so its name arrives as a
+  // fixed English string; only real Projects carry a user-supplied name.
+  const projectLabel = (project: ApiKeyProject) =>
+    project.is_ungrouped
+      ? t("api_keys.projects.ungrouped")
+      : project.metadata.name;
   const { current: workspace } = useWorkspace();
   const scoped = workspace === ALL_WORKSPACES ? undefined : workspace;
   const [open, setOpen] = useState(false);
@@ -296,7 +302,7 @@ export const ApiKeysList = () => {
   const moveProjectNames = new Map(
     [...moveProjects, ...projects].map((project) => [
       project.id,
-      project.metadata.name,
+      projectLabel(project),
     ]),
   );
   const expansionContext = [
@@ -922,7 +928,7 @@ export const ApiKeysList = () => {
                   )}
                   <span className="min-w-0">
                     <strong className="block truncate">
-                      {project.metadata.name}
+                      {projectLabel(project)}
                     </strong>
                     {project.spec.description && (
                       <span
@@ -993,7 +999,7 @@ export const ApiKeysList = () => {
                               <Checkbox
                                 aria-label={t(
                                   "api_keys.selection.selectAllInProject",
-                                  { name: project.metadata.name },
+                                  { name: projectLabel(project) },
                                 )}
                                 checked={projectSelectionState}
                                 onCheckedChange={(checked) =>


### PR DESCRIPTION
The API key list groups keys by Project. The ungrouped bucket is synthesised by
`get_api_key_project_groups` and carries a fixed English `metadata.name`
("Ungrouped"), which the group heading rendered verbatim — so it stayed English
in every locale, while the Project picker, the move dialog and the detail page
already resolved the same label through `api_keys.projects.ungrouped`.

Resolve the label through that existing key wherever the list prints a Project
name: the group heading, the "select all in Project" aria-label, and the
project-name map behind the move dialog. Real Projects keep their
user-supplied name.