### PR TITLE
Fix/resource form footer gap

### DIFF
--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -136,7 +136,7 @@
   "src/foundation/components/LogoutButton.tsx": "6855feb8a8d82f4e50cc27de0d6209e3",
   "src/foundation/components/ModeToggle.tsx": "212fac9ec88049587cff16063b2457ac",
   "src/foundation/components/PageHeader.tsx": "9b011fb9aa373e90ea079ba794080f34",
-  "src/foundation/components/ResourceForm.tsx": "016d3523fe05db2d366f5d87a41d38dc",
+  "src/foundation/components/ResourceForm.tsx": "6fdac2bcedf6c5daaa1d108fa0fba1c2",
   "src/foundation/components/SaveButton.tsx": "07319625c45afb85384cfed1a6b6adb4",
   "src/foundation/components/ShowButton.tsx": "00c2d793fd667589aec7935aef0740d7",
   "src/foundation/components/ShowPage.tsx": "91e5f3b3f38c971820d7266a6272b97c",

--- a/.i18n-tracker.lock
+++ b/.i18n-tracker.lock
@@ -136,7 +136,7 @@
   "src/foundation/components/LogoutButton.tsx": "6855feb8a8d82f4e50cc27de0d6209e3",
   "src/foundation/components/ModeToggle.tsx": "212fac9ec88049587cff16063b2457ac",
   "src/foundation/components/PageHeader.tsx": "9b011fb9aa373e90ea079ba794080f34",
-  "src/foundation/components/ResourceForm.tsx": "01ba6e4838a38fa7c55e72bcc7a8da4c",
+  "src/foundation/components/ResourceForm.tsx": "016d3523fe05db2d366f5d87a41d38dc",
   "src/foundation/components/SaveButton.tsx": "07319625c45afb85384cfed1a6b6adb4",
   "src/foundation/components/ShowButton.tsx": "00c2d793fd667589aec7935aef0740d7",
   "src/foundation/components/ShowPage.tsx": "91e5f3b3f38c971820d7266a6272b97c",

--- a/src/foundation/components/ResourceForm.test.tsx
+++ b/src/foundation/components/ResourceForm.test.tsx
@@ -93,6 +93,17 @@ function VariablesForm({
 }
 
 describe("ResourceForm", () => {
+  it("keeps the sticky action bar flush with the form viewport bottom", () => {
+    render(<TestForm onFinish={vi.fn()} />);
+
+    const actionBar = screen.getByTestId("form-submit").parentElement;
+    const content = actionBar?.parentElement;
+
+    expect(actionBar?.className).toContain("sticky");
+    expect(actionBar?.className).toContain("bottom-0");
+    expect(content?.className).not.toContain("pb-6");
+  });
+
   it("submits the handleSubmit payload instead of reading getValues again", async () => {
     const onFinish = vi.fn();
     render(<TestForm onFinish={onFinish} />);

--- a/src/foundation/components/ResourceForm.test.tsx
+++ b/src/foundation/components/ResourceForm.test.tsx
@@ -100,7 +100,7 @@ describe("ResourceForm", () => {
     const content = actionBar?.parentElement;
 
     expect(actionBar?.className).toContain("sticky");
-    expect(actionBar?.className).toContain("bottom-0");
+    expect(actionBar?.className).toContain("-bottom-2");
     expect(content?.className).not.toContain("pb-6");
   });
 

--- a/src/foundation/components/ResourceForm.tsx
+++ b/src/foundation/components/ResourceForm.tsx
@@ -118,7 +118,7 @@ export const ResourceForm = <
     <FormUI {...props}>
       <ResourceFormSubmitContext.Provider value={submitContext}>
         <form {...formProps} onSubmit={onSubmit} data-testid="form">
-          <div className="mx-auto w-full max-w-[1280px] pb-6">
+          <div className="mx-auto w-full max-w-[1280px]">
             {title && (
               <div className="mb-4">
                 <h1 className="text-2xl font-semibold leading-8 text-foreground">

--- a/src/foundation/components/ResourceForm.tsx
+++ b/src/foundation/components/ResourceForm.tsx
@@ -129,7 +129,7 @@ export const ResourceForm = <
 
             <div className="space-y-4">{props.children}</div>
 
-            <div className="sticky bottom-0 z-10 mt-5 flex justify-end gap-x-3 border-t bg-background/90 px-1 py-4 backdrop-blur">
+            <div className="sticky -bottom-2 z-10 mt-5 flex justify-end gap-x-3 border-t bg-background/90 px-1 py-4 backdrop-blur">
               {!props.hideCancel && (
                 <Button
                   type="button"


### PR DESCRIPTION
## Summary

- Remove the extra bottom padding from the shared `ResourceForm` container.
- Align the sticky form action bar with the viewport edge by accounting for the layout content inset.
- Apply the fix consistently to all create and edit pages that use `ResourceForm`.
- Add a layout contract test covering the sticky position and bottom spacing.

## Root Cause

PR #353 introduced a sticky action bar with `bottom-0` and added `pb-6` to the form container.

The action bar is positioned inside the `DefaultLayout` main content area, which already has an 8px bottom padding (`py-2`). Consequently, the sticky bar stopped 8px above the viewport edge. The additional form padding could create further whitespace when reaching the natural end of the page.

## Affected Pages

The shared fix covers 18 form pages:

- Cluster create and edit
- Image registry create and edit
- Model registry create and edit
- Endpoint create and edit
- External endpoint create and edit
- User create and edit
- Role create and edit
- Role assignment create and edit
- Workspace create
- OEM configuration

List pages, detail pages, authentication forms, dialogs, playgrounds, API Key forms, and the Model Catalog edit page do not use `ResourceForm` and are not affected.

## Verification

- `yarn vitest run src/foundation/components/ResourceForm.test.tsx src/pages/resource-create-titles.test.tsx`
- `yarn typecheck`
- Biome
- Dependency Cruiser
- Knip
- i18n validation
- Production preview build

Browser layout verification on the Create Cluster page:

- Viewport bottom: `993px`
- Action bar bottom: `993px`
- Remaining gap: `0px`

